### PR TITLE
Remove ts-ignore from random implementation

### DIFF
--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,30 +1,22 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable @typescript-eslint/restrict-plus-operands */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
+const UUID_V4_TEMPLATE = "10000000-1000-4000-8000-100000000000";
+
 /**
  * Generates RFC4122 version 4 guid ()
  */
-
-// @ts-ignore
-const crypto = (typeof window !== "undefined") ? (window.crypto || window.msCrypto) : undefined;
-
 function _cryptoUuidv4() {
-    // @ts-ignore
-    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        (c ^ crypto!.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
+        (+c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
     );
 }
 
 function _uuidv4() {
-    // @ts-ignore
-    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-        (c ^ Math.random() * 16 >> c / 4).toString(16)
+    return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
+        (+c ^ Math.random() * 16 >> +c / 4).toString(16)
     );
 }
 
 export function random(): string {
-    const hasRandomValues = crypto && Object.prototype.hasOwnProperty.call(crypto, "getRandomValues");
-    const uuid = hasRandomValues ? _cryptoUuidv4 : _uuidv4;
-    return uuid().replace(/-/g, "");
+    const hasRandomValues = window.crypto && Object.prototype.hasOwnProperty.call(window.crypto, "getRandomValues");
+    const uuid = hasRandomValues ? _cryptoUuidv4() : _uuidv4();
+    return uuid.replace(/-/g, "");
 }


### PR DESCRIPTION
Another small one removing ts-ignore. 

I removed the "magic numbers" that create the uuid template string, it didn't really reduce character count previously by much considering it was repeated in both uuid implementations.

That being said could probably refactor this further as it doesn't make sense that it creates a UUID containing `-` then effectively removes them in the only exported function of `random`.