### PR TITLE
Refactor navigators

### DIFF
--- a/.proxyrc.js
+++ b/.proxyrc.js
@@ -7,10 +7,9 @@ module.exports = function (app) {
         })
     );
 
-    app.use((req, res, next) => {
+    app.use('/code-flow-identityserver', (req, res, next) => {
         res.setHeader('Cross-Origin-Opener-Policy', 'unsafe-none');
         res.setHeader('Cross-Origin-Embedder-Policy', 'unsafe-none');
-		next();
-	});
-
+        next();
+    });
 };

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -747,7 +747,7 @@ export class UserManager {
     // (undocumented)
     signinCallback(url?: string): Promise<User | null>;
     // (undocumented)
-    protected _signinCallback(url: string | undefined, navigator: IFrameNavigator | PopupNavigator): Promise<void>;
+    protected _signinCallback(url: string, navigator: IFrameNavigator | PopupNavigator): Promise<void>;
     // (undocumented)
     protected _signinEnd(url: string, verifySub?: string): Promise<User>;
     signinPopup(args?: SigninPopupArgs): Promise<User>;

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -206,7 +206,7 @@ export class UserManager {
     /**
      * Returns promise to notify the opening window of response from the authorization endpoint.
      */
-    public async signinPopupCallback(url?: string): Promise<void> {
+    public async signinPopupCallback(url = window.location.href): Promise<void> {
         try {
             await this._signinCallback(url, this._popupNavigator);
             this._logger.info("signinPopupCallback: successful");
@@ -319,12 +319,12 @@ export class UserManager {
     /**
      * Returns promise to notify the parent window of response from the authorization endpoint.
      */
-    public async signinSilentCallback(url?: string): Promise<void> {
+    public async signinSilentCallback(url = window.location.href): Promise<void> {
         await this._signinCallback(url, this._iframeNavigator);
         this._logger.info("signinSilentCallback: successful");
     }
 
-    public async signinCallback(url?: string): Promise<User | null> {
+    public async signinCallback(url = window.location.href): Promise<User | null> {
         const { state } = await this._client.readSigninResponseState(url);
         if (state.request_type === "si:r") {
             return this.signinRedirectCallback(url);
@@ -340,7 +340,7 @@ export class UserManager {
         throw new Error("invalid response_type in state");
     }
 
-    public async signoutCallback(url?: string, keepOpen = false): Promise<void> {
+    public async signoutCallback(url = window.location.href, keepOpen = false): Promise<void> {
         const { state } = await this._client.readSignoutResponseState(url);
         if (state) {
             if (state.request_type === "so:r") {
@@ -423,9 +423,9 @@ export class UserManager {
             const signinRequest = await this._client.createSigninRequest(args);
             this._logger.debug("_signinStart: got signin request");
 
-            return handle.navigate({
+            return await handle.navigate({
                 url: signinRequest.url,
-                id: signinRequest.state.id,
+                state: signinRequest.state.id,
             });
         }
         catch (err) {
@@ -455,7 +455,7 @@ export class UserManager {
 
         return user;
     }
-    protected async _signinCallback(url: string | undefined, navigator: IFrameNavigator | PopupNavigator): Promise<void> {
+    protected async _signinCallback(url: string, navigator: IFrameNavigator | PopupNavigator): Promise<void> {
         this._logger.debug("_signinCallback");
         const delimiter = this.settings.response_mode === "query" ? "?" : "#";
         await navigator.callback(url, false, delimiter);
@@ -514,7 +514,7 @@ export class UserManager {
     /**
      * Returns promise to process response from the end session endpoint from a popup window.
      */
-    public async signoutPopupCallback(url?: string, keepOpen = false): Promise<void> {
+    public async signoutPopupCallback(url = window.location.href, keepOpen = false): Promise<void> {
         const delimiter = "?";
         await this._popupNavigator.callback(url, keepOpen, delimiter);
         this._logger.info("signoutPopupCallback: successful");
@@ -549,7 +549,7 @@ export class UserManager {
 
             return handle.navigate({
                 url: signoutRequest.url,
-                id: signoutRequest.state?.id,
+                state: signoutRequest.state?.id,
             });
         }
         catch (err) {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -458,7 +458,7 @@ export class UserManager {
     protected async _signinCallback(url: string, navigator: IFrameNavigator | PopupNavigator): Promise<void> {
         this._logger.debug("_signinCallback");
         const delimiter = this.settings.response_mode === "query" ? "?" : "#";
-        await navigator.callback(url, false, delimiter);
+        await navigator.callback(url, delimiter, false);
     }
 
     /**
@@ -516,7 +516,7 @@ export class UserManager {
      */
     public async signoutPopupCallback(url = window.location.href, keepOpen = false): Promise<void> {
         const delimiter = "?";
-        await this._popupNavigator.callback(url, keepOpen, delimiter);
+        await this._popupNavigator.callback(url, delimiter, keepOpen);
         this._logger.info("signoutPopupCallback: successful");
     }
 

--- a/src/navigators/AbstractChildWindow.ts
+++ b/src/navigators/AbstractChildWindow.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+import { Event, Logger, UrlUtils } from "../utils";
+import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
+
+const messageSource = "oidc-client";
+
+/**
+ * Window implementation which resolves via communication from a child window
+ * via the `Window.postMessage()` interface.
+ *
+ * @internal
+ */
+export abstract class AbstractChildWindow implements IWindow {
+    protected abstract readonly _logger: Logger;
+    protected readonly _abort = new Event<[reason: Error]>("Window navigation aborted")
+    protected readonly _disposeHandlers = new Set<() => void>();
+
+    protected _window: WindowProxy | null = null;
+
+    public async navigate(params: NavigateParams): Promise<NavigateResponse> {
+        if (!this._window) {
+            throw new Error("Attempted to navigate on a disposed window");
+        }
+
+        this._logger.debug("navigate: Setting URL in window");
+        this._window.location.replace(params.url);
+
+        const { url, keepOpen } = await new Promise<{ data: Record<string, string>; url: string; keepOpen?: boolean }>((resolve, reject) => {
+            const listener = (e: MessageEvent) => {
+                if (e.origin !== window.location.origin || e.data?.source !== messageSource) {
+                    // silently discard events not intended for us
+                    return;
+                }
+
+                const { data } = e.data;
+                if (!data.state) {
+                    this._logger.warn("navigate: no state found in response url");
+                }
+
+                if (e.source === this._window || data.state === params.state) {
+                    // MessageEvent source is a relatively modern feature, we can't rely on it
+                    // so we also inspect the payload for a matching state key as an alternative
+                    resolve(e.data);
+                }
+            };
+            window.addEventListener("message", listener, false);
+            this._disposeHandlers.add(() => window.removeEventListener("message", listener, false));
+            this._disposeHandlers.add(this._abort.addHandler((reason) => {
+                this._dispose();
+                reject(reason);
+            }));
+        });
+        this._logger.debug("navigate: Got response from window");
+        this._dispose();
+
+        if (!keepOpen) {
+            this.close();
+        }
+
+        if (!url) {
+            throw new Error("Invalid response from window");
+        }
+
+        return { url };
+    }
+
+    public abstract close(): void;
+
+    private _dispose(): void {
+        this._logger.debug("_dispose");
+
+        for (const dispose of this._disposeHandlers) {
+            dispose();
+        }
+        this._disposeHandlers.clear();
+    }
+
+    protected static _notifyParent(parent: Window, url: string, delimiter: string, keepOpen = false): void {
+        const data = UrlUtils.parseUrlFragment(url, delimiter);
+        parent.postMessage({
+            source: messageSource,
+            data,
+            url,
+            keepOpen,
+        }, window.location.origin);
+    }
+}

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -22,8 +22,8 @@ export class IFrameNavigator implements INavigator {
         return new IFrameWindow({ silentRequestTimeoutInSeconds });
     }
 
-    public async callback(url: string | undefined): Promise<void> {
+    public async callback(url: string, delimiter: string): Promise<void> {
         this._logger.debug("callback");
-        IFrameWindow.notifyParent(url);
+        IFrameWindow.notifyParent(url, delimiter);
     }
 }

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Event, Logger, UrlUtils } from "../utils";
-import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
+import { Logger } from "../utils";
+import type { NavigateParams, NavigateResponse } from "./IWindow";
+import { AbstractChildWindow } from "./AbstractChildWindow";
 
 const defaultTimeoutInSeconds = 10;
 
@@ -16,21 +17,19 @@ export interface IFrameWindowParams {
 /**
  * @internal
  */
-export class IFrameWindow implements IWindow {
-    private readonly _logger = new Logger("IFrameWindow");
-    private readonly _timeout = new Event("IFrame timed out");
-    private readonly _disposeHandlers = new Set<() => void>();
-
-    private _timeoutInSeconds: number;
+export class IFrameWindow extends AbstractChildWindow {
+    protected readonly _logger = new Logger("IFrameWindow");
     private _frame: HTMLIFrameElement | null;
-    private _state: string | undefined;
+    private _timeoutInSeconds: number;
 
     public constructor({
         silentRequestTimeoutInSeconds = defaultTimeoutInSeconds
     }: IFrameWindowParams) {
+        super();
         this._timeoutInSeconds = silentRequestTimeoutInSeconds;
 
         this._frame = window.document.createElement("iframe");
+        this._window = this._frame.contentWindow;
 
         // shotgun approach
         this._frame.style.visibility = "hidden";
@@ -45,79 +44,25 @@ export class IFrameWindow implements IWindow {
     }
 
     public async navigate(params: NavigateParams): Promise<NavigateResponse> {
-        if (!this._frame) {
-            throw new Error("Error creating IFrame");
-        }
-
-        this._state = params.state;
-
-        const promise = new Promise<{ data: Record<string, string>; url: string }>((resolve, reject) => {
-            const listener = (e: MessageEvent) => {
-                if (e.origin !== window.location.origin || e.data?.source !== "oidc-client") {
-                    // silently discard events not intended for us
-                    return;
-                }
-                if (e.source === this._frame || e.data.data.state === this._state) {
-                    // MessageEvent source is a relatively modern feature, we can't rely on it
-                    // so we also inspect the payload for a matching state key as an alternative
-                    resolve(e.data);
-                }
-            };
-            window.addEventListener("message", listener, false);
-            this._disposeHandlers.add(() => window.removeEventListener("message", listener, false));
-            this._disposeHandlers.add(this._timeout.addHandler(() => reject(new Error("IFrame timed out without a response"))));
-        });
-
         this._logger.debug("navigate: Using timeout of:", this._timeoutInSeconds);
-
-        const timer = window.setTimeout(() => this._timeout.raise(), this._timeoutInSeconds * 1000);
+        const timer = setTimeout(() => this._abort.raise(new Error("IFrame timed out without a response")), this._timeoutInSeconds * 1000);
         this._disposeHandlers.add(() => clearTimeout(timer));
 
-        this._logger.debug("navigate: Setting URL in IFrame");
-        this._frame.src = params.url;
-
-        const { data, url } = await promise;
-        this.close();
-
-        this._logger.debug("navigate: Got response from IFrame window");
-
-        if (!data.state) this._logger.warn("navigate: no state found in response url");
-
-        if (!url) {
-            throw new Error("Invalid response from IFrame");
-        }
-
-        return { url };
+        return await super.navigate(params);
     }
 
     close(): void {
-        if (this._frame?.parentNode) {
-            this._frame.parentNode.removeChild(this._frame);
-        }
-        this._dispose();
-    }
-
-    protected _dispose(): void {
-        this._logger.debug("_dispose");
-
-        for (const dispose of this._disposeHandlers) {
-            dispose();
-        }
-        this._disposeHandlers.clear();
-        if (this._frame && !this._frame.parentNode) {
+        if (this._frame) {
+            if (this._frame.parentNode) {
+                this._frame.parentNode.removeChild(this._frame);
+            }
+            this._abort.raise(new Error("IFrame removed from DOM"));
             this._frame = null;
         }
-
-        this._frame = null;
+        this._window = null;
     }
 
     public static notifyParent(url: string, delimiter: string): void {
-        Logger.debug("IFrameWindow", "notifyParent: posting url message to parent");
-        const data = UrlUtils.parseUrlFragment(url, delimiter);
-        window.parent.postMessage({
-            source: "oidc-client",
-            data,
-            url
-        }, window.location.origin);
+        return super._notifyParent(window.parent, url, delimiter);
     }
 }

--- a/src/navigators/IWindow.ts
+++ b/src/navigators/IWindow.ts
@@ -5,7 +5,8 @@
  */
 export interface NavigateParams {
     url: string;
-    id?: string;
+    /** The request "state" parameter. For sign out requests, this parameter is optional. */
+    state?: string;
 }
 
 /**

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -23,9 +23,9 @@ export class PopupNavigator implements INavigator {
         return new PopupWindow({ popupWindowFeatures, popupWindowTarget });
     }
 
-    public async callback(url: string, keepOpen: boolean, delimiter: string): Promise<void> {
+    public async callback(url: string, delimiter: string, keepOpen = false): Promise<void> {
         this._logger.debug("callback");
 
-        PopupWindow.notifyOpener(url, keepOpen, delimiter);
+        PopupWindow.notifyOpener(url, delimiter, keepOpen);
     }
 }

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -23,7 +23,7 @@ export class PopupNavigator implements INavigator {
         return new PopupWindow({ popupWindowFeatures, popupWindowTarget });
     }
 
-    public async callback(url: string | undefined, keepOpen: boolean, delimiter: string): Promise<void> {
+    public async callback(url: string, keepOpen: boolean, delimiter: string): Promise<void> {
         this._logger.debug("callback");
 
         PopupWindow.notifyOpener(url, keepOpen, delimiter);

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Event, Logger, UrlUtils } from "../utils";
-import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
+import { Logger } from "../utils";
+import { AbstractChildWindow } from "./AbstractChildWindow";
+import type { NavigateParams, NavigateResponse } from "./IWindow";
 
 const checkForPopupClosedInterval = 500;
-const defaultPopupFeatures = "location=no,toolbar=no,width=500,height=500,left=100,top=100;";
+const defaultPopupFeatures = "location=no,toolbar=no,width=500,height=500,left=100,top=100";
 
 const defaultPopupTarget = "_blank";
 
@@ -20,105 +21,46 @@ export interface PopupWindowParams {
 /**
  * @internal
  */
-export class PopupWindow implements IWindow {
-    private readonly _logger = new Logger("PopupWindow");
-    private readonly _close = new Event("Popup closed");
-    private readonly _disposeHandlers = new Set<() => void>();
+export class PopupWindow extends AbstractChildWindow {
+    protected readonly _logger = new Logger("PopupWindow");
 
-    private _popup: Window | null;
-    private _state: string | undefined;
+    protected _window: WindowProxy | null;
 
     public constructor({
         popupWindowTarget = defaultPopupTarget,
         popupWindowFeatures = defaultPopupFeatures
     }: PopupWindowParams) {
-        this._popup = window.open("", popupWindowTarget, popupWindowFeatures);
-
-        const popupClosedInterval = setInterval(() => {
-            if (!this._popup || this._popup.closed) {
-                this._close.raise();
-                this._dispose();
-            }
-        }, checkForPopupClosedInterval);
-        this._disposeHandlers.add(this._close.addHandler(() => clearInterval(popupClosedInterval)));
+        super();
+        this._window = window.open(undefined, popupWindowTarget, popupWindowFeatures);
     }
 
     public async navigate(params: NavigateParams): Promise<NavigateResponse> {
-        if (!this._popup || this._popup.closed) {
-            throw new Error("Error opening popup window");
-        }
+        this._window?.focus();
 
-        this._state = params.state;
+        const popupClosedInterval = setInterval(() => {
+            if (!this._window || this._window.closed) {
+                this._abort.raise(new Error("Popup closed by user"));
+            }
+        }, checkForPopupClosedInterval);
+        this._disposeHandlers.add(this._abort.addHandler(() => clearInterval(popupClosedInterval)));
 
-        const promise = new Promise<{ data: Record<string, string>; url: string; keepOpen: boolean }>((resolve, reject) => {
-            const listener = (e: MessageEvent) => {
-                if (e.origin !== window.location.origin || e.data?.source !== "oidc-client") {
-                    // silently discard events not intended for us
-                    return;
-                }
-                if (e.source === this._popup || e.data.data.state === this._state) {
-                    // MessageEvent source is a relatively modern feature, we can't rely on it
-                    // so we also inspect the payload for a matching state key as an alternative
-                    resolve(e.data);
-                }
-            };
-            window.addEventListener("message", listener, false);
-            this._disposeHandlers.add(() => window.removeEventListener("message", listener, false));
-            this._disposeHandlers.add(this._close.addHandler(() => reject(new Error("Popup closed without a response"))));
-        });
-
-        this._logger.debug("navigate: Setting URL in popup");
-        this._popup.focus();
-        this._popup.location.replace(params.url);
-
-        const { data, url, keepOpen } = await promise;
-        if (keepOpen) {
-            this._dispose();
-        } else {
-            this.close();
-        }
-
-        this._logger.debug("navigate: Got response from popup window");
-        if (!data.state) this._logger.warn("navigate: no state found in response url");
-
-        if (!url) {
-            throw new Error("Invalid response from popup");
-        }
-
-        return { url };
+        return await super.navigate(params);
     }
 
     public close(): void {
-        if (this._popup && !this._popup.closed) {
-            this._popup.close();
-            this._close.raise();
+        if (this._window) {
+            if (!this._window.closed) {
+                this._window.close();
+            }
+            this._abort.raise(new Error("Popup closed"));
         }
-        this._dispose();
-    }
-
-    protected _dispose(): void {
-        this._logger.debug("_dispose");
-
-        for (const dispose of this._disposeHandlers) {
-            dispose();
-        }
-        this._disposeHandlers.clear();
-        this._state = undefined;
-        if (this._popup && this._popup.closed) {
-            this._popup = null;
-        }
+        this._window = null;
     }
 
     public static notifyOpener(url: string, delimiter: string, keepOpen: boolean): void {
         if (!window.opener) {
             throw new Error("No window.opener. Can't complete notification.");
         }
-        const data = UrlUtils.parseUrlFragment(url, delimiter);
-        window.opener.postMessage({
-            source: "oidc-client",
-            data,
-            url,
-            keepOpen,
-        }, window.location.origin);
+        return super._notifyParent(window.opener, url, delimiter, keepOpen);
     }
 }

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger, UrlUtils } from "../utils";
+import { Event, Logger, UrlUtils } from "../utils";
 import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
 
 const checkForPopupClosedInterval = 500;
@@ -23,151 +23,101 @@ export interface PopupWindowParams {
 export class PopupWindow implements IWindow {
     private readonly _logger: Logger;
 
-    private _resolve!: (value: NavigateResponse) => void;
-    private _reject!: (reason?: any) => void;
-    private _promise = new Promise<NavigateResponse>((resolve, reject) => {
-        this._resolve = resolve;
-        this._reject = reject;
-    });
     private _popup: Window | null;
-    private _checkForPopupClosedTimer: number | null = null
-    private _id: string | undefined;
+    private _state: string | undefined;
+    private _close = new Event("Popup closed");
+    private _disposeHandlers = new Set<() => void>();
 
     public constructor({
         popupWindowTarget = defaultPopupTarget,
         popupWindowFeatures = defaultPopupFeatures
     }: PopupWindowParams) {
         this._logger = new Logger("PopupWindow");
-
         this._popup = window.open("", popupWindowTarget, popupWindowFeatures);
-        if (this._popup) {
-            this._logger.debug("ctor: popup successfully created");
-            this._checkForPopupClosedTimer = window.setInterval(this._checkForPopupClosed, checkForPopupClosedInterval);
-        }
+
+        const popupClosedInterval = setInterval(() => {
+            if (!this._popup || this._popup.closed) {
+                this._close.raise();
+                this._dispose();
+            }
+        }, checkForPopupClosedInterval);
+        this._disposeHandlers.add(this._close.addHandler(() => clearInterval(popupClosedInterval)));
     }
 
     public async navigate(params: NavigateParams): Promise<NavigateResponse> {
-        if (!this._popup) {
-            this._error("PopupWindow.navigate: Error opening popup window");
-        }
-        else if (!params || !params.url) {
-            this._error("PopupWindow.navigate: no url provided");
-            this._error("No url provided");
-        }
-        else {
-            this._logger.debug("navigate: Setting URL in popup");
-
-            this._id = params.id;
-            if (this._id) {
-                (window as any)["popupCallback_" + this._id] = this._callback;
-            }
-
-            this._popup.focus();
-            this._popup.window.location.replace(params.url);
-            window.addEventListener("message", this._messageReceived, false);
+        if (!this._popup || this._popup.closed) {
+            throw new Error("Error opening popup window");
         }
 
-        return await this._promise;
+        this._state = params.state;
+
+        this._logger.debug("navigate: Setting URL in popup");
+        this._popup.focus();
+        this._popup.location.replace(params.url);
+
+        const { data, url, keepOpen } = await new Promise<{ data: Record<string, string>; url: string; keepOpen: boolean }>((resolve, reject) => {
+            const listener = (e: MessageEvent) => {
+                if (e.origin !== window.location.origin || e.data?.source !== "oidc-client") {
+                    // silently discard events not intended for us
+                    return;
+                }
+                if (e.source === this._popup || e.data.data.state === this._state) {
+                    // MessageEvent source is a relatively modern feature, we can't rely on it
+                    // so we also inspect the payload for a matching state key as an alternative
+                    resolve(e.data);
+                }
+            };
+            window.addEventListener("message", listener, false);
+            this._disposeHandlers.add(() => window.removeEventListener("message", listener, false));
+            this._disposeHandlers.add(this._close.addHandler(() => reject(new Error("Popup closed without a response"))));
+        });
+        if (keepOpen) {
+            this._dispose();
+        } else {
+            this.close();
+        }
+
+        this._logger.debug("navigate: Got response from popup window");
+        if (!data.state) this._logger.warn("navigate: no state found in response url");
+
+        if (!url) {
+            throw new Error("Invalid response from popup");
+        }
+
+        return { url };
     }
 
-    protected _messageReceived = (event: MessageEvent): void => {
-        if (event.origin !== window.location.origin) {
-            this._logger.warn("_messageReceived: Message not coming from same origin: " + event.origin);
-            return;
+    protected _dispose(): void {
+        this._logger.debug("_dispose");
+
+        for (const dispose of this._disposeHandlers) {
+            dispose();
         }
-
-        const { data, url, keepOpen } = JSON.parse(event.data) as { data: Record<string, string>; url: string; keepOpen: boolean };
-
-        if (data.state) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            const callback = window["popupCallback_" + data.state];
-            if (callback) {
-                this._logger.debug("_messageReceived: passing url message to opener");
-                callback(url, keepOpen);
-            }
-            else {
-                this._logger.warn("_messageReceived: no matching callback found on opener");
-            }
+        this._disposeHandlers.clear();
+        this._state = undefined;
+        if (this._popup && this._popup.closed) {
+            this._popup = null;
         }
-        else {
-            this._logger.warn("_messageReceived: no state found in response url");
-        }
-    }
-
-    protected _success(data: NavigateResponse): void {
-        this._logger.debug("callback: Successful response from popup window");
-
-        this._cleanup();
-        this._resolve(data);
-    }
-
-    protected _error(message: string): void {
-        this._logger.error("_error", message);
-
-        this._cleanup();
-        this._reject(new Error(message));
     }
 
     public close(): void {
-        this._cleanup(false);
-    }
-
-    protected _cleanup(keepOpen?: boolean): void {
-        this._logger.debug("cleanup");
-
-        if (this._checkForPopupClosedTimer) {
-            window.clearInterval(this._checkForPopupClosedTimer);
-            this._checkForPopupClosedTimer = null;
-        }
-
-        window.removeEventListener("message", this._messageReceived);
-
-        if (this._id) {
-            delete (window as any)["popupCallback_" + this._id];
-        }
-        this._id = undefined;
-
-        if (this._popup && !keepOpen) {
+        if (this._popup && !this._popup.closed) {
             this._popup.close();
+            this._close.raise();
         }
-        this._popup = null;
+        this._dispose();
     }
 
-    protected _checkForPopupClosed = (): void => {
-        if (!this._popup || this._popup.closed) {
-            this._error("Popup window closed");
+    public static notifyOpener(url: string, keepOpen: boolean, delimiter: string): void {
+        if (!window.opener) {
+            throw new Error("No window.opener. Can't complete notification.");
         }
-    }
-
-    protected _callback = (url: string, keepOpen: boolean): void => {
-        this._cleanup(keepOpen);
-
-        if (url) {
-            this._logger.debug("callback success");
-            this._success({ url: url });
-        }
-        else {
-            this._logger.debug("callback: Invalid response from popup");
-            this._error("Invalid response from popup");
-        }
-    }
-
-    public static notifyOpener(url: string | undefined, keepOpen: boolean, delimiter: string): void {
-        if (window.opener) {
-            url = url || window.location.href;
-
-            if (url) {
-                const data = UrlUtils.parseUrlFragment(url, delimiter);
-                window.opener?.postMessage(JSON.stringify({
-                    data,
-                    url,
-                    keepOpen,
-                }), window.location.origin);
-            }
-        }
-        else {
-            Logger.warn("PopupWindow", "notifyOpener: no window.opener. Can't complete notification.");
-        }
+        const data = UrlUtils.parseUrlFragment(url, delimiter);
+        window.opener.postMessage({
+            source: "oidc-client",
+            data,
+            url,
+            keepOpen,
+        }, window.location.origin);
     }
 }

--- a/src/utils/Event.ts
+++ b/src/utils/Event.ts
@@ -22,12 +22,13 @@ export class Event<EventType extends unknown[]> {
         this._logger = new Logger(`Event(${name})`);
     }
 
-    public addHandler(cb: Callback<EventType>): void {
+    public addHandler(cb: Callback<EventType>): () => void {
         this._callbacks.push(cb);
+        return () => this.removeHandler(cb);
     }
 
     public removeHandler(cb: Callback<EventType>): void {
-        const idx = this._callbacks.findIndex(item => item === cb);
+        const idx = this._callbacks.lastIndexOf(cb);
         if (idx >= 0) {
             this._callbacks.splice(idx, 1);
         }
@@ -35,8 +36,8 @@ export class Event<EventType extends unknown[]> {
 
     public raise(...ev: EventType): void {
         this._logger.debug("Raising event: " + this._name);
-        for (let i = 0; i < this._callbacks.length; i++) {
-            void this._callbacks[i](...ev);
+        for (const cb of this._callbacks) {
+            void cb(...ev);
         }
     }
 }

--- a/test/unit/AccessTokenEvents.test.ts
+++ b/test/unit/AccessTokenEvents.test.ts
@@ -140,8 +140,6 @@ class StubTimer extends Timer {
         this.cancelWasCalled = true;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    addHandler() {}
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    removeHandler() {}
+    addHandler = jest.fn();
+    removeHandler = jest.fn();
 }

--- a/test/unit/PopupWindow.test.ts
+++ b/test/unit/PopupWindow.test.ts
@@ -1,7 +1,7 @@
 import { PopupWindow } from "../../src/navigators/PopupWindow";
 
 describe("PopupWindow", () => {
-    let popupFromWindowOpen: { window: { location: { replace: () => void } }; focus: () => void; close: () => void };
+    let popupFromWindowOpen: { location: { replace: () => void }; focus: () => void; close: () => void };
 
     beforeEach(() => {
         Object.defineProperty(window, "location", {
@@ -11,7 +11,7 @@ describe("PopupWindow", () => {
 
         window.open = jest.fn().mockImplementation(() => {
             popupFromWindowOpen = {
-                window: { location: { replace: jest.fn() } },
+                location: { replace: jest.fn() },
                 focus: jest.fn(),
                 close: jest.fn(),
             };
@@ -30,35 +30,30 @@ describe("PopupWindow", () => {
         expect(window.open).toHaveBeenCalled();
     });
 
-    it("should resolve when navigate succeeds", (done) => {
+    it("should resolve when navigate succeeds", async () => {
         const popupWindow = new PopupWindow({});
 
-        popupWindow.navigate({ url: "https://myidp.com/authorize?x=y", id: "someid" }).then((data) => {
-            expect(popupFromWindowOpen.window.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
-            expect(data.url).toBe("https://myapp.com");
-            done();
-        }).catch((err) => {
-            fail(err);
-        });
+        const promise = popupWindow.navigate({ url: "https://myidp.com/authorize?x=y", state: "someid" });
 
         window.dispatchEvent(new MessageEvent("message", {
-            data: JSON.stringify({ data: { state: "someid" }, url: "https://myapp.com" }),
+            data: { source: "oidc-client", data: { state: "someid" }, url: "https://myapp.com" },
             origin: "myapp.com"
         }));
+
+        await expect(promise).resolves.toHaveProperty("url", "https://myapp.com");
+        expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
     });
 
-    it("should reject when navigate fails", (done) => {
+    it("should reject when navigate fails", async () => {
         const popupWindow = new PopupWindow({});
 
-        popupWindow.navigate({ url: "https://myidp.com/authorize?x=y", id: "someid" }).catch((error: Error) => {
-            expect(popupFromWindowOpen.window.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
-            expect(error.message).toBe("Invalid response from popup");
-            done();
-        });
-
+        const promise = popupWindow.navigate({ url: "https://myidp.com/authorize?x=y", state: "someid" });
         window.dispatchEvent(new MessageEvent("message", {
-            data: JSON.stringify({ data: { state: "someid" }, url: "" }),
+            data: { source: "oidc-client", data: { state: "someid" }, url: "" },
             origin: "myapp.com"
         }));
+
+        await expect(promise).rejects.toThrow("Invalid response from popup");
+        expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
     });
 });

--- a/test/unit/PopupWindow.test.ts
+++ b/test/unit/PopupWindow.test.ts
@@ -53,7 +53,7 @@ describe("PopupWindow", () => {
             origin: "myapp.com"
         }));
 
-        await expect(promise).rejects.toThrow("Invalid response from popup");
+        await expect(promise).rejects.toThrow("Invalid response from window");
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
     });
 });


### PR DESCRIPTION
This cleans up navigator code. There might be some subtle differences from how things worked before, but I feel confident that this new implementation is much more robust. It has a couple of important improvements:

* callbacks attempt to compare to the `MessageEvent.source` property rather that the state ID. Not all browsers support this feature, so it still falls back to comparing to the state ID of the current navigation. This allows the navigator to recover even when the state param is entirely missing from the iframe/popup callback page.
* message payloads are encoded with a `source` key to prevent other libraries from interfering with navigator callbacks. The old code was deserializing with `JSON.parse` which could cause some console spam triggered by React dev tools while a popup window is open.

This refactoring should make #157's diff significantly cleaner.