### PR TITLE
Replace UrlUtils with WhatWG URL APIs

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -68,7 +68,7 @@ export interface CreateSigninRequestArgs {
     // (undocumented)
     resource?: string;
     // (undocumented)
-    response_mode?: string;
+    response_mode?: "query" | "fragment";
     // (undocumented)
     response_type?: string;
     // (undocumented)
@@ -191,16 +191,16 @@ export class OidcClient {
     // (undocumented)
     readonly metadataService: MetadataService;
     // (undocumented)
-    processSigninResponse(url?: string): Promise<SigninResponse>;
+    processSigninResponse(url: string): Promise<SigninResponse>;
     // (undocumented)
     processSignoutResponse(url: string): Promise<SignoutResponse>;
     // (undocumented)
-    readSigninResponseState(url?: string, removeState?: boolean): Promise<{
+    readSigninResponseState(url: string, removeState?: boolean): Promise<{
         state: SigninState;
         response: SigninResponse;
     }>;
     // (undocumented)
-    readSignoutResponseState(url?: string, removeState?: boolean): Promise<{
+    readSignoutResponseState(url: string, removeState?: boolean): Promise<{
         state: State | undefined;
         response: SignoutResponse;
     }>;
@@ -427,7 +427,7 @@ export type SigninRedirectArgs = RedirectParams & ExtraSigninRequestArgs;
 
 // @public (undocumented)
 export class SigninRequest {
-    constructor({ url, authority, client_id, redirect_uri, response_type, scope, state_data, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, response_mode, request, request_uri, extraQueryParams, request_type, client_secret, extraTokenParams, skipUserInfo }: SigninRequestArgs);
+    constructor({ url, authority, client_id, redirect_uri, response_type, scope, state_data, response_mode, request_type, client_secret, skipUserInfo, extraQueryParams, extraTokenParams, ...optionalParams }: SigninRequestArgs);
     // (undocumented)
     readonly state: SigninState;
     // (undocumented)
@@ -469,7 +469,7 @@ export interface SigninRequestArgs {
     // (undocumented)
     resource?: string;
     // (undocumented)
-    response_mode?: string;
+    response_mode?: "query" | "fragment";
     // (undocumented)
     response_type: string;
     // (undocumented)
@@ -485,7 +485,7 @@ export interface SigninRequestArgs {
 
 // @public (undocumented)
 export class SigninResponse {
-    constructor(url?: string, delimiter?: string);
+    constructor(params: URLSearchParams);
     // (undocumented)
     access_token: string;
     // (undocumented)
@@ -517,7 +517,7 @@ export class SigninResponse {
     get scopes(): string[];
     // (undocumented)
     session_state: string | undefined;
-    state: unknown | undefined;
+    state: unknown;
     // (undocumented)
     readonly state_id: string | undefined;
     // (undocumented)
@@ -541,7 +541,7 @@ export class SigninState extends State {
         scope: string;
         client_secret?: string;
         extraTokenParams?: Record<string, unknown>;
-        response_mode?: string;
+        response_mode?: "query" | "fragment";
         skipUserInfo?: boolean;
     });
     // (undocumented)
@@ -561,7 +561,7 @@ export class SigninState extends State {
     // (undocumented)
     readonly redirect_uri: string;
     // (undocumented)
-    readonly response_mode: string | undefined;
+    readonly response_mode: "query" | "fragment" | undefined;
     // (undocumented)
     readonly scope: string;
     // (undocumented)
@@ -603,14 +603,14 @@ export interface SignoutRequestArgs {
 
 // @public (undocumented)
 export class SignoutResponse {
-    constructor(url?: string);
+    constructor(params: URLSearchParams);
     // (undocumented)
     error: string | undefined;
     // (undocumented)
     error_description: string | undefined;
     // (undocumented)
     error_uri: string | undefined;
-    state: unknown | undefined;
+    state: unknown;
     // (undocumented)
     readonly state_id: string | undefined;
 }
@@ -747,11 +747,9 @@ export class UserManager {
     // (undocumented)
     signinCallback(url?: string): Promise<User | null>;
     // (undocumented)
-    protected _signinCallback(url: string, navigator: IFrameNavigator | PopupNavigator): Promise<void>;
-    // (undocumented)
     protected _signinEnd(url: string, verifySub?: string): Promise<User>;
     signinPopup(args?: SigninPopupArgs): Promise<User>;
-    signinPopupCallback(url?: string): Promise<void>;
+    signinPopupCallback(url?: string, keepOpen?: boolean): Promise<void>;
     signinRedirect(args?: SigninRedirectArgs): Promise<void>;
     signinRedirectCallback(url?: string): Promise<User>;
     signinSilent(args?: SigninSilentArgs): Promise<User | null>;

--- a/src/SigninResponse.ts
+++ b/src/SigninResponse.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Timer, UrlUtils } from "./utils";
+import { Timer } from "./utils";
 import type { UserProfile } from "./User";
 
 const OidcScope = "openid";
@@ -29,31 +29,31 @@ export class SigninResponse {
 
     // set by ResponseValidator
     /** custom "state", which can be used by a caller to have "data" round tripped */
-    public state: unknown | undefined;
+    public state: unknown;
 
     // set by ResponseValidator
-    public profile: UserProfile;
+    public profile: UserProfile = {};
 
-    public constructor(url?: string, delimiter = "#") {
-        const values = UrlUtils.parseUrlFragment(url, delimiter);
+    public constructor(params: URLSearchParams) {
+        // URLSearchParams returns `null` for missing values, reconstruct it as a map
+        const values = new Map(params);
+        this.error = values.get("error");
+        this.error_description = values.get("error_description");
+        this.error_uri = values.get("error_uri");
 
-        this.error = values.error;
-        this.error_description = values.error_description;
-        this.error_uri = values.error_uri;
+        // the default values here are for type safety only
+        // ResponseValidator should check if these are empty and throw accordingly
+        this.code = values.get("code") ?? "";
+        this.access_token = values.get("access_token") ?? "";
+        this.token_type = values.get("token_type") ?? "";
 
-        this.code = values.code;
-        this.state_id = values.state;
-
-        this.id_token = values.id_token;
-        this.session_state = values.session_state;
-        this.access_token = values.access_token;
-        this.refresh_token = values.refresh_token;
-        this.token_type = values.token_type;
-        this.scope = values.scope;
-        this.expires_in = parseInt(values.expires_in);
-
-        this.state = undefined;
-        this.profile = {};
+        this.state_id = values.get("state");
+        this.id_token = values.get("id_token");
+        this.session_state = values.get("session_state");
+        this.refresh_token = values.get("refresh_token");
+        this.scope = values.get("scope");
+        const expiresIn = values.get("expires_in");
+        this.expires_in = expiresIn ? parseInt(expiresIn) : undefined;
     }
 
     public get expires_in(): number | undefined {

--- a/src/SigninState.ts
+++ b/src/SigninState.ts
@@ -20,7 +20,7 @@ export class SigninState extends State {
     public readonly client_secret: string | undefined;
     public readonly extraTokenParams: Record<string, unknown> | undefined;
 
-    public readonly response_mode: string | undefined;
+    public readonly response_mode: "query" | "fragment" | undefined;
     public readonly skipUserInfo: boolean | undefined;
 
     public constructor(args: {
@@ -36,7 +36,7 @@ export class SigninState extends State {
         scope: string;
         client_secret?: string;
         extraTokenParams?: Record<string, unknown>;
-        response_mode?: string;
+        response_mode?: "query" | "fragment";
         skipUserInfo?: boolean;
     }) {
         super(args);

--- a/src/SignoutRequest.ts
+++ b/src/SignoutRequest.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger, UrlUtils } from "./utils";
+import { Logger } from "./utils";
 import { State } from "./State";
 
 /**
@@ -39,24 +39,27 @@ export class SignoutRequest {
             throw new Error("url");
         }
 
+        const parsedUrl = new URL(url);
         if (id_token_hint) {
-            url = UrlUtils.addQueryParam(url, "id_token_hint", id_token_hint);
+            parsedUrl.searchParams.append("id_token_hint", id_token_hint);
         }
 
         if (post_logout_redirect_uri) {
-            url = UrlUtils.addQueryParam(url, "post_logout_redirect_uri", post_logout_redirect_uri);
+            parsedUrl.searchParams.append("post_logout_redirect_uri", post_logout_redirect_uri);
 
             if (state_data) {
                 this.state = new State({ data: state_data, request_type });
 
-                url = UrlUtils.addQueryParam(url, "state", this.state.id);
+                parsedUrl.searchParams.append("state", this.state.id);
             }
         }
 
-        for (const key in extraQueryParams) {
-            url = UrlUtils.addQueryParam(url, key, extraQueryParams[key]);
+        for (const [key, value] of Object.entries({ ...extraQueryParams })) {
+            if (value != null) {
+                parsedUrl.searchParams.append(key, value.toString());
+            }
         }
 
-        this.url = url;
+        this.url = parsedUrl.href;
     }
 }

--- a/src/SignoutResponse.ts
+++ b/src/SignoutResponse.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { UrlUtils } from "./utils";
-
 /**
  * @public
  */
@@ -16,17 +14,15 @@ export class SignoutResponse {
 
     // set by ResponseValidator
     /** custom "state", which can be used by a caller to have "data" round tripped */
-    public state: unknown | undefined;
+    public state: unknown;
 
-    public constructor(url?: string) {
-        const values = UrlUtils.parseUrlFragment(url, "?");
+    public constructor(params: URLSearchParams) {
+        const values = new Map(params);
 
-        this.error = values.error;
-        this.error_description = values.error_description;
-        this.error_uri = values.error_uri;
+        this.error = values.get("error");
+        this.error_description = values.get("error_description");
+        this.error_uri = values.get("error_uri");
 
-        this.state_id = values.state;
-
-        this.state = undefined;
+        this.state_id = values.get("state");
     }
 }

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -22,8 +22,8 @@ export class IFrameNavigator implements INavigator {
         return new IFrameWindow({ silentRequestTimeoutInSeconds });
     }
 
-    public async callback(url: string, delimiter: string): Promise<void> {
+    public async callback(url: string): Promise<void> {
         this._logger.debug("callback");
-        IFrameWindow.notifyParent(url, delimiter);
+        IFrameWindow.notifyParent(url);
     }
 }

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -62,7 +62,7 @@ export class IFrameWindow extends AbstractChildWindow {
         this._window = null;
     }
 
-    public static notifyParent(url: string, delimiter: string): void {
-        return super._notifyParent(window.parent, url, delimiter);
+    public static notifyParent(url: string): void {
+        return super._notifyParent(window.parent, url);
     }
 }

--- a/src/navigators/IWindow.ts
+++ b/src/navigators/IWindow.ts
@@ -7,6 +7,7 @@ export interface NavigateParams {
     url: string;
     /** The request "state" parameter. For sign out requests, this parameter is optional. */
     state?: string;
+    response_mode?: "query" | "fragment";
 }
 
 /**

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -23,9 +23,9 @@ export class PopupNavigator implements INavigator {
         return new PopupWindow({ popupWindowFeatures, popupWindowTarget });
     }
 
-    public async callback(url: string, delimiter: string, keepOpen = false): Promise<void> {
+    public async callback(url: string, keepOpen = false): Promise<void> {
         this._logger.debug("callback");
 
-        PopupWindow.notifyOpener(url, delimiter, keepOpen);
+        PopupWindow.notifyOpener(url, keepOpen);
     }
 }

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -57,10 +57,10 @@ export class PopupWindow extends AbstractChildWindow {
         this._window = null;
     }
 
-    public static notifyOpener(url: string, delimiter: string, keepOpen: boolean): void {
+    public static notifyOpener(url: string, keepOpen: boolean): void {
         if (!window.opener) {
             throw new Error("No window.opener. Can't complete notification.");
         }
-        return super._notifyParent(window.opener, url, delimiter, keepOpen);
+        return super._notifyParent(window.opener, url, keepOpen);
     }
 }

--- a/src/utils/UrlUtils.ts
+++ b/src/utils/UrlUtils.ts
@@ -1,61 +1,13 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger } from "./Log";
-
 /**
  * @internal
  */
 export class UrlUtils {
-    public static addQueryParam(url: string, name: string, value: string | number | boolean): string {
-        if (url.indexOf("?") < 0) {
-            url += "?";
-        }
-
-        if (url[url.length - 1] !== "?") {
-            url += "&";
-        }
-
-        url += encodeURIComponent(name);
-        url += "=";
-        url += encodeURIComponent(value);
-
-        return url;
-    }
-
-    public static parseUrlFragment(value?: string, delimiter = "#"): Record<string, string> {
-        if (!value) {
-            value = location.href;
-        }
-
-        let idx = value.lastIndexOf(delimiter);
-        if (idx >= 0) {
-            value = value.substr(idx + 1);
-        }
-
-        if (delimiter === "?") {
-            // if we're doing query, then strip off hash fragment before we parse
-            idx = value.indexOf("#");
-            if (idx >= 0) {
-                value = value.substr(0, idx);
-            }
-        }
-
-        const params: Record<string, string> = {};
-        const regex = /([^&=]+)=([^&]*)/g;
-        let m;
-
-        let counter = 0;
-        while ((m = regex.exec(value)) !== null) {
-            params[decodeURIComponent(m[1])] = decodeURIComponent(m[2].replace(/\+/g, " "));
-            if (counter++ > 50) {
-                Logger.error("UrlUtils", "parseUrlFragment: response exceeded expected number of parameters", value);
-                return {
-                    error: "Response exceeded expected number of parameters"
-                };
-            }
-        }
-
-        return params;
+    public static readParams(url: string, responseMode: "query" | "fragment" = "query"): URLSearchParams {
+        const parsedUrl = new URL(url);
+        const params = parsedUrl[responseMode === "fragment" ? "hash" : "search"];
+        return new URLSearchParams(params.slice(1));
     }
 }

--- a/test/unit/OidcClient.test.ts
+++ b/test/unit/OidcClient.test.ts
@@ -90,7 +90,7 @@ describe("OidcClient", () => {
             const request = await subject.createSigninRequest({
                 state: "foo",
                 response_type: "code",
-                response_mode: "mode",
+                response_mode: "fragment",
                 scope: "baz",
                 redirect_uri: "quux",
                 prompt: "p",
@@ -122,7 +122,7 @@ describe("OidcClient", () => {
             expect(url).toContain("resource=res");
             expect(url).toContain("request=req");
             expect(url).toContain("request_uri=req_uri");
-            expect(url).toContain("response_mode=mode");
+            expect(url).toContain("response_mode=fragment");
         });
 
         it("should pass state in place of data to SigninRequest", async () => {
@@ -244,7 +244,7 @@ describe("OidcClient", () => {
 
         it("should return a promise", async () => {
             // act
-            const p = subject.readSigninResponseState("state=state");
+            const p = subject.readSigninResponseState("http://app/cb?state=state");
 
             // asssert
             expect(p).toBeInstanceOf(Promise);
@@ -258,7 +258,7 @@ describe("OidcClient", () => {
 
             // act
             try {
-                await subject.readSigninResponseState("");
+                await subject.readSigninResponseState("http://app/cb");
                 fail("should not come here");
             }
             catch (err) {
@@ -273,7 +273,7 @@ describe("OidcClient", () => {
 
             // act
             try {
-                await subject.readSigninResponseState("state=state");
+                await subject.readSigninResponseState("http://app/cb?state=state");
                 fail("should not come here");
             }
             catch (err) {
@@ -288,14 +288,14 @@ describe("OidcClient", () => {
                 id: "1",
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "http://cb",
+                redirect_uri: "http://app/cb",
                 scope: "scope",
                 request_type: "type"
             }).toStorageString();
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve(item));
 
             // act
-            const { state, response } = await subject.readSigninResponseState("state=1");
+            const { state, response } = await subject.readSigninResponseState("http://app/cb?state=1");
 
             // assert
             expect(state.id).toEqual("1");
@@ -309,7 +309,7 @@ describe("OidcClient", () => {
     describe("processSigninResponse", () => {
         it("should return a promise", async () => {
             // act
-            const p = subject.processSigninResponse("state=state");
+            const p = subject.processSigninResponse("http://app/cb?state=state");
 
             // assert
             expect(p).toBeInstanceOf(Promise);
@@ -323,7 +323,7 @@ describe("OidcClient", () => {
 
             // act
             try {
-                await subject.processSigninResponse("");
+                await subject.processSigninResponse("http://app/cb");
                 fail("should not come here");
             }
             catch (err) {
@@ -338,7 +338,7 @@ describe("OidcClient", () => {
 
             // act
             try {
-                await subject.processSigninResponse("state=state");
+                await subject.processSigninResponse("http://app/cb?state=state");
                 fail("should not come here");
             }
             catch (err) {
@@ -353,7 +353,7 @@ describe("OidcClient", () => {
                 id: "1",
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "http://cb",
+                redirect_uri: "http://app/cb",
                 scope: "scope",
                 request_type: "type"
             });
@@ -363,7 +363,7 @@ describe("OidcClient", () => {
                 .mockImplementation((_s, r) => Promise.resolve(r));
 
             // act
-            const response = await subject.processSigninResponse("state=1");
+            const response = await subject.processSigninResponse("http://app/cb?state=1");
 
             // assert
             expect(validateSigninResponseMock).toBeCalledWith(item, response);
@@ -496,7 +496,7 @@ describe("OidcClient", () => {
     describe("readSignoutResponseState", () => {
         it("should return a promise", async () => {
             // act
-            const p = subject.readSignoutResponseState("state=state");
+            const p = subject.readSignoutResponseState("http://app/cb?state=state");
 
             // assert
             expect(p).toBeInstanceOf(Promise);
@@ -506,7 +506,7 @@ describe("OidcClient", () => {
 
         it("should return result if no state on response", async () => {
             // act
-            const { response } = await subject.readSignoutResponseState("");
+            const { response } = await subject.readSignoutResponseState("http://app/cb");
 
             // assert
             expect(response).toBeInstanceOf(SignoutResponse);
@@ -515,7 +515,7 @@ describe("OidcClient", () => {
         it("should return error", async () => {
             // act
             try {
-                await subject.readSignoutResponseState("error=foo");
+                await subject.readSignoutResponseState("http://app/cb?error=foo");
                 fail("should not come here");
             }
             catch (err) {
@@ -530,7 +530,7 @@ describe("OidcClient", () => {
 
             // act
             try {
-                await subject.readSignoutResponseState("state=state");
+                await subject.readSignoutResponseState("http://app/cb?state=state");
                 fail("should not come here");
             }
             catch (err) {
@@ -545,7 +545,7 @@ describe("OidcClient", () => {
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve(item));
 
             // act
-            const { state, response } = await subject.readSignoutResponseState("state=1");
+            const { state, response } = await subject.readSignoutResponseState("http://app/cb?state=1");
 
             // assert
             expect(state).toBeDefined();
@@ -567,7 +567,7 @@ describe("OidcClient", () => {
                 .mockImplementation((_s, r) => r);
 
             // act
-            const response = await subject.processSignoutResponse("state=1&error=foo");
+            const response = await subject.processSignoutResponse("http://app/cb?state=1&error=foo");
 
             // assert
             expect(validateSignoutResponse).toBeCalledWith(item, response);
@@ -587,7 +587,7 @@ describe("OidcClient", () => {
 
         it("should return result if no state on response", async () => {
             // act
-            const response = await subject.processSignoutResponse("");
+            const response = await subject.processSignoutResponse("http://app/cb");
 
             // assert
             expect(response).toBeInstanceOf(SignoutResponse);
@@ -596,7 +596,7 @@ describe("OidcClient", () => {
         it("should return error", async () => {
             // act
             try {
-                await subject.processSignoutResponse("error=foo");
+                await subject.processSignoutResponse("http://app/cb?error=foo");
                 fail("should not come here");
             }
             catch (err) {
@@ -611,7 +611,7 @@ describe("OidcClient", () => {
 
             // act
             try {
-                await subject.processSignoutResponse("state=state");
+                await subject.processSignoutResponse("http://app/cb?state=state");
                 fail("should not come here");
             }
             catch (err) {
@@ -632,7 +632,7 @@ describe("OidcClient", () => {
                 .mockImplementation((_s, r) => r);
 
             // act
-            const response = await subject.processSignoutResponse("state=1");
+            const response = await subject.processSignoutResponse("http://app/cb?state=1");
 
             // assert
             expect(validateSignoutResponse).toBeCalledWith(item, response);
@@ -651,7 +651,7 @@ describe("OidcClient", () => {
                 .mockImplementation((_s, r) => r);
 
             // act
-            const response = await subject.processSignoutResponse("state=1&error=foo");
+            const response = await subject.processSignoutResponse("http://app/cb?state=1&error=foo");
 
             // assert
             expect(validateSignoutResponse).toBeCalledWith(item, response);

--- a/test/unit/SigninResponse.test.ts
+++ b/test/unit/SigninResponse.test.ts
@@ -10,7 +10,7 @@ describe("SigninResponse", () => {
 
         it("should read error", () => {
             // act
-            const subject = new SigninResponse("error=foo");
+            const subject = new SigninResponse(new URLSearchParams("error=foo"));
 
             // assert
             expect(subject.error).toEqual("foo");
@@ -18,7 +18,7 @@ describe("SigninResponse", () => {
 
         it("should read error_description", () => {
             // act
-            const subject = new SigninResponse("error_description=foo");
+            const subject = new SigninResponse(new URLSearchParams("error_description=foo"));
 
             // assert
             expect(subject.error_description).toEqual("foo");
@@ -26,7 +26,7 @@ describe("SigninResponse", () => {
 
         it("should read error_uri", () => {
             // act
-            const subject = new SigninResponse("error_uri=foo");
+            const subject = new SigninResponse(new URLSearchParams("error_uri=foo"));
 
             // assert
             expect(subject.error_uri).toEqual("foo");
@@ -34,7 +34,7 @@ describe("SigninResponse", () => {
 
         it("should read state", () => {
             // act
-            const subject = new SigninResponse("state=foo");
+            const subject = new SigninResponse(new URLSearchParams("state=foo"));
 
             // assert
             expect(subject.state_id).toEqual("foo");
@@ -42,7 +42,7 @@ describe("SigninResponse", () => {
 
         it("should read code", () => {
             // act
-            const subject = new SigninResponse("code=foo");
+            const subject = new SigninResponse(new URLSearchParams("code=foo"));
 
             // assert
             expect(subject.code).toEqual("foo");
@@ -50,7 +50,7 @@ describe("SigninResponse", () => {
 
         it("should read id_token", () => {
             // act
-            const subject = new SigninResponse("id_token=foo");
+            const subject = new SigninResponse(new URLSearchParams("id_token=foo"));
 
             // assert
             expect(subject.id_token).toEqual("foo");
@@ -58,7 +58,7 @@ describe("SigninResponse", () => {
 
         it("should read session_state", () => {
             // act
-            const subject = new SigninResponse("session_state=foo");
+            const subject = new SigninResponse(new URLSearchParams("session_state=foo"));
 
             // assert
             expect(subject.session_state).toEqual("foo");
@@ -66,7 +66,7 @@ describe("SigninResponse", () => {
 
         it("should read access_token", () => {
             // act
-            const subject = new SigninResponse("access_token=foo");
+            const subject = new SigninResponse(new URLSearchParams("access_token=foo"));
 
             // assert
             expect(subject.access_token).toEqual("foo");
@@ -74,7 +74,7 @@ describe("SigninResponse", () => {
 
         it("should read token_type", () => {
             // act
-            const subject = new SigninResponse("token_type=foo");
+            const subject = new SigninResponse(new URLSearchParams("token_type=foo"));
 
             // assert
             expect(subject.token_type).toEqual("foo");
@@ -82,7 +82,7 @@ describe("SigninResponse", () => {
 
         it("should read scope", () => {
             // act
-            const subject = new SigninResponse("scope=foo");
+            const subject = new SigninResponse(new URLSearchParams("scope=foo"));
 
             // assert
             expect(subject.scope).toEqual("foo");
@@ -90,7 +90,7 @@ describe("SigninResponse", () => {
 
         it("should read expires_in", () => {
             // act
-            const subject = new SigninResponse("expires_in=10");
+            const subject = new SigninResponse(new URLSearchParams("expires_in=10"));
 
             // assert
             expect(subject.expires_in).toEqual(10);
@@ -98,7 +98,7 @@ describe("SigninResponse", () => {
 
         it("should calculate expires_at", () => {
             // act
-            const subject = new SigninResponse("expires_in=10");
+            const subject = new SigninResponse(new URLSearchParams("expires_in=10"));
 
             // assert
             expect(subject.expires_at).toEqual(Timer.getEpochTime() + 10);
@@ -106,14 +106,14 @@ describe("SigninResponse", () => {
 
         it("should not read invalid expires_in", () => {
             // act
-            let subject = new SigninResponse("expires_in=foo");
+            let subject = new SigninResponse(new URLSearchParams("expires_in=foo"));
 
             // assert
             expect(subject.expires_in).toBeUndefined();
             expect(subject.expires_at).toBeUndefined();
 
             // act
-            subject = new SigninResponse("expires_in=-10");
+            subject = new SigninResponse(new URLSearchParams("expires_in=-10"));
 
             // assert
             expect(subject.expires_in).toBeUndefined();
@@ -125,17 +125,17 @@ describe("SigninResponse", () => {
     describe("scopes", () => {
         it("should return list of scope", () => {
             // act
-            let subject = new SigninResponse("scope=foo");
+            let subject = new SigninResponse(new URLSearchParams("scope=foo"));
 
             // assert
             expect(subject.scopes).toEqual(["foo"]);
 
-            subject = new SigninResponse("scope=foo%20bar");
+            subject = new SigninResponse(new URLSearchParams("scope=foo%20bar"));
 
             // assert
             expect(subject.scopes).toEqual(["foo", "bar"]);
 
-            subject = new SigninResponse("scope=foo%20bar%20baz");
+            subject = new SigninResponse(new URLSearchParams("scope=foo%20bar%20baz"));
 
             // assert
             expect(subject.scopes).toEqual(["foo", "bar", "baz"]);
@@ -150,7 +150,7 @@ describe("SigninResponse", () => {
             };
 
             // act
-            const subject = new SigninResponse("expires_in=100");
+            const subject = new SigninResponse(new URLSearchParams("expires_in=100"));
 
             // assert
             expect(subject.expires_in).toEqual(100);
@@ -173,7 +173,7 @@ describe("SigninResponse", () => {
             };
 
             // act
-            const subject = new SigninResponse("expires_in=100");
+            const subject = new SigninResponse(new URLSearchParams("expires_in=100"));
 
             // assert
             expect(subject.expired).toEqual(false);
@@ -191,25 +191,25 @@ describe("SigninResponse", () => {
     describe("isOpenIdConnect", () => {
         it("should detect openid scope", () => {
             // act
-            let subject = new SigninResponse("scope=foo%20openid%20bar");
+            let subject = new SigninResponse(new URLSearchParams("scope=foo%20openid%20bar"));
 
             // assert
             expect(subject.isOpenIdConnect).toEqual(true);
 
             // act
-            subject = new SigninResponse("scope=openid%20foo%20bar");
+            subject = new SigninResponse(new URLSearchParams("scope=openid+foo+bar"));
 
             // assert
             expect(subject.isOpenIdConnect).toEqual(true);
 
             // act
-            subject = new SigninResponse("scope=foo%20bar%20openid");
+            subject = new SigninResponse(new URLSearchParams("scope=foo+bar+openid"));
 
             // assert
             expect(subject.isOpenIdConnect).toEqual(true);
 
             // act
-            subject = new SigninResponse("scope=foo%20bar");
+            subject = new SigninResponse(new URLSearchParams("scope=foo+bar"));
 
             // assert
             expect(subject.isOpenIdConnect).toEqual(false);

--- a/test/unit/SignoutResponse.test.ts
+++ b/test/unit/SignoutResponse.test.ts
@@ -9,7 +9,7 @@ describe("SignoutResponse", () => {
 
         it("should read error", () => {
             // act
-            const subject = new SignoutResponse("error=foo");
+            const subject = new SignoutResponse(new URLSearchParams("error=foo"));
 
             // assert
             expect(subject.error).toEqual("foo");
@@ -17,7 +17,7 @@ describe("SignoutResponse", () => {
 
         it("should read error_description", () => {
             // act
-            const subject = new SignoutResponse("error_description=foo");
+            const subject = new SignoutResponse(new URLSearchParams("error_description=foo"));
 
             // assert
             expect(subject.error_description).toEqual("foo");
@@ -25,7 +25,7 @@ describe("SignoutResponse", () => {
 
         it("should read error_uri", () => {
             // act
-            const subject = new SignoutResponse("error_uri=foo");
+            const subject = new SignoutResponse(new URLSearchParams("error_uri=foo"));
 
             // assert
             expect(subject.error_uri).toEqual("foo");
@@ -33,7 +33,7 @@ describe("SignoutResponse", () => {
 
         it("should read state", () => {
             // act
-            const subject = new SignoutResponse("state=foo");
+            const subject = new SignoutResponse(new URLSearchParams("state=foo"));
 
             // assert
             expect(subject.state_id).toEqual("foo");

--- a/test/unit/utils/UrlUtils.test.ts
+++ b/test/unit/utils/UrlUtils.test.ts
@@ -5,114 +5,24 @@ import { UrlUtils } from "../../../src/utils";
 
 describe("UrlUtils", () => {
 
-    describe("addQueryParam", () => {
+    describe("readUrlParams", () => {
 
-        it("should add ? if not present", () => {
+        it("should return query params by default", () => {
             // act
-            const result = UrlUtils.addQueryParam("url", "foo", "test");
+            const result = UrlUtils.readParams("http://app/?foo=test");
+            const resultObj = Object.fromEntries(result);
 
             // assert
-            expect(result).toEqual("url?foo=test");
+            expect(resultObj).toHaveProperty("foo", "test");
         });
 
-        it("should not add ? if already present", () => {
+        it("should return fragment params for response_mode=fragment", () => {
             // act
-            const result = UrlUtils.addQueryParam("url?", "foo", "test");
+            const result = UrlUtils.readParams("http://app/?foo=test#bar=test_fragment", "fragment");
+            const resultObj = Object.fromEntries(result);
 
             // assert
-            expect(result).toEqual("url?foo=test");
-        });
-
-        it("should add & if needed", () => {
-            // act
-            const result = UrlUtils.addQueryParam("url?x=1", "foo", "test");
-
-            // assert
-            expect(result).toEqual("url?x=1&foo=test");
-        });
-
-        it("should stringify boolean values", () => {
-            // act
-            let result = UrlUtils.addQueryParam("url?x=1", "foo", true);
-            result = UrlUtils.addQueryParam(result, "bar", false);
-
-            // assert
-            expect(result).toEqual("url?x=1&foo=true&bar=false");
-        });
-
-        it("should stringify numeric values", () => {
-            // act
-            const result = UrlUtils.addQueryParam("url?x=1", "foo", 1.2);
-
-            // assert
-            expect(result).toEqual("url?x=1&foo=1.2");
-        });
-
-        it("should url encode key and value", () => {
-            // act
-            const result = UrlUtils.addQueryParam("url", "#", "#");
-
-            // assert
-            expect(result).toEqual("url?%23=%23");
-        });
-    });
-
-    describe("parseUrlFragment", () => {
-
-        it("should parse key/value pairs", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("a=apple&b=banana&c=carrot");
-
-            // assert
-            expect(result).toEqual({ a: "apple", b: "banana", c: "carrot" });
-        });
-
-        it("should parse any order", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("b=banana&c=carrot&a=apple");
-
-            // assert
-            expect(result).toEqual({ a: "apple", b: "banana", c: "carrot" });
-        });
-
-        it("should parse past host name and hash fragment", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("http://server?test1=xoxo&test2=xoxo/#a=apple&b=banana&c=carrot");
-
-            // assert
-            expect(result).toEqual({ a: "apple", b: "banana", c: "carrot" });
-        });
-
-        it("should parse query string", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("http://server?test1=xoxo&test2=yoyo", "?");
-
-            // assert
-            expect(result).toEqual({ test1: "xoxo", test2: "yoyo" });
-        });
-
-        it("should parse query string up to hash", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("http://server?test1=xoxo&test2=yoyo#a=apple&b=banana&c=carrot", "?");
-
-            // assert
-            expect(result).toEqual({ test1: "xoxo", test2: "yoyo" });
-        });
-
-        it("should return error for long values", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple&a=apple");
-
-            // assert
-            expect(result).toHaveProperty("error");
-        });
-
-        it("should return empty object for empty string", () => {
-            // act
-            const result = UrlUtils.parseUrlFragment("");
-
-            // assert
-            expect(result).toEqual({});
+            expect(resultObj).toHaveProperty("bar", "test_fragment");
         });
     });
 });


### PR DESCRIPTION
Closes #157

This refactors navigator code a bit further:

* URL parsing is now dictated solely by the settings of the window opener/iframe parent. The previous implementation extracted the `state` param from the URL on the child window and passed it separately from the full URL in `.postMessage()`.  Essentially this means that before, when using `response_mode=fragment`, the child window `settings` must match its parent since the parent window parses the URL according to its own `response_mode` setting after the navigator completes.

* `_signinCallback()` was inlined since the refactoring above made it into a trivial one-line function. Additionally, `signinPopupCallback` was lacking parity with `signoutPopupCallback`  w.r.t the `keepOpen` param.