### PR TITLE
Automatically center popups in front of the opener window

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -376,21 +376,23 @@ export interface OidcMetadata {
 // @public (undocumented)
 export interface PopupWindowFeatures {
     // (undocumented)
+    [k: string]: boolean | string | number | undefined;
+    // (undocumented)
     height?: number;
     // (undocumented)
     left?: number;
     // (undocumented)
-    location?: boolean;
+    location?: boolean | string;
     // (undocumented)
-    menubar?: boolean;
+    menubar?: boolean | string;
     // (undocumented)
-    resizable?: boolean;
+    resizable?: boolean | string;
     // (undocumented)
-    scrollbars?: boolean;
+    scrollbars?: boolean | string;
     // (undocumented)
-    status?: boolean;
+    status?: boolean | string;
     // (undocumented)
-    toolbar?: boolean;
+    toolbar?: boolean | string;
     // (undocumented)
     top?: number;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -374,9 +374,33 @@ export interface OidcMetadata {
 }
 
 // @public (undocumented)
+export interface PopupWindowFeatures {
+    // (undocumented)
+    height?: number;
+    // (undocumented)
+    left?: number;
+    // (undocumented)
+    location?: boolean;
+    // (undocumented)
+    menubar?: boolean;
+    // (undocumented)
+    resizable?: boolean;
+    // (undocumented)
+    scrollbars?: boolean;
+    // (undocumented)
+    status?: boolean;
+    // (undocumented)
+    toolbar?: boolean;
+    // (undocumented)
+    top?: number;
+    // (undocumented)
+    width?: number;
+}
+
+// @public (undocumented)
 export interface PopupWindowParams {
     // (undocumented)
-    popupWindowFeatures?: string;
+    popupWindowFeatures?: PopupWindowFeatures;
     // (undocumented)
     popupWindowTarget?: string;
 }
@@ -835,7 +859,7 @@ export interface UserManagerSettings extends OidcClientSettings {
     // (undocumented)
     popup_post_logout_redirect_uri?: string;
     popup_redirect_uri?: string;
-    popupWindowFeatures?: string;
+    popupWindowFeatures?: PopupWindowFeatures;
     popupWindowTarget?: string;
     // (undocumented)
     query_status_response_type?: string;
@@ -869,7 +893,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     // (undocumented)
     readonly popup_redirect_uri: string | undefined;
     // (undocumented)
-    readonly popupWindowFeatures: string | undefined;
+    readonly popupWindowFeatures: PopupWindowFeatures | undefined;
     // (undocumented)
     readonly popupWindowTarget: string | undefined;
     // (undocumented)

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { OidcClientSettings, OidcClientSettingsStore } from "./OidcClientSettings";
+import type { PopupWindowFeatures } from "./utils";
 import { WebStorageStateStore } from "./WebStorageStateStore";
 
 const DefaultAccessTokenExpiringNotificationTimeInSeconds = 60;
@@ -15,10 +16,11 @@ export interface UserManagerSettings extends OidcClientSettings {
     popup_redirect_uri?: string;
     popup_post_logout_redirect_uri?: string;
     /**
-     * The features parameter to window.open for the popup signin window.
-     * (default: "location=no,toolbar=no,width=500,height=500,left=100,top=100;")
+     * The features parameter to window.open for the popup signin window. By default, the popup is
+     * placed centered in front of the window opener.
+     * (default: "location=no,toolbar=no,width=576,height=640")
      */
-    popupWindowFeatures?: string;
+    popupWindowFeatures?: PopupWindowFeatures;
     /** The target parameter to window.open for the popup signin window (default: "_blank") */
     popupWindowTarget?: string;
     /** The methods window.location method used to redirect (default: "assign") */
@@ -61,7 +63,7 @@ export interface UserManagerSettings extends OidcClientSettings {
 export class UserManagerSettingsStore extends OidcClientSettingsStore {
     public readonly popup_redirect_uri: string | undefined;
     public readonly popup_post_logout_redirect_uri: string | undefined;
-    public readonly popupWindowFeatures: string | undefined;
+    public readonly popupWindowFeatures: PopupWindowFeatures | undefined;
     public readonly popupWindowTarget: string | undefined;
     public readonly redirectMethod: "replace" | "assign";
 

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -18,7 +18,7 @@ export interface UserManagerSettings extends OidcClientSettings {
     /**
      * The features parameter to window.open for the popup signin window. By default, the popup is
      * placed centered in front of the window opener.
-     * (default: "location=no,toolbar=no,width=576,height=640")
+     * (default: \{ location: false, menubar: false, height: 640 \})
      */
     popupWindowFeatures?: PopupWindowFeatures;
     /** The target parameter to window.open for the popup signin window (default: "_blank") */

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 
 export type { IFrameWindowParams, PopupWindowParams, RedirectParams } from "./navigators";
 export { Log } from "./utils";
-export type { ILogger } from "./utils";
+export type { ILogger, PopupWindowFeatures } from "./utils";
 
 export { AccessTokenEvents } from "./AccessTokenEvents";
 export type { AccessTokenCallback } from "./AccessTokenEvents";

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -1,12 +1,17 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger } from "../utils";
+import { Logger, PopupUtils, PopupWindowFeatures } from "../utils";
 import { AbstractChildWindow } from "./AbstractChildWindow";
 import type { NavigateParams, NavigateResponse } from "./IWindow";
 
 const checkForPopupClosedInterval = 500;
-const defaultPopupFeatures = "location=no,toolbar=no,width=500,height=500,left=100,top=100";
+const defaultPopupWindowFeatures: PopupWindowFeatures = {
+    location: false,
+    toolbar: false,
+    width: 576,
+    height: 640,
+};
 
 const defaultPopupTarget = "_blank";
 
@@ -14,7 +19,7 @@ const defaultPopupTarget = "_blank";
  * @public
  */
 export interface PopupWindowParams {
-    popupWindowFeatures?: string;
+    popupWindowFeatures?: PopupWindowFeatures;
     popupWindowTarget?: string;
 }
 
@@ -28,10 +33,11 @@ export class PopupWindow extends AbstractChildWindow {
 
     public constructor({
         popupWindowTarget = defaultPopupTarget,
-        popupWindowFeatures = defaultPopupFeatures
+        popupWindowFeatures = {},
     }: PopupWindowParams) {
         super();
-        this._window = window.open(undefined, popupWindowTarget, popupWindowFeatures);
+        const centeredPopup = PopupUtils.center(Object.assign({}, defaultPopupWindowFeatures, popupWindowFeatures));
+        this._window = window.open(undefined, popupWindowTarget, PopupUtils.serialize(centeredPopup));
     }
 
     public async navigate(params: NavigateParams): Promise<NavigateResponse> {

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -9,7 +9,6 @@ const checkForPopupClosedInterval = 500;
 const defaultPopupWindowFeatures: PopupWindowFeatures = {
     location: false,
     toolbar: false,
-    width: 576,
     height: 640,
 };
 
@@ -36,7 +35,7 @@ export class PopupWindow extends AbstractChildWindow {
         popupWindowFeatures = {},
     }: PopupWindowParams) {
         super();
-        const centeredPopup = PopupUtils.center(Object.assign({}, defaultPopupWindowFeatures, popupWindowFeatures));
+        const centeredPopup = PopupUtils.center({ ...defaultPopupWindowFeatures, ...popupWindowFeatures });
         this._window = window.open(undefined, popupWindowTarget, PopupUtils.serialize(centeredPopup));
     }
 

--- a/src/utils/PopupUtils.ts
+++ b/src/utils/PopupUtils.ts
@@ -9,12 +9,14 @@ export interface PopupWindowFeatures {
     top?: number;
     width?: number;
     height?: number;
-    menubar?: boolean;
-    toolbar?: boolean;
-    location?: boolean;
-    status?: boolean;
-    resizable?: boolean;
-    scrollbars?: boolean;
+    menubar?: boolean | string;
+    toolbar?: boolean | string;
+    location?: boolean | string;
+    status?: boolean | string;
+    resizable?: boolean | string;
+    scrollbars?: boolean | string;
+
+    [k: string]: boolean | string | number | undefined;
 }
 
 export class PopupUtils {
@@ -35,7 +37,7 @@ export class PopupUtils {
     static serialize(features: PopupWindowFeatures): string {
         return Object.entries(features)
             .filter(([, value]) => value != null)
-            .map(([key, value]) => `${key}=${typeof value === "number" ? value : value ? "yes" : "no"}`)
+            .map(([key, value]) => `${key}=${typeof value !== "boolean" ? value as string : value ? "yes" : "no"}`)
             .join(",");
     }
 }

--- a/src/utils/PopupUtils.ts
+++ b/src/utils/PopupUtils.ts
@@ -18,9 +18,15 @@ export interface PopupWindowFeatures {
 }
 
 export class PopupUtils {
+    /**
+     * Popuplates a map of window features with a placement centered in front of
+     * the current window. If no explicit width is given, a default value is
+     * binned into [800, 720, 600, 480, 360] based on the current window's width.
+     */
     static center({ ...features }: PopupWindowFeatures): PopupWindowFeatures {
-        if (features.width != null)
-            features.left ??= Math.max(0, Math.round(window.screenX + (window.outerWidth - features.width) / 2));
+        if (features.width == null)
+            features.width = [800, 720, 600, 480].find(width => width <= window.outerWidth / 1.618) ?? 360;
+        features.left ??= Math.max(0, Math.round(window.screenX + (window.outerWidth - features.width) / 2));
         if (features.height != null)
             features.top ??= Math.max(0, Math.round(window.screenY + (window.outerHeight - features.height) / 2));
         return features;

--- a/src/utils/PopupUtils.ts
+++ b/src/utils/PopupUtils.ts
@@ -1,0 +1,35 @@
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_features
+ *
+ * @public
+ */
+export interface PopupWindowFeatures {
+    left?: number;
+    top?: number;
+    width?: number;
+    height?: number;
+    menubar?: boolean;
+    toolbar?: boolean;
+    location?: boolean;
+    status?: boolean;
+    resizable?: boolean;
+    scrollbars?: boolean;
+}
+
+export class PopupUtils {
+    static center({ ...features }: PopupWindowFeatures): PopupWindowFeatures {
+        if (features.width != null)
+            features.left ??= Math.max(0, Math.round(window.screenX + (window.outerWidth - features.width) / 2));
+        if (features.height != null)
+            features.top ??= Math.max(0, Math.round(window.screenY + (window.outerHeight - features.height) / 2));
+        return features;
+    }
+
+    static serialize(features: PopupWindowFeatures): string {
+        return Object.entries(features)
+            .filter(([, value]) => value != null)
+            .map(([key, value]) => `${key}=${typeof value === "number" ? value : value ? "yes" : "no"}`)
+            .join(",");
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,6 @@ export * from "./CryptoUtils";
 export * from "./Event";
 export * from "./JwtUtils";
 export * from "./Log";
+export * from "./PopupUtils";
 export * from "./Timer";
 export * from "./UrlUtils";

--- a/test/unit/UserManagerSettings.test.ts
+++ b/test/unit/UserManagerSettings.test.ts
@@ -53,11 +53,11 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                popupWindowFeatures: "foo"
+                popupWindowFeatures: { status: true }
             });
 
             // assert
-            expect(subject.popupWindowFeatures).toEqual("foo");
+            expect(subject.popupWindowFeatures).toEqual({ status: true });
         });
 
     });

--- a/test/unit/utils/PopupUtils.test.ts
+++ b/test/unit/utils/PopupUtils.test.ts
@@ -1,4 +1,4 @@
-import { PopupUtils, PopupWindowFeatures } from "../../../src/utils";
+import { PopupUtils } from "../../../src/utils";
 
 describe("PopupUtils", () => {
     describe("center", () => {
@@ -37,21 +37,21 @@ describe("PopupUtils", () => {
 
     describe("serialize", () => {
         it("should encode boolean values as yes/no", () => {
-            const result = PopupUtils.serialize({ foo: true, bar: false } as PopupWindowFeatures);
+            const result = PopupUtils.serialize({ foo: true, bar: false });
 
             expect(result).toEqual("foo=yes,bar=no");
         });
 
         it("should omit undefined properties", () => {
-            const result = PopupUtils.serialize({ foo: true, bar: undefined } as PopupWindowFeatures);
+            const result = PopupUtils.serialize({ foo: true, bar: undefined });
 
             expect(result).toEqual("foo=yes");
         });
 
-        it("should preserve numerical values", () => {
-            const result = PopupUtils.serialize({ foo: true, bar: 0, baz: 20 } as PopupWindowFeatures);
+        it("should preserve numerical and string values", () => {
+            const result = PopupUtils.serialize({ foo: "yes", bar: 0, baz: 20, quux: "" });
 
-            expect(result).toEqual("foo=yes,bar=0,baz=20");
+            expect(result).toEqual("foo=yes,bar=0,baz=20,quux=");
         });
     });
 });

--- a/test/unit/utils/PopupUtils.test.ts
+++ b/test/unit/utils/PopupUtils.test.ts
@@ -1,0 +1,57 @@
+import { PopupUtils, PopupWindowFeatures } from "../../../src/utils";
+
+describe("PopupUtils", () => {
+    describe("center", () => {
+        it("should center a window to integer offsets", () => {
+            Object.defineProperties(window, {
+                screenX: { enumerable: true, value: 50 },
+                screenY: { enumerable: true, value: 50 },
+                outerWidth: { enumerable: true, value: 101 },
+                outerHeight: { enumerable: true, value: 101 },
+            });
+            const features = PopupUtils.center({
+                width: 100,
+                height: 100,
+            });
+
+            expect(features.left).toBe(51);
+            expect(features.top).toBe(51);
+        });
+
+        it("should restrict window placement to nonnegative offsets", () => {
+            Object.defineProperties(window, {
+                screenX: { enumerable: true, value: 0 },
+                screenY: { enumerable: true, value: 0 },
+                outerWidth: { enumerable: true, value: 50 },
+                outerHeight: { enumerable: true, value: 50 },
+            });
+            const features = PopupUtils.center({
+                width: 100,
+                height: 100,
+            });
+
+            expect(features.left).toBe(0);
+            expect(features.top).toBe(0);
+        });
+    });
+
+    describe("serialize", () => {
+        it("should encode boolean values as yes/no", () => {
+            const result = PopupUtils.serialize({ foo: true, bar: false } as PopupWindowFeatures);
+
+            expect(result).toEqual("foo=yes,bar=no");
+        });
+
+        it("should omit undefined properties", () => {
+            const result = PopupUtils.serialize({ foo: true, bar: undefined } as PopupWindowFeatures);
+
+            expect(result).toEqual("foo=yes");
+        });
+
+        it("should preserve numerical values", () => {
+            const result = PopupUtils.serialize({ foo: true, bar: 0, baz: 20 } as PopupWindowFeatures);
+
+            expect(result).toEqual("foo=yes,bar=0,baz=20");
+        });
+    });
+});


### PR DESCRIPTION
This updates the popup window navigator to automatically open and place the window centered in front the window opener. This is accomplished by refactoring the `popupWindowFeatures` setting to be an object instead of a string and introducing a new `PopupUtils` library which can compute a centered placement based on window dimensions.

Screenshot:
![image](https://user-images.githubusercontent.com/4993980/140829175-c841c0ca-aa98-4b19-b2b7-00dd091a8c22.png)
