### PR TITLE
Update tests for PopupWindow and UserManager

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -60,5 +60,6 @@ overrides:
     env:
       jest: true
     rules:
+      "@typescript-eslint/no-non-null-assertion": "off"
       "@typescript-eslint/unbound-method": "off"
 

--- a/src/JsonService.test.ts
+++ b/src/JsonService.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "./utils";
+import { ErrorResponse } from "./ErrorResponse";
 import { JsonService } from "./JsonService";
 import { mocked } from "ts-jest/utils";
 
@@ -306,7 +307,7 @@ describe("JsonService", () => {
             // act
             await expect(subject.postForm("http://test", new URLSearchParams("payload=dummy")))
                 // assert
-                .rejects.toThrow(json.error);
+                .rejects.toThrow(ErrorResponse);
         });
 
         it("should reject promise when http response is 400 and json has no error field", async () => {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -147,7 +147,7 @@ export class OidcClient {
 
         const { state, response } = await this.readSigninResponseState(url, true);
         this._logger.debug("processSigninResponse: Received state from storage; validating response");
-        return this._validator.validateSigninResponse(state, response);
+        return await this._validator.validateSigninResponse(state, response);
     }
 
     public async createSignoutRequest({

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -67,7 +67,6 @@ describe("SignoutRequest", () => {
         it("should include state if post_logout_redirect_uri provided", () => {
             // assert
             expect(subject.state).toBeDefined();
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(subject.url).toContain("state=" + subject.state!.id);
         });
 
@@ -89,7 +88,6 @@ describe("SignoutRequest", () => {
             expect(url).toContain("id_token_hint=hint");
             expect(url).toContain("post_logout_redirect_uri=loggedout");
             expect(subject.state).toBeDefined();
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(url).toContain("state=" + subject.state!.id);
         });
 

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -88,7 +88,6 @@ describe("UserManager", () => {
     describe("signinRedirect", () => {
         it("should redirect the browser to the authorize url", async () => {
             await subject.signinRedirect();
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(window.location.assign).toHaveBeenCalledWith(expect.stringContaining(settings.metadata!.authorization_endpoint!));
             const [location] = mocked(window.location.assign).mock.calls[0];
             const state = new URL(location).searchParams.get("state");

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -2,35 +2,57 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log, Logger } from "./utils";
+import type { SigninResponse } from "./SigninResponse";
 import { UserManager } from "./UserManager";
 import { UserManagerSettings, UserManagerSettingsStore } from "./UserManagerSettings";
 import { User } from "./User";
 import { WebStorageStateStore } from "./WebStorageStateStore";
 
 import { mocked } from "ts-jest/utils";
-import type { IWindow } from "./navigators";
 
 describe("UserManager", () => {
     let settings: UserManagerSettings;
     let logger: Logger;
-    let userStoreMock: any;
+    let userStoreMock: WebStorageStateStore;
+
     let subject: UserManager;
 
     beforeEach(() => {
         Log.logger = console;
         Log.level = Log.NONE;
+        localStorage.clear();
 
-        userStoreMock = mocked(new WebStorageStateStore());
+        userStoreMock = new WebStorageStateStore();
         logger = new Logger("UserManager.test");
 
         settings = {
             authority: "http://sts/oidc",
             client_id: "client",
-            redirect_uri: "redirect",
+            redirect_uri: "http://app/cb",
             monitorSession : false,
             userStore: userStoreMock,
+            metadata: {
+                authorization_endpoint: "http://sts/oidc/authorize",
+                token_endpoint: "http://sts/oidc/token"
+            }
         };
         subject = new UserManager(settings);
+
+        const location = Object.defineProperties({}, {
+            ...Object.getOwnPropertyDescriptors(window.location),
+            assign: {
+                enumerable: true,
+                value: jest.fn()
+            },
+            replace: {
+                enumerable: true,
+                value: jest.fn()
+            }
+        });
+        Object.defineProperty(window, "location", {
+            enumerable: true,
+            get: () => location
+        });
     });
 
     describe("constructor", () => {
@@ -49,20 +71,10 @@ describe("UserManager", () => {
         });
     });
 
-    describe("userLoaded", () => {
+    describe("getUser", () => {
 
         it("should be able to call getUser without recursion", () => {
             // arrange
-            const user = new User({
-                id_token: "id_token",
-                access_token: "access_token",
-                token_type: "token_type",
-                profile: {}
-            });
-            userStoreMock.item = user.toStorageString();
-
-            // lamda function is never called but complier thinks it returns Promise
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             subject.events.addUserLoaded(async (user) => {
                 logger.debug("event.load", user);
                 await subject.getUser();
@@ -73,7 +85,33 @@ describe("UserManager", () => {
         });
     });
 
-    describe("signinSilent", () =>{
+    describe("signinRedirect", () => {
+        it("should redirect the browser to the authorize url", async () => {
+            await subject.signinRedirect();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            expect(window.location.assign).toHaveBeenCalledWith(expect.stringContaining(settings.metadata!.authorization_endpoint!));
+            const [location] = mocked(window.location.assign).mock.calls[0];
+            const state = new URL(location).searchParams.get("state");
+            const item = await userStoreMock.get(state!);
+            expect(JSON.parse(item!)).toHaveProperty("request_type", "si:r");
+        });
+    });
+
+    describe("signinRedirectCallback", () => {
+        it("should return a user", async () => {
+            const spy = jest.spyOn(subject["_client"], "processSigninResponse").mockResolvedValue({} as SigninResponse);
+            await userStoreMock.set("test", JSON.stringify({
+                id: "test",
+                request_type: "si:r",
+                ...settings,
+            }));
+            const user = await subject.signinRedirectCallback("http://app/cb?state=test&code=code");
+            expect(user).toBeInstanceOf(User);
+            spy.mockRestore();
+        });
+    });
+
+    describe("signinSilent", () => {
 
         it("should pass silentRequestTimeout from settings", async () => {
             // arrange
@@ -83,7 +121,6 @@ describe("UserManager", () => {
                 token_type: "token_type",
                 profile: {}
             });
-            userStoreMock.item = user.toStorageString();
 
             settings = {
                 ...settings,
@@ -91,20 +128,14 @@ describe("UserManager", () => {
                 silent_redirect_uri: "http://client/silent_callback"
             };
             subject = new UserManager(settings);
-
-            let navInstance: any = null;
-
-            subject["_signin"] = async function (args: any, handle: IWindow) {
-                logger.debug("_signin", args, handle);
-                navInstance = handle;
-                return user;
-            };
+            subject["_signin"] = jest.fn().mockResolvedValue(user);
 
             // act
             await subject.signinSilent();
+            const [, navInstance] = mocked(subject["_signin"]).mock.calls[0];
 
             // assert
-            expect(navInstance._timeoutInSeconds).toEqual(123);
+            expect(navInstance).toHaveProperty("_timeoutInSeconds", 123);
         });
 
         it("should pass silentRequestTimeout from params", async () => {
@@ -115,26 +146,20 @@ describe("UserManager", () => {
                 token_type: "token_type",
                 profile: {}
             });
-            userStoreMock.item = user.toStorageString();
 
             settings = {
                 ...settings,
                 silent_redirect_uri: "http://client/silent_callback"
             };
             subject = new UserManager(settings);
-
-            let navInstance: any = null;
-            subject["_signin"] = async function (args: any, handle: IWindow) {
-                logger.debug("_signin", args, handle);
-                navInstance = handle;
-                return user;
-            };
+            subject["_signin"] = jest.fn().mockResolvedValue(user);
 
             // act
             await subject.signinSilent({ silentRequestTimeoutInSeconds: 234 });
+            const [, navInstance] = mocked(subject["_signin"]).mock.calls[0];
 
             // assert
-            expect(navInstance._timeoutInSeconds).toEqual(234);
+            expect(navInstance).toHaveProperty("_timeoutInSeconds", 234);
         });
 
         it("should work when having no User present", async () => {
@@ -149,11 +174,7 @@ describe("UserManager", () => {
                 silent_redirect_uri: "http://client/silent_callback"
             };
             subject = new UserManager(settings);
-
-            subject["_signin"] = async function (args: any, handle: IWindow) {
-                logger.debug("_signin", args, handle);
-                return user;
-            };
+            subject["_signin"] = jest.fn().mockResolvedValue(user);
 
             // act
             await subject.signinSilent();

--- a/src/navigators/PopupWindow.test.ts
+++ b/src/navigators/PopupWindow.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { PopupWindow } from "./PopupWindow";
 
 describe("PopupWindow", () => {
@@ -9,6 +10,9 @@ describe("PopupWindow", () => {
             value: { origin: "http://app" }
         });
 
+        window.opener = {
+            postMessage: jest.fn(),
+        };
         window.open = jest.fn().mockImplementation(() => {
             popupFromWindowOpen = {
                 location: { replace: jest.fn() },
@@ -42,6 +46,47 @@ describe("PopupWindow", () => {
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
+        expect(popupFromWindowOpen.focus).toHaveBeenCalled();
+        expect(popupFromWindowOpen.close).toHaveBeenCalled();
+    });
+
+    it("should keep the window open after navigate succeeds", async () => {
+        const popupWindow = new PopupWindow({});
+
+        const promise = popupWindow.navigate({ url: "http://sts/authorize?x=y", state: "someid" });
+
+        window.dispatchEvent(new MessageEvent("message", {
+            data: { source: "oidc-client", url: "http://app/cb?state=someid", keepOpen: true },
+            origin: "http://app"
+        }));
+
+        await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
+        expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
+        expect(popupFromWindowOpen.close).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages from foreign origins", async () => {
+        const popupWindow = new PopupWindow({});
+
+        const promise = popupWindow.navigate({ url: "http://sts/authorize?x=y", state: "someid" });
+
+        window.dispatchEvent(new MessageEvent("message", {
+            data: { source: "oidc-client", url: "http://app/cb?state=someid&code=foreign-origin" },
+            origin: "http://foreign-origin"
+        }));
+        window.dispatchEvent(new MessageEvent("message", {
+            data: { source: "foreign-lib", url: "http://app/cb?state=someid&code=foreign-lib" },
+            origin: "http://app",
+            source: {} as MessageEventSource
+        }));
+        window.dispatchEvent(new MessageEvent("message", {
+            data: { source: "oidc-client", url: "http://app/cb?state=someid&code=code" },
+            origin: "http://app"
+        }));
+
+        await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid&code=code");
+        expect(popupFromWindowOpen.focus).toHaveBeenCalled();
+        expect(popupFromWindowOpen.close).toHaveBeenCalled();
     });
 
     it("should reject when navigate fails", async () => {
@@ -56,5 +101,35 @@ describe("PopupWindow", () => {
 
         await expect(promise).rejects.toThrow("Invalid response from window");
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
+    });
+
+    it("should reject when the window is closed by user", async () => {
+        const popupWindow = new PopupWindow({});
+
+        const promise = popupWindow.navigate({ url: "http://sts/authorize?x=y", state: "someid" });
+        Object.defineProperty(popupFromWindowOpen, "closed", {
+            enumerable: true,
+            value: true,
+        });
+
+        await expect(promise).rejects.toThrow("Popup closed by user");
+    });
+
+    it("should reject when the window is closed programmatically", async () => {
+        const popupWindow = new PopupWindow({});
+
+        const promise = popupWindow.navigate({ url: "http://sts/authorize?x=y", state: "someid" });
+        popupWindow.close();
+
+        await expect(promise).rejects.toThrow("Popup closed");
+    });
+
+    it("should notify the parent window", async () => {
+        PopupWindow.notifyOpener("http://sts/authorize?x=y", false);
+        expect(window.opener.postMessage).toHaveBeenCalledWith({
+            source: "oidc-client",
+            url: "http://sts/authorize?x=y",
+            keepOpen: false,
+        }, window.location.origin);
     });
 });


### PR DESCRIPTION
Adds some error handling tests for PopupWindow's and some smoke tests UserManager's redirect flows.

I'll probably be working on smoke tests for the rest of UserManager's public API next.