### PR TITLE
round tripping "state" is missing

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -579,8 +579,8 @@ export class WebStorageStateStore implements StateStore {
 //
 // src/OidcClient.ts:114:88 - (ae-forgotten-export) The symbol "SigninState" needs to be exported by the entry point index.d.ts
 // src/OidcClient.ts:114:108 - (ae-forgotten-export) The symbol "SigninResponse" needs to be exported by the entry point index.d.ts
-// src/OidcClient.ts:183:89 - (ae-forgotten-export) The symbol "State" needs to be exported by the entry point index.d.ts
-// src/OidcClient.ts:183:115 - (ae-forgotten-export) The symbol "SignoutResponse" needs to be exported by the entry point index.d.ts
+// src/OidcClient.ts:184:89 - (ae-forgotten-export) The symbol "State" needs to be exported by the entry point index.d.ts
+// src/OidcClient.ts:184:115 - (ae-forgotten-export) The symbol "SignoutResponse" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -75,7 +75,7 @@ export interface CreateSigninRequestArgs {
     // (undocumented)
     skipUserInfo?: boolean;
     // (undocumented)
-    state?: any;
+    state?: unknown;
     // (undocumented)
     ui_locales?: string;
 }
@@ -194,7 +194,7 @@ export class OidcClient {
     }>;
     // (undocumented)
     readSignoutResponseState(url?: string, removeState?: boolean): Promise<{
-        state: undefined | State;
+        state: State | undefined;
         response: SignoutResponse;
     }>;
     // (undocumented)
@@ -329,6 +329,7 @@ export class User {
         scope?: string;
         profile: UserProfile;
         expires_at?: number;
+        state?: unknown;
     });
     // (undocumented)
     access_token: string;
