### PR TITLE
Move unit tests into `src` folder

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -56,6 +56,9 @@ overrides:
   - files: src/**/*
     env:
       node: false
-  - files: test/**/*
+  - files: [src/**/*.test.*, test/**/*]
     env:
       jest: true
+    rules:
+      "@typescript-eslint/unbound-method": "off"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           path: |
             lib/
-            tsconfig.tsbuildinfo
+            tsconfig.build.tsbuildinfo
           key: build-${{ github.head_ref }}-${{ github.sha }}
           restore-keys: |
             build-${{ github.head_ref }}-
@@ -47,7 +47,7 @@ jobs:
         with:
           path: |
             .eslintcache
-            test/unit/tsconfig.tsbuildinfo
+            tsconfig.tsbuildinfo
           key: test-${{ github.head_ref }}-${{ github.sha }}
           restore-keys: |
             test-${{ github.head_ref }}-

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -77,7 +77,7 @@
          * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
          * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
          */
-        // "tsconfigFilePath": "<projectFolder>/tsconfig.json",
+        "tsconfigFilePath": "<projectFolder>/tsconfig.build.json"
         /**
          * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
          * The object must conform to the TypeScript tsconfig schema:

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,7 +5,7 @@ const collectCoverage = yn(process.env.CI);
 export default {
     preset: "ts-jest",
     clearMocks: true,
-    testMatch: ["**/test/unit/**/*.test.ts"],
+    testMatch: ["**/{src,test}/**/*.test.ts"],
     testEnvironment: "jsdom",
     collectCoverage,
     coverageReporters: collectCoverage ? ["lcov"] : ["lcov", "text"],

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   ],
   "scripts": {
     "build": "node scripts/build.js && npm run build-types",
-    "build-types": "tsc --emitDeclarationOnly && api-extractor run",
-    "clean": "git clean -fdX dist",
+    "build-types": "tsc -p tsconfig.build.json && api-extractor run",
+    "clean": "git clean -fdX dist lib *.tsbuildinfo",
     "prepack": "npm run build",
-    "test": "tsc -p test/unit/tsconfig.json && jest",
+    "test": "tsc && jest",
     "typedoc": "typedoc",
     "lint": "eslint --max-warnings=0 --cache .",
     "prepare": "husky install"

--- a/src/AccessTokenEvents.test.ts
+++ b/src/AccessTokenEvents.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Timer } from "../../src/utils";
-import { AccessTokenEvents } from "../../src/AccessTokenEvents";
-import type { User } from "../../src/User";
+import { Timer } from "./utils";
+import { AccessTokenEvents } from "./AccessTokenEvents";
+import type { User } from "./User";
 
 describe("AccessTokenEvents", () => {
 

--- a/src/ErrorResponse.test.ts
+++ b/src/ErrorResponse.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { ErrorResponse } from "../../src/ErrorResponse";
+import { ErrorResponse } from "./ErrorResponse";
 
 describe("ErrorResponse", () => {
 

--- a/src/JsonService.test.ts
+++ b/src/JsonService.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { JsonService } from "../../src/JsonService";
+import { Log } from "./utils";
+import { JsonService } from "./JsonService";
 import { mocked } from "ts-jest/utils";
 
 describe("JsonService", () => {

--- a/src/MetadataService.test.ts
+++ b/src/MetadataService.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { MetadataService } from "../../src/MetadataService";
-import { OidcClientSettings, OidcClientSettingsStore } from "../../src/OidcClientSettings";
+import { Log } from "./utils";
+import { MetadataService } from "./MetadataService";
+import { OidcClientSettings, OidcClientSettingsStore } from "./OidcClientSettings";
 
 describe("MetadataService", () => {
     let settings: OidcClientSettings;

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { OidcClient } from "../../src/OidcClient";
-import { OidcClientSettings, OidcClientSettingsStore } from "../../src/OidcClientSettings";
-import { SigninState } from "../../src/SigninState";
-import { State } from "../../src/State";
-import { SigninRequest } from "../../src/SigninRequest";
-import { SignoutRequest } from "../../src/SignoutRequest";
-import { SignoutResponse } from "../../src/SignoutResponse";
-import type { ErrorResponse } from "../../src/ErrorResponse";
+import { Log } from "./utils";
+import { OidcClient } from "./OidcClient";
+import { OidcClientSettings, OidcClientSettingsStore } from "./OidcClientSettings";
+import { SigninState } from "./SigninState";
+import { State } from "./State";
+import { SigninRequest } from "./SigninRequest";
+import { SignoutRequest } from "./SignoutRequest";
+import { SignoutResponse } from "./SignoutResponse";
+import type { ErrorResponse } from "./ErrorResponse";
 
 describe("OidcClient", () => {
     let subject: OidcClient;

--- a/src/OidcClientSettings.test.ts
+++ b/src/OidcClientSettings.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { OidcClientSettingsStore } from "../../src/OidcClientSettings";
-import type { StateStore } from "../../src/StateStore";
+import { Log } from "./utils";
+import { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { StateStore } from "./StateStore";
 
 describe("OidcClientSettings", () => {
 

--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { ResponseValidator } from "../../src/ResponseValidator";
-import { MetadataService } from "../../src/MetadataService";
-import type { UserInfoService } from "../../src/UserInfoService";
-import { SigninState } from "../../src/SigninState";
-import type { SigninResponse } from "../../src/SigninResponse";
-import type { ErrorResponse } from "../../src/ErrorResponse";
-import type { UserProfile } from "../../src/User";
+import { Log } from "./utils";
+import { ResponseValidator } from "./ResponseValidator";
+import { MetadataService } from "./MetadataService";
+import type { UserInfoService } from "./UserInfoService";
+import { SigninState } from "./SigninState";
+import type { SigninResponse } from "./SigninResponse";
+import type { ErrorResponse } from "./ErrorResponse";
+import type { UserProfile } from "./User";
 
 // access private methods
 class ResponseValidatorWrapper extends ResponseValidator {

--- a/src/SigninRequest.test.ts
+++ b/src/SigninRequest.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { SigninRequest } from "../../src/SigninRequest";
+import { SigninRequest } from "./SigninRequest";
 
 describe("SigninRequest", () => {
 

--- a/src/SigninResponse.test.ts
+++ b/src/SigninResponse.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { SigninResponse } from "../../src/SigninResponse";
-import { Timer } from "../../src/utils";
+import { SigninResponse } from "./SigninResponse";
+import { Timer } from "./utils";
 
 describe("SigninResponse", () => {
     describe("constructor", () => {

--- a/src/SigninState.test.ts
+++ b/src/SigninState.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { SigninState } from "../../src/SigninState";
+import { Log } from "./utils";
+import { SigninState } from "./SigninState";
 
 describe("SigninState", () => {
 

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { SignoutRequest, SignoutRequestArgs } from "../../src/SignoutRequest";
+import { SignoutRequest, SignoutRequestArgs } from "./SignoutRequest";
 
 describe("SignoutRequest", () => {
 

--- a/src/SignoutResponse.test.ts
+++ b/src/SignoutResponse.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { SignoutResponse } from "../../src/SignoutResponse";
+import { SignoutResponse } from "./SignoutResponse";
 
 describe("SignoutResponse", () => {
 

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { State } from "../../src/State";
+import { Log } from "./utils";
+import { State } from "./State";
 
-import { InMemoryWebStorage } from "../../src/InMemoryWebStorage";
-import { WebStorageStateStore } from "../../src/WebStorageStateStore";
+import { InMemoryWebStorage } from "./InMemoryWebStorage";
+import { WebStorageStateStore } from "./WebStorageStateStore";
 
 describe("State", () => {
 

--- a/src/UserInfoService.test.ts
+++ b/src/UserInfoService.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { UserInfoService } from "../../src/UserInfoService";
-import { MetadataService } from "../../src/MetadataService";
-import type { JsonService } from "../../src/JsonService";
-import { OidcClientSettingsStore } from "../../src/OidcClientSettings";
+import { UserInfoService } from "./UserInfoService";
+import { MetadataService } from "./MetadataService";
+import type { JsonService } from "./JsonService";
+import { OidcClientSettingsStore } from "./OidcClientSettings";
 
 describe("UserInfoService", () => {
     let subject: UserInfoService;

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log, Logger } from "../../src/utils";
-import { UserManager } from "../../src/UserManager";
-import { UserManagerSettings, UserManagerSettingsStore } from "../../src/UserManagerSettings";
-import { User } from "../../src/User";
-import { WebStorageStateStore } from "../../src/WebStorageStateStore";
+import { Log, Logger } from "./utils";
+import { UserManager } from "./UserManager";
+import { UserManagerSettings, UserManagerSettingsStore } from "./UserManagerSettings";
+import { User } from "./User";
+import { WebStorageStateStore } from "./WebStorageStateStore";
 
 import { mocked } from "ts-jest/utils";
-import type { IWindow } from "../../src/navigators";
+import type { IWindow } from "./navigators";
 
 describe("UserManager", () => {
     let settings: UserManagerSettings;

--- a/src/UserManagerEvents.test.ts
+++ b/src/UserManagerEvents.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { UserManagerEvents } from "../../src/UserManagerEvents";
-import { UserManagerSettingsStore } from "../../src/UserManagerSettings";
+import { UserManagerEvents } from "./UserManagerEvents";
+import { UserManagerSettingsStore } from "./UserManagerSettings";
 
 describe("UserManagerEvents", () => {
 

--- a/src/UserManagerSettings.test.ts
+++ b/src/UserManagerSettings.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "../../src/utils";
-import { UserManagerSettingsStore } from "../../src/UserManagerSettings";
-import type { WebStorageStateStore } from "../../src/WebStorageStateStore";
+import { Log } from "./utils";
+import { UserManagerSettingsStore } from "./UserManagerSettings";
+import type { WebStorageStateStore } from "./WebStorageStateStore";
 
 describe("UserManagerSettings", () => {
 

--- a/src/WebStorageStateStore.test.ts
+++ b/src/WebStorageStateStore.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { WebStorageStateStore } from "../../src/WebStorageStateStore";
-import { InMemoryWebStorage } from "../../src/InMemoryWebStorage";
+import { WebStorageStateStore } from "./WebStorageStateStore";
+import { InMemoryWebStorage } from "./InMemoryWebStorage";
 
 describe("WebStorageStateStore", () => {
     let prefix: string;

--- a/src/navigators/PopupWindow.test.ts
+++ b/src/navigators/PopupWindow.test.ts
@@ -1,4 +1,4 @@
-import { PopupWindow } from "../../src/navigators/PopupWindow";
+import { PopupWindow } from "./PopupWindow";
 
 describe("PopupWindow", () => {
     let popupFromWindowOpen: WindowProxy;
@@ -41,7 +41,6 @@ describe("PopupWindow", () => {
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
     });
 
@@ -56,7 +55,6 @@ describe("PopupWindow", () => {
         }));
 
         await expect(promise).rejects.toThrow("Invalid response from window");
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
     });
 });

--- a/src/utils/CryptoUtils.test.ts
+++ b/src/utils/CryptoUtils.test.ts
@@ -1,4 +1,4 @@
-import { CryptoUtils } from "../../../src/utils";
+import { CryptoUtils } from "./CryptoUtils";
 
 const pattern = /^[0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}$/;
 

--- a/src/utils/Event.test.ts
+++ b/src/utils/Event.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Event } from "../../../src/utils";
+import { Event } from "./Event";
 
 describe("Event", () => {
 

--- a/src/utils/JwtUtils.test.ts
+++ b/src/utils/JwtUtils.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log, JwtUtils } from "../../../src/utils";
+import { JwtUtils } from "./JwtUtils";
+import { Log } from "./Log";
 
 describe("JwtUtils", () => {
 

--- a/src/utils/Log.test.ts
+++ b/src/utils/Log.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log, ILogger, Logger } from "../../../src/utils";
+import { Log, ILogger, Logger } from "./Log";
 
 describe("Log", () => {
     let subject: Logger;

--- a/src/utils/PopupUtils.test.ts
+++ b/src/utils/PopupUtils.test.ts
@@ -1,4 +1,4 @@
-import { PopupUtils } from "../../../src/utils";
+import { PopupUtils } from "./PopupUtils";
 
 describe("PopupUtils", () => {
     describe("center", () => {

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { IntervalTimer, Timer } from "../../../src/utils";
+import { IntervalTimer, Timer } from "./Timer";
 
 class IntervalTimerMock implements IntervalTimer {
     callback: ((...args: any[]) => void);

--- a/src/utils/UrlUtils.test.ts
+++ b/src/utils/UrlUtils.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { UrlUtils } from "../../../src/utils";
+import { UrlUtils } from "./UrlUtils";
 
 describe("UrlUtils", () => {
 

--- a/test/unit/tsconfig.json
+++ b/test/unit/tsconfig.json
@@ -1,9 +1,0 @@
-{
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "rootDir": "../..",
-        "noEmit": true,
-        "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-    },
-    "include": ["."]
-}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+    "rootDir": "./src",
+    "outDir": "./lib",
+    // output .d.ts declaration files for consumers
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "tsBuildInfoFile": "tsconfig.build.tsbuildinfo"
+  },
+  "files": ["src/index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,13 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types"],
   "compilerOptions": {
     "target": "ES2019",
     "module": "ESNext",
     "moduleResolution": "node",
     "lib": ["ES2019", "DOM", "DOM.Iterable"],
     "incremental": true,
+    "noEmit": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
-    // output .d.ts declaration files for consumers
-    "declaration": true,
-    "declarationMap": true,
-    // match output dir to input dir. e.g. dist/index instead of dist/src/index
-    "rootDir": "./src",
-    "outDir": "./lib",
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
     // interop between ESM and CJS modules. Recommended by TS
@@ -24,7 +18,8 @@
     "forceConsistentCasingInFileNames": true,
     // ensure type imports are side-effect free by enforcing that `import type` is used
     "importsNotUsedAsValues": "error",
-    // prevent the use features that do not work with isolated transpilation
+    // prevent the use of features that are incompatible with isolated transpilation
     "isolatedModules": true,
-  }
+  },
+  "include": ["src/"],
 }


### PR DESCRIPTION
This project has a lot of files to the extent that it's difficult to tell when files are missing an accompanying unit test suite. Additionally, it's not ideal to have to backtrack up several directories (`../../src/foo/bar`) for every import in each test suite.

This refactors our tsconfigs into `tsconfig.json` and `tsconfig.build.json`. The former is loaded by your IDE and performs type-checking on the whole repo before running tests, and the latter is used by API Extractor to generate the type definition bundle.