### PR TITLE
Refactor json service

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -178,7 +178,9 @@ export class MetadataService {
     // (undocumented)
     getIssuer(): Promise<string>;
     // (undocumented)
-    getKeysEndpoint(optional?: boolean): Promise<string | undefined>;
+    getKeysEndpoint(optional?: true): Promise<string | undefined>;
+    // (undocumented)
+    getKeysEndpoint(optional: false): Promise<string>;
     // (undocumented)
     getMetadata(): Promise<Partial<OidcMetadata>>;
     // (undocumented)
@@ -188,7 +190,9 @@ export class MetadataService {
     // (undocumented)
     getSigningKeys(): Promise<SigningKey[] | null>;
     // (undocumented)
-    getTokenEndpoint(optional?: boolean): Promise<string | undefined>;
+    getTokenEndpoint(optional?: true): Promise<string | undefined>;
+    // (undocumented)
+    getTokenEndpoint(optional: false): Promise<string>;
     // (undocumented)
     getUserInfoEndpoint(): Promise<string>;
     // (undocumented)
@@ -234,7 +238,7 @@ export class OidcClient {
 export interface OidcClientSettings {
     acr_values?: string;
     authority: string;
-    client_authentication?: string;
+    client_authentication?: "client_secret_basic" | "client_secret_post";
     client_id: string;
     // (undocumented)
     client_secret?: string;
@@ -274,7 +278,7 @@ export class OidcClientSettingsStore {
     // (undocumented)
     readonly authority: string;
     // (undocumented)
-    readonly client_authentication: string | undefined;
+    readonly client_authentication: "client_secret_basic" | "client_secret_post";
     // (undocumented)
     readonly client_id: string;
     // (undocumented)

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+import { ErrorResponse } from "./ErrorResponse";
 import { Logger } from "./utils";
 
 /**
@@ -144,7 +145,7 @@ export class JsonService {
                         const json = await response.json();
                         if (json && json.error) {
                             this._logger.error("postForm: Error from server:", json.error);
-                            throw new Error(json.error);
+                            throw new ErrorResponse(json);
                         }
 
                         return json;

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -15,31 +15,24 @@ export type JwtHandler = (text: string) => Promise<any>;
 export class JsonService {
     private readonly _logger: Logger;
 
-    private _contentTypes: string[];
-    private _jwtHandler: JwtHandler | null;
+    private _contentTypes: string[] = [];
 
     public constructor(
         additionalContentTypes: string[] = [],
-        jwtHandler: JwtHandler | null = null
+        private _jwtHandler: JwtHandler | null = null
     ) {
         this._logger = new Logger("JsonService");
 
-        this._contentTypes = additionalContentTypes.slice();
-        this._contentTypes.push("application/json");
-        if (jwtHandler) {
+        this._contentTypes.push(...additionalContentTypes, "application/json");
+        if (_jwtHandler) {
             this._contentTypes.push("application/jwt");
         }
-
-        this._jwtHandler = jwtHandler;
     }
 
-    public async getJson(url: string, token?: string): Promise<any> {
-        if (!url) {
-            this._logger.error("getJson: No url passed");
-            throw new Error("url");
-        }
-
-        const headers: HeadersInit = {};
+    public async getJson(url: string, token?: string): Promise<Record<string, unknown>> {
+        const headers: HeadersInit = {
+            "Accept": this._contentTypes.join(", "),
+        };
         if (token) {
             this._logger.debug("getJson: token passed, setting Authorization header");
             headers["Authorization"] = "Bearer " + token;
@@ -56,53 +49,39 @@ export class JsonService {
         }
 
         this._logger.debug("getJson: HTTP response received, status", response.status);
-        if (response.status === 200) {
-            const contentType = response.headers.get("Content-Type");
-            if (contentType) {
-                const found = this._contentTypes.find(item => contentType.startsWith(item));
-                if (found === "application/jwt" && this._jwtHandler) {
-                    const text = await response.text();
-                    return await this._jwtHandler(text);
-                }
-
-                if (found) {
-                    try {
-                        const json = await response.json();
-                        return json;
-                    }
-                    catch (err) {
-                        this._logger.error("getJson: Error parsing JSON response", err instanceof Error ? err.message : err);
-                        throw err;
-                    }
-                }
-            }
-
-            throw new Error("Invalid response Content-Type: " + (contentType ?? "undefined") + ", from URL: " + url);
+        const contentType = response.headers.get("Content-Type");
+        if (contentType && !this._contentTypes.find(item => contentType.startsWith(item))) {
+            throw new Error(`Invalid response Content-Type: ${(contentType ?? "undefined")}, from URL: ${url}`);
         }
-
-        throw new Error(response.statusText + " (" + response.status.toString() + ")");
+        if (response.ok && this._jwtHandler && contentType?.startsWith("application/jwt")) {
+            return await this._jwtHandler(await response.text());
+        }
+        let json: Record<string, unknown>;
+        try {
+            json = await response.json();
+        }
+        catch (err) {
+            this._logger.error("getJson: Error parsing JSON response", err);
+            if (response.ok) throw err;
+            throw new Error(`${response.statusText} (${response.status})`);
+        }
+        if (!response.ok) {
+            this._logger.error("getJson: Error from server:", json);
+            if (json.error) {
+                throw new ErrorResponse(json);
+            }
+            throw new Error(`${response.statusText} (${response.status}): ${JSON.stringify(json)}`);
+        }
+        return json;
     }
 
-    public async postForm(url: string, payload: any, basicAuth?: string): Promise<any> {
-        if (!url) {
-            this._logger.error("postForm: No url passed");
-            throw new Error("url");
-        }
-
+    public async postForm(url: string, body: URLSearchParams, basicAuth?: string): Promise<any> {
         const headers: HeadersInit = {
+            "Accept": this._contentTypes.join(", "),
             "Content-Type": "application/x-www-form-urlencoded",
         };
         if (basicAuth !== undefined) {
-            headers["Authorization"] = "Basic " + btoa(basicAuth);
-        }
-
-        const body = new URLSearchParams();
-        for (const key in payload) {
-            const value = payload[key];
-
-            if (value) {
-                body.set(key, value);
-            }
+            headers["Authorization"] = "Basic " + basicAuth;
         }
 
         let response: Response;
@@ -115,51 +94,27 @@ export class JsonService {
             throw new Error("Network Error");
         }
 
-        const allowedContentTypes = this._contentTypes;
-
         this._logger.debug("postForm: HTTP response received, status", response.status);
-        if (response.status === 200) {
-            const contentType = response.headers.get("Content-Type");
-            if (contentType) {
-                const found = allowedContentTypes.find(item => contentType.startsWith(item));
-                if (found) {
-                    try {
-                        const json = await response.json();
-                        return json;
-                    }
-                    catch (err) {
-                        this._logger.error("postForm: Error parsing JSON response", err instanceof Error ? err.message : err);
-                        throw err;
-                    }
-                }
-            }
-
-            throw new Error("Invalid response Content-Type: " +  (contentType ?? "undefined") + ", from URL: " + url);
+        const contentType = response.headers.get("Content-Type");
+        if (contentType && !this._contentTypes.find(item => contentType.startsWith(item))) {
+            throw new Error(`Invalid response Content-Type: ${(contentType ?? "undefined")}, from URL: ${url}`);
         }
-        else if (response.status === 400) {
-            const contentType = response.headers.get("Content-Type");
-            if (contentType) {
-                const found = allowedContentTypes.find(item => contentType.startsWith(item));
-                if (found) {
-                    try {
-                        const json = await response.json();
-                        if (json && json.error) {
-                            this._logger.error("postForm: Error from server:", json.error);
-                            throw new ErrorResponse(json);
-                        }
-
-                        return json;
-                    }
-                    catch (err) {
-                        this._logger.error("postForm: Error parsing JSON response", err instanceof Error ? err.message : err);
-                        throw err;
-                    }
-                }
-            }
-
-            throw new Error("Invalid response Content-Type: " +  (contentType ?? "undefined") + ", from URL: " + url);
+        let json: Record<string, unknown>;
+        try {
+            json = await response.json();
         }
-
-        throw new Error(response.statusText + " (" + response.status.toString() + ")");
+        catch (err) {
+            this._logger.error("postForm: Error parsing JSON response", err);
+            if (response.ok) throw err;
+            throw new Error(`${response.statusText} (${response.status})`);
+        }
+        if (!response.ok) {
+            this._logger.error("postForm: Error from server:", json);
+            if (json.error) {
+                throw new ErrorResponse(json);
+            }
+            throw new Error(`${response.statusText} (${response.status}): ${JSON.stringify(json)}`);
+        }
+        return json;
     }
 }

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -86,7 +86,9 @@ export class MetadataService {
         return this._getMetadataProperty("userinfo_endpoint") as Promise<string>;
     }
 
-    public getTokenEndpoint(optional=true): Promise<string | undefined> {
+    public getTokenEndpoint(optional?: true): Promise<string | undefined>
+    public getTokenEndpoint(optional: false): Promise<string>
+    public getTokenEndpoint(optional = true): Promise<string | undefined> {
         return this._getMetadataProperty("token_endpoint", optional) as Promise<string | undefined>;
     }
 
@@ -102,7 +104,9 @@ export class MetadataService {
         return this._getMetadataProperty("revocation_endpoint", true) as Promise<string | undefined>;
     }
 
-    public getKeysEndpoint(optional=true): Promise<string | undefined> {
+    public getKeysEndpoint(optional?: true): Promise<string | undefined>
+    public getKeysEndpoint(optional: false): Promise<string>
+    public getKeysEndpoint(optional = true): Promise<string | undefined> {
         return this._getMetadataProperty("jwks_uri", optional) as Promise<string | undefined>;
     }
 
@@ -131,13 +135,13 @@ export class MetadataService {
             return this._signingKeys;
         }
 
-        const jwks_uri = await this.getKeysEndpoint(false) as string;
+        const jwks_uri = await this.getKeysEndpoint(false);
         this._logger.debug("getSigningKeys: jwks_uri received", jwks_uri);
 
         const keySet = await this._jsonService.getJson(jwks_uri);
         this._logger.debug("getSigningKeys: key set received", keySet);
 
-        if (!keySet.keys) {
+        if (!Array.isArray(keySet.keys)) {
             this._logger.error("getSigningKeys: Missing keys on keyset");
             throw new Error("Missing keys on keyset");
         }

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -52,7 +52,7 @@ export interface OidcClientSettings {
      *
      * See https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
      */
-    client_authentication?: string;
+    client_authentication?: "client_secret_basic" | "client_secret_post";
 
     /** optional protocol param */
     prompt?: string;
@@ -122,7 +122,7 @@ export class OidcClientSettingsStore {
     public readonly scope: string;
     public readonly redirect_uri: string;
     public readonly post_logout_redirect_uri: string | undefined;
-    public readonly client_authentication: string | undefined;
+    public readonly client_authentication: "client_secret_basic" | "client_secret_post";
 
     // optional protocol params
     public readonly prompt: string | undefined;

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -233,21 +233,10 @@ export class ResponseValidator {
             Object.assign(request, state.extraTokenParams);
         }
 
-        const tokenResponse = await this._tokenClient.exchangeCode(request);
         // merge
-        response.error = tokenResponse.error || response.error;
-        response.error_description = tokenResponse.error_description || response.error_description;
-        response.error_uri = tokenResponse.error_uri || response.error_uri;
-
-        response.id_token = tokenResponse.id_token || response.id_token;
-        response.session_state = tokenResponse.session_state || response.session_state;
-        response.access_token = tokenResponse.access_token || response.access_token;
-        response.refresh_token = tokenResponse.refresh_token || response.refresh_token;
-
-        response.token_type = tokenResponse.token_type || response.token_type;
-        response.scope = tokenResponse.scope || response.scope;
-        response.expires_in = parseInt(tokenResponse.expires_in) || response.expires_in;
-
+        const { expires_in, ...tokenResponse } = await this._tokenClient.exchangeCode(request);
+        Object.assign(response, tokenResponse);
+        if (expires_in) response.expires_in = Number(expires_in);
         if (response.id_token) {
             this._logger.debug("_processCode: token response successful, processing id_token");
             return this._validateIdTokenAttributes(state, response, response.id_token);

--- a/src/utils/CryptoUtils.ts
+++ b/src/utils/CryptoUtils.ts
@@ -1,5 +1,6 @@
 import sha256 from "crypto-js/sha256.js";
 import Base64 from "crypto-js/enc-base64.js";
+import Utf8 from "crypto-js/enc-utf8.js";
 
 import { Logger } from "./Log";
 
@@ -16,7 +17,7 @@ export class CryptoUtils {
         );
     }
 
-    private static  _UUIDv4(): string {
+    private static _UUIDv4(): string {
         return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
             (+c ^ Math.random() * 16 >> +c / 4).toString(16)
         );
@@ -25,7 +26,7 @@ export class CryptoUtils {
     /**
      * Generates RFC4122 version 4 guid
      */
-    public static  generateUUIDv4(): string {
+    public static generateUUIDv4(): string {
         const hasRandomValues = window.crypto && Object.prototype.hasOwnProperty.call(window.crypto, "getRandomValues");
         const uuid = hasRandomValues ? CryptoUtils._cryptoUUIDv4() : CryptoUtils._UUIDv4();
         return uuid.replace(/-/g, "");
@@ -50,5 +51,13 @@ export class CryptoUtils {
             Logger.error("CryptoUtils", err instanceof Error ? err.message : err);
             throw err;
         }
+    }
+
+    /**
+     * Generates a base64-encoded string for a basic auth header
+     */
+    public static generateBasicAuth(client_id: string, client_secret: string): string {
+        const basicAuth = Utf8.parse([client_id, client_secret].join(":"));
+        return Base64.stringify(basicAuth);
     }
 }

--- a/test/unit/MetadataService.test.ts
+++ b/test/unit/MetadataService.test.ts
@@ -56,7 +56,7 @@ describe("MetadataService", () => {
             // arrange
             const jsonService = subject["_jsonService"]; // access private member
             const getJsonMock = jest.spyOn(jsonService, "getJson")
-                .mockImplementation(() => Promise.resolve("test"));
+                .mockResolvedValue({ foo: "bar" });
 
             // act
             await subject.getMetadata();
@@ -91,7 +91,7 @@ describe("MetadataService", () => {
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
             const getJsonMock = jest.spyOn(jsonService, "getJson")
-                .mockImplementation(() => Promise.resolve("test"));
+                .mockResolvedValue({ foo: "bar" });
 
             // act
             await subject.getMetadata();

--- a/test/unit/UserInfoService.test.ts
+++ b/test/unit/UserInfoService.test.ts
@@ -53,7 +53,7 @@ describe("UserInfoService", () => {
             // arrange
             jest.spyOn(metadataService, "getUserInfoEndpoint").mockImplementation(() => Promise.resolve("http://sts/userinfo"));
             const getJsonMock = jest.spyOn(jsonService, "getJson")
-                .mockImplementation(() => Promise.resolve("test"));
+                .mockResolvedValue({ foo: "bar" });
 
             // act
             await subject.getClaims("token");


### PR DESCRIPTION
This properly resolves the issue addressed in #213 by throwing an `ErrorResponse` instance when the response is parseable as JSON and contains a `.error` value.

The unit test code checked into #215 will need some minor updates if this merges first.