@@ -355,6 +356,8 @@ export class User {
     get scopes(): string[];
     // (undocumented)
     session_state: string | undefined;
+    // (undocumented)
+    readonly state: unknown | undefined;
     // (undocumented)
     token_type: string;
     // (undocumented)

--- a/samples/Parcel/src/user-manager/sample.js
+++ b/samples/Parcel/src/user-manager/sample.js
@@ -101,7 +101,7 @@ function removeUser() {
 }
 
 function startSigninMainWindow() {
-    mgr.signinRedirect().then(function() {
+    mgr.signinRedirect({ state: { some: "data" } }).then(function() {
         log("signinRedirect done");
     }).catch(function(err) {
         log(err);

--- a/src/ErrorResponse.ts
+++ b/src/ErrorResponse.ts
@@ -10,11 +10,13 @@ export class ErrorResponse extends Error {
     public readonly error_description: string | undefined;
     public readonly error_uri: string | undefined;
 
-    public readonly state: any;
     public readonly session_state: string | undefined;
 
+    // custom "state", which can be used by a caller to have "data" round tripped
+    public state: unknown | undefined;
+
     public constructor(args: {
-        error?: string; error_description?: string; error_uri?: string; state?: any; session_state?: string;
+        error?: string; error_description?: string; error_uri?: string; state?: unknown; session_state?: string;
     }) {
         if (!args.error) {
             Log.error("No error passed to ErrorResponse");

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -119,7 +119,8 @@ export class OidcClient {
         const delimiter = useQuery ? "?" : "#";
 
         const response = new SigninResponse(url, delimiter);
-        if (!response.state) {
+        const stateKey = response.state_id;
+        if (!stateKey) {
             Log.error("OidcClient.readSigninResponseState: No state in response");
             throw new Error("No state in response");
         }
@@ -127,7 +128,7 @@ export class OidcClient {
         const stateStore = this.settings.stateStore;
         const stateApi = removeState ? stateStore.remove.bind(stateStore) : stateStore.get.bind(stateStore);
 
-        const storedStateString = await stateApi(response.state as string);
+        const storedStateString = await stateApi(stateKey);
         if (!storedStateString) {
             Log.error("OidcClient.readSigninResponseState: No matching state found in storage");
             throw new Error("No matching state found in storage");
@@ -184,7 +185,8 @@ export class OidcClient {
         Log.debug("OidcClient.readSignoutResponseState");
 
         const response = new SignoutResponse(url);
-        if (!response.state) {
+        const stateKey = response.state_id;
+        if (!stateKey) {
             Log.debug("OidcClient.readSignoutResponseState: No state in response");
 
             if (response.error) {
@@ -195,11 +197,10 @@ export class OidcClient {
             return { state: undefined, response };
         }
 
-        const stateKey = response.state;
         const stateStore = this.settings.stateStore;
 
         const stateApi = removeState ? stateStore.remove.bind(stateStore) : stateStore.get.bind(stateStore);
-        const storedStateString = await stateApi(stateKey as string);
+        const storedStateString = await stateApi(stateKey);
         if (!storedStateString) {
             Log.error("OidcClient.readSignoutResponseState: No matching state found in storage");
             throw new Error("No matching state found in storage");

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -21,8 +21,8 @@ export interface CreateSigninRequestArgs {
     response_type?: string;
     scope?: string;
 
-    // state can be used by a caller to have data round tripped
-    state?: any;
+    // custom "state", which can be used by a caller to have "data" round tripped
+    state?: unknown;
 
     prompt?: string;
     display?: string;
@@ -127,7 +127,7 @@ export class OidcClient {
         const stateStore = this.settings.stateStore;
         const stateApi = removeState ? stateStore.remove.bind(stateStore) : stateStore.get.bind(stateStore);
 
-        const storedStateString = await stateApi(response.state);
+        const storedStateString = await stateApi(response.state as string);
         if (!storedStateString) {
             Log.error("OidcClient.readSigninResponseState: No matching state found in storage");
             throw new Error("No matching state found in storage");
@@ -180,7 +180,7 @@ export class OidcClient {
         return request;
     }
 
-    public async readSignoutResponseState(url?: string, removeState = false): Promise<{ state: undefined | State; response: SignoutResponse }> {
+    public async readSignoutResponseState(url?: string, removeState = false): Promise<{ state: State | undefined; response: SignoutResponse }> {
         Log.debug("OidcClient.readSignoutResponseState");
 
         const response = new SignoutResponse(url);
@@ -199,7 +199,7 @@ export class OidcClient {
         const stateStore = this.settings.stateStore;
 
         const stateApi = removeState ? stateStore.remove.bind(stateStore) : stateStore.get.bind(stateStore);
-        const storedStateString = await stateApi(stateKey);
+        const storedStateString = await stateApi(stateKey as string);
         if (!storedStateString) {
             Log.error("OidcClient.readSignoutResponseState: No matching state found in storage");
             throw new Error("No matching state found in storage");

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -44,7 +44,7 @@ export class ResponseValidator {
     }
 
     public validateSignoutResponse(state: State, response: SignoutResponse): SignoutResponse {
-        if (state.id !== response.state) {
+        if (state.id !== response.state_id) {
             Log.error("ResponseValidator.validateSignoutResponse: State does not match");
             throw new Error("State does not match");
         }
@@ -64,7 +64,7 @@ export class ResponseValidator {
     }
 
     protected _processSigninParams(state: SigninState, response: SigninResponse): SigninResponse {
-        if (state.id !== response.state) {
+        if (state.id !== response.state_id) {
             Log.error("ResponseValidator._processSigninParams: State does not match");
             throw new Error("State does not match");
         }

--- a/src/SigninRequest.ts
+++ b/src/SigninRequest.ts
@@ -14,7 +14,6 @@ export interface SigninRequestArgs {
     scope: string;
 
     // optional
-    state_data?: any;
     prompt?: string;
     display?: string;
     max_age?: number;
@@ -31,6 +30,9 @@ export interface SigninRequestArgs {
     client_secret?: string;
     extraTokenParams?: Record<string, any>;
     skipUserInfo?: boolean;
+
+    // custom "state", which can be used by a caller to have "data" round tripped
+    state_data?: unknown;
 }
 
 export class SigninRequest {

--- a/src/SigninResponse.ts
+++ b/src/SigninResponse.ts
@@ -10,7 +10,9 @@ export class SigninResponse {
     public readonly code: string;
 
     // updated by ResponseValidator
-    public state: any | undefined;
+    // first state id, then
+    // custom "state", which can be used by a caller to have "data" round tripped
+    public state: string | unknown | undefined;
 
     // updated by ResponseValidator
     public error: string | undefined;

--- a/src/SigninResponse.ts
+++ b/src/SigninResponse.ts
@@ -8,11 +8,7 @@ const OidcScope = "openid";
 
 export class SigninResponse {
     public readonly code: string;
-
-    // updated by ResponseValidator
-    // first state id, then
-    // custom "state", which can be used by a caller to have "data" round tripped
-    public state: string | unknown | undefined;
+    public readonly state_id: string | undefined;
 
     // updated by ResponseValidator
     public error: string | undefined;
@@ -29,6 +25,10 @@ export class SigninResponse {
     public expires_at: number | undefined;
 
     // set by ResponseValidator
+    // custom "state", which can be used by a caller to have "data" round tripped
+    public state: unknown | undefined;
+
+    // set by ResponseValidator
     public profile: UserProfile;
 
     public constructor(url?: string, delimiter = "#") {
@@ -39,7 +39,7 @@ export class SigninResponse {
         this.error_uri = values.error_uri;
 
         this.code = values.code;
-        this.state = values.state;
+        this.state_id = values.state;
 
         this.id_token = values.id_token;
         this.session_state = values.session_state;
@@ -49,6 +49,7 @@ export class SigninResponse {
         this.scope = values.scope;
         this.expires_in = parseInt(values.expires_in);
 
+        this.state = undefined;
         this.profile = {};
     }
 

--- a/src/SignoutResponse.ts
+++ b/src/SignoutResponse.ts
@@ -8,7 +8,10 @@ export class SignoutResponse {
     public error_description: string | undefined;
     public error_uri: string | undefined;
 
-    public state: any | undefined;
+    // updated by ResponseValidator
+    // first state id, then
+    // custom "state", which can be used by a caller to have "data" round tripped
+    public state: string | unknown | undefined;
 
     public constructor(url?: string) {
         const values = UrlUtils.parseUrlFragment(url, "?");

--- a/src/SignoutResponse.ts
+++ b/src/SignoutResponse.ts
@@ -4,14 +4,16 @@
 import { UrlUtils } from "./utils";
 
 export class SignoutResponse {
+    public readonly state_id: string | undefined;
+
+    // updated by ResponseValidator
     public error: string | undefined;
     public error_description: string | undefined;
     public error_uri: string | undefined;
 
-    // updated by ResponseValidator
-    // first state id, then
+    // set by ResponseValidator
     // custom "state", which can be used by a caller to have "data" round tripped
-    public state: string | unknown | undefined;
+    public state: unknown | undefined;
 
     public constructor(url?: string) {
         const values = UrlUtils.parseUrlFragment(url, "?");
@@ -20,6 +22,8 @@ export class SignoutResponse {
         this.error_description = values.error_description;
         this.error_uri = values.error_uri;
 
-        this.state = values.state;
+        this.state_id = values.state;
+
+        this.state = undefined;
     }
 }

--- a/src/State.ts
+++ b/src/State.ts
@@ -6,13 +6,15 @@ import type { StateStore } from "./StateStore";
 
 export class State {
     public readonly id: string;
-    public readonly data: any;
     public readonly created: number;
     public readonly request_type: string | undefined;
 
+    // custom "state", which can be used by a caller to have "data" round tripped
+    public readonly data: unknown | undefined;
+
     public constructor(args: {
         id?: string;
-        data?: any;
+        data?: unknown;
         created?: number;
         request_type?: string;
     }) {

--- a/src/User.ts
+++ b/src/User.ts
@@ -19,24 +19,31 @@ export class User {
     public session_state: string | undefined;
     public access_token: string;
     public refresh_token: string | undefined;
+
     public token_type: string;
     public scope: string | undefined;
     public profile: UserProfile;
     public expires_at: number | undefined;
 
+    // custom "state", which can be used by a caller to have "data" round tripped
+    public readonly state: unknown | undefined;
+
     public constructor(args: {
         id_token?: string; session_state?: string;
         access_token: string; refresh_token?: string;
         token_type: string; scope?: string; profile: UserProfile; expires_at?: number;
+        state?: unknown;
     }) {
         this.id_token = args.id_token;
         this.session_state = args.session_state;
         this.access_token = args.access_token;
         this.refresh_token = args.refresh_token;
+
         this.token_type = args.token_type;
         this.scope = args.scope;
         this.profile = args.profile;
         this.expires_at = args.expires_at;
+        this.state = args.state;
     }
 
     public get expires_in(): number | undefined {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -16,8 +16,8 @@ import type { SignoutResponse } from "./SignoutResponse";
 import { ErrorResponse } from "./ErrorResponse";
 import type { MetadataService } from "./MetadataService";
 
-type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "extraQueryParams" | "extraTokenParams">
-type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams">
+type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "extraQueryParams" | "extraTokenParams" | "state">
+type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state">
 
 /**
  * @public

--- a/test/unit/OidcClient.test.ts
+++ b/test/unit/OidcClient.test.ts
@@ -302,7 +302,7 @@ describe("OidcClient", () => {
             expect(state.authority).toEqual("authority");
             expect(state.client_id).toEqual("client");
             expect(state.request_type).toEqual("type");
-            expect(response.state).toEqual("1");
+            expect(response.state_id).toEqual("1");
         });
     });
 
@@ -551,7 +551,7 @@ describe("OidcClient", () => {
             expect(state).toBeDefined();
             expect(state?.id).toEqual("1");
             expect(state?.request_type).toEqual("type");
-            expect(response.state).toEqual("1");
+            expect(response.state_id).toEqual("1");
         });
 
         it("should call validator with state even if error in response", async () => {

--- a/test/unit/ResponseValidator.test.ts
+++ b/test/unit/ResponseValidator.test.ts
@@ -54,7 +54,7 @@ describe("ResponseValidator", () => {
             authority: "op"
         };
         stubResponse = {
-            state: "the_id",
+            state_id: "the_id",
             isOpenIdConnect: false
         };
         settings = {
@@ -76,7 +76,7 @@ describe("ResponseValidator", () => {
 
         it("should validate that the client state matches response state", () => {
             // arrange
-            stubResponse.state = "not_the_id";
+            stubResponse.state_id = "not_the_id";
 
             // act
             try {
@@ -277,7 +277,7 @@ describe("ResponseValidator", () => {
 
         it("should validate that the client state matches response state", () => {
             // arrange
-            stubResponse.state = "not_the_id";
+            stubResponse.state_id = "not_the_id";
 
             // act
             try {

--- a/test/unit/SigninResponse.test.ts
+++ b/test/unit/SigninResponse.test.ts
@@ -37,7 +37,7 @@ describe("SigninResponse", () => {
             const subject = new SigninResponse("state=foo");
 
             // assert
-            expect(subject.state).toEqual("foo");
+            expect(subject.state_id).toEqual("foo");
         });
 
         it("should read code", () => {

--- a/test/unit/SignoutResponse.test.ts
+++ b/test/unit/SignoutResponse.test.ts
@@ -36,7 +36,7 @@ describe("SignoutResponse", () => {
             const subject = new SignoutResponse("state=foo");
 
             // assert
-            expect(subject.state).toEqual("foo");
+            expect(subject.state_id).toEqual("foo");
         });
     });
 });


### PR DESCRIPTION
- additionally i spitted the confusing "state" property in xResponse.ts class used as state id query parameter and the optional custom state passed by the user.

For the public API (request + User): 
- state is the optional custom state

in xResponse classes:
- state is the query response state=id -> id
- state_data is the optional custom state
