### PR TITLE
Eslint updates

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,6 +35,7 @@ overrides:
       - plugin:@typescript-eslint/recommended-requiring-type-checking
     rules:
       indent: "off"
+      no-return-await: "off"
       "@typescript-eslint/indent":
         - error
         - 4
@@ -44,6 +45,9 @@ overrides:
         - error
         - allowArgumentsExplicitlyTypedAsAny: true
       "@typescript-eslint/object-curly-spacing":
+        - error
+        - always
+      "@typescript-eslint/return-await":
         - error
         - always
       # custom rules to fix code style

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -29,7 +29,6 @@ overrides:
     parserOptions:
       project:
         - ./tsconfig.json
-        - ./test/unit/tsconfig.json
     extends:
       - plugin:@typescript-eslint/recommended
       - plugin:@typescript-eslint/recommended-requiring-type-checking

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,9 @@ extends:
   - eslint:recommended
   - plugin:testing-library/dom
 rules:
+  comma-dangle:
+    - error
+    - always-multiline
   consistent-return: error
   indent:
     - error
@@ -23,7 +26,9 @@ rules:
   no-multiple-empty-lines:
     - error
     - max: 1
+      maxBOF: 0
       maxEOF: 0
+  no-multi-spaces: error
 overrides:
   - files: ["*.ts", "*.tsx"]
     parserOptions:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -41,9 +41,6 @@ overrides:
         - 4
         - SwitchCase: 1
       "@typescript-eslint/member-delimiter-style": error
-      "@typescript-eslint/explicit-module-boundary-types":
-        - error
-        - allowArgumentsExplicitlyTypedAsAny: true
       "@typescript-eslint/object-curly-spacing":
         - error
         - always
@@ -53,10 +50,6 @@ overrides:
       # custom rules to fix code style
       "@typescript-eslint/require-await": "off"
       "@typescript-eslint/no-unsafe-assignment": "off"
-      "@typescript-eslint/no-unsafe-call": "off"
-      "@typescript-eslint/no-unsafe-member-access": "off"
-      "@typescript-eslint/no-explicit-any": "off"
-      "@typescript-eslint/no-unsafe-return": "off"
   - files: src/**/*
     env:
       node: false

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public (undocumented)
-export type AccessTokenCallback = (...ev: any[]) => void;
+export type AccessTokenCallback = (...ev: unknown[]) => void;
 
 // @public (undocumented)
 export class AccessTokenEvents {
@@ -118,13 +118,13 @@ export interface IFrameWindowParams {
 // @public
 export interface ILogger {
     // (undocumented)
-    debug(...args: any[]): void;
+    debug(...args: unknown[]): void;
     // (undocumented)
-    error(...args: any[]): void;
+    error(...args: unknown[]): void;
     // (undocumented)
-    info(...args: any[]): void;
+    info(...args: unknown[]): void;
     // (undocumented)
-    warn(...args: any[]): void;
+    warn(...args: unknown[]): void;
 }
 
 // @public (undocumented)
@@ -290,7 +290,7 @@ export class OidcClientSettingsStore {
     // (undocumented)
     readonly extraQueryParams: Record<string, string | number | boolean>;
     // (undocumented)
-    readonly extraTokenParams: Record<string, any>;
+    readonly extraTokenParams: Record<string, unknown>;
     // (undocumented)
     readonly filterProtocolClaims: boolean;
     // (undocumented)
@@ -918,6 +918,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
 
 // @public
 export interface UserProfile {
+    // (undocumented)
+    [claim: string]: unknown;
     address?: Record<string, unknown>;
     // (undocumented)
     at_hash?: string;

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -205,9 +205,9 @@ export class OidcClient {
     // (undocumented)
     clearStaleState(): Promise<void>;
     // (undocumented)
-    createSigninRequest({ response_type, scope, redirect_uri, state, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo }: CreateSigninRequestArgs): Promise<SigninRequest>;
+    createSigninRequest({ response_type, scope, redirect_uri, state, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo, }: CreateSigninRequestArgs): Promise<SigninRequest>;
     // (undocumented)
-    createSignoutRequest({ state, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
+    createSignoutRequest({ state, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
     // (undocumented)
     protected readonly _logger: Logger;
     // (undocumented)
@@ -272,7 +272,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraTokenParams }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -624,7 +624,7 @@ export type SignoutRedirectArgs = RedirectParams & ExtraSignoutRequestArgs;
 
 // @public (undocumented)
 export class SignoutRequest {
-    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type }: SignoutRequestArgs);
+    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }: SignoutRequestArgs);
     // (undocumented)
     readonly state?: State;
     // (undocumented)

--- a/src/AccessTokenEvents.test.ts
+++ b/src/AccessTokenEvents.test.ts
@@ -45,7 +45,7 @@ describe("AccessTokenEvents", () => {
             // act
             subject.load({
                 access_token:"token",
-                expires_in : 70
+                expires_in : 70,
             } as User);
 
             // assert
@@ -57,7 +57,7 @@ describe("AccessTokenEvents", () => {
             // act
             subject.load({
                 access_token:"token",
-                expires_in : 10
+                expires_in : 10,
             } as User);
 
             // assert
@@ -68,7 +68,7 @@ describe("AccessTokenEvents", () => {
             // act
             subject.load({
                 access_token:"token",
-                expires_in : 0
+                expires_in : 0,
             } as User);
 
             // assert
@@ -79,7 +79,7 @@ describe("AccessTokenEvents", () => {
             // act
             subject.load({
                 access_token:"token",
-                expires_in : 0
+                expires_in : 0,
             } as User);
 
             // assert
@@ -89,7 +89,7 @@ describe("AccessTokenEvents", () => {
         it("should not initialize timers if no access token", () => {
             // act
             subject.load({
-                expires_in : 70
+                expires_in : 70,
             } as User);
 
             // assert
@@ -100,7 +100,7 @@ describe("AccessTokenEvents", () => {
         it("should not initialize timers if no expiration on access token", () => {
             // act
             subject.load({
-                access_token:"token"
+                access_token:"token",
             } as User);
 
             // assert

--- a/src/AccessTokenEvents.ts
+++ b/src/AccessTokenEvents.ts
@@ -7,7 +7,7 @@ import type { User } from "./User";
 /**
  * @public
  */
-export type AccessTokenCallback = (...ev: any[]) => void;
+export type AccessTokenCallback = (...ev: unknown[]) => void;
 
 /**
  * @public

--- a/src/CheckSessionIFrame.ts
+++ b/src/CheckSessionIFrame.ts
@@ -18,7 +18,7 @@ export class CheckSessionIFrame {
         private _client_id: string,
         url: string,
         private _intervalInSeconds: number,
-        private _stopOnError: boolean
+        private _stopOnError: boolean,
     ) {
         this._logger = new Logger("CheckSessionIFrame");
 

--- a/src/JsonService.test.ts
+++ b/src/JsonService.test.ts
@@ -25,7 +25,7 @@ describe("JsonService", () => {
             // assert
             expect(fetch).toBeCalledWith("http://test", {
                 headers: { Accept: "application/json" },
-                method: "GET"
+                method: "GET",
             });
         });
 
@@ -36,7 +36,7 @@ describe("JsonService", () => {
             // assert
             expect(fetch).toBeCalledWith("http://test", {
                 headers: { Accept: "application/json", Authorization: "Bearer token" },
-                method: "GET"
+                method: "GET",
             });
         });
 
@@ -47,9 +47,9 @@ describe("JsonService", () => {
                 status: 200,
                 ok: true,
                 headers: new Headers({
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                json: () => Promise.resolve(json)
+                json: () => Promise.resolve(json),
             } as Response);
 
             // act
@@ -66,9 +66,9 @@ describe("JsonService", () => {
                 status: 200,
                 ok: true,
                 headers: new Headers({
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                json: () => Promise.reject(error)
+                json: () => Promise.reject(error),
             } as Response);
 
             // act
@@ -84,7 +84,7 @@ describe("JsonService", () => {
                 statusText: "server error",
                 ok: false,
                 headers: new Headers(),
-                json: () => Promise.reject(new SyntaxError())
+                json: () => Promise.reject(new SyntaxError()),
             } as Response);
 
             // act
@@ -110,9 +110,9 @@ describe("JsonService", () => {
                 status: 200,
                 ok: true,
                 headers: new Headers({
-                    "Content-Type": "text/html"
+                    "Content-Type": "text/html",
                 }),
-                json: () => Promise.resolve(json)
+                json: () => Promise.resolve(json),
             } as Response);
 
             // act
@@ -129,9 +129,9 @@ describe("JsonService", () => {
                 status: 200,
                 ok: true,
                 headers: new Headers({
-                    "Content-Type": "foo/bar"
+                    "Content-Type": "foo/bar",
                 }),
-                json: () => Promise.resolve(json)
+                json: () => Promise.resolve(json),
             } as Response);
 
             // act
@@ -151,9 +151,9 @@ describe("JsonService", () => {
                 ok: true,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "application/jwt"
+                    "Content-Type": "application/jwt",
                 }),
-                text: () => Promise.resolve(text)
+                text: () => Promise.resolve(text),
             } as Response);
 
             // act
@@ -175,11 +175,11 @@ describe("JsonService", () => {
                 expect.objectContaining({
                     headers: {
                         Accept: "application/json",
-                        "Content-Type": "application/x-www-form-urlencoded"
+                        "Content-Type": "application/x-www-form-urlencoded",
                     },
                     method: "POST",
-                    body: new URLSearchParams()
-                })
+                    body: new URLSearchParams(),
+                }),
             );
         });
 
@@ -197,8 +197,8 @@ describe("JsonService", () => {
                         "Content-Type": "application/x-www-form-urlencoded",
                     },
                     method: "POST",
-                    body: new URLSearchParams()
-                })
+                    body: new URLSearchParams(),
+                }),
             );
         });
 
@@ -215,11 +215,11 @@ describe("JsonService", () => {
                 expect.objectContaining({
                     headers: {
                         Accept: "application/json",
-                        "Content-Type": "application/x-www-form-urlencoded"
+                        "Content-Type": "application/x-www-form-urlencoded",
                     },
                     method: "POST",
-                    body
-                })
+                    body,
+                }),
             );
         });
 
@@ -231,9 +231,9 @@ describe("JsonService", () => {
                 ok: true,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act
@@ -261,9 +261,9 @@ describe("JsonService", () => {
                 ok: true,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                text: () => Promise.reject(error)
+                text: () => Promise.reject(error),
             } as Response);
 
             // act
@@ -280,9 +280,9 @@ describe("JsonService", () => {
                 ok: true,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "text/html"
+                    "Content-Type": "text/html",
                 }),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act
@@ -299,9 +299,9 @@ describe("JsonService", () => {
                 ok: false,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act
@@ -318,9 +318,9 @@ describe("JsonService", () => {
                 ok: false,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act
@@ -337,9 +337,9 @@ describe("JsonService", () => {
                 ok: false,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 }),
-                text: () => Promise.resolve("not_json_data")
+                text: () => Promise.resolve("not_json_data"),
             } as Response);
 
             // act
@@ -356,9 +356,9 @@ describe("JsonService", () => {
                 ok: false,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "text/html"
+                    "Content-Type": "text/html",
                 }),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act
@@ -375,7 +375,7 @@ describe("JsonService", () => {
                 statusText: "server error",
                 ok: false,
                 headers: new Headers(),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act
@@ -393,9 +393,9 @@ describe("JsonService", () => {
                 ok: true,
                 headers: new Headers({
                     Accept: "application/json",
-                    "Content-Type": "foo/bar"
+                    "Content-Type": "foo/bar",
                 }),
-                text: () => Promise.resolve(JSON.stringify(json))
+                text: () => Promise.resolve(JSON.stringify(json)),
             } as Response);
 
             // act

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -7,7 +7,7 @@ import { Logger } from "./utils";
 /**
  * @internal
  */
-export type JwtHandler = (text: string) => Promise<any>;
+export type JwtHandler = (text: string) => Promise<Record<string, unknown>>;
 
 /**
  * @internal
@@ -75,7 +75,7 @@ export class JsonService {
         return json;
     }
 
-    public async postForm(url: string, body: URLSearchParams, basicAuth?: string): Promise<any> {
+    public async postForm(url: string, body: URLSearchParams, basicAuth?: string): Promise<Record<string, unknown>> {
         const headers: HeadersInit = {
             "Accept": this._contentTypes.join(", "),
             "Content-Type": "application/x-www-form-urlencoded",

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -19,7 +19,7 @@ export class JsonService {
 
     public constructor(
         additionalContentTypes: string[] = [],
-        private _jwtHandler: JwtHandler | null = null
+        private _jwtHandler: JwtHandler | null = null,
     ) {
         this._logger = new Logger("JsonService");
 

--- a/src/MetadataService.test.ts
+++ b/src/MetadataService.test.ts
@@ -16,7 +16,7 @@ describe("MetadataService", () => {
         settings = {
             authority: "authority",
             client_id: "client",
-            redirect_uri: "redirect"
+            redirect_uri: "redirect",
         };
         subject = new MetadataService(new OidcClientSettingsStore(settings));
     });
@@ -70,7 +70,7 @@ describe("MetadataService", () => {
             settings = {
                 authority: "",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -86,7 +86,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadataUrl: "http://sts/metadata"
+                metadataUrl: "http://sts/metadata",
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
@@ -106,7 +106,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadataUrl: "http://sts/metadata"
+                metadataUrl: "http://sts/metadata",
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
@@ -126,7 +126,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadataUrl: "http://sts/metadata"
+                metadataUrl: "http://sts/metadata",
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
@@ -148,7 +148,7 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadataUrl: "http://sts/metadata",
-                metadataSeed: { issuer: "one" }
+                metadataSeed: { issuer: "one" },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
@@ -169,7 +169,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadataUrl: "http://sts/metadata"
+                metadataUrl: "http://sts/metadata",
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const error = new Error("test");
@@ -191,7 +191,7 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    issuer: "test"
+                    issuer: "test",
                 },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
@@ -210,7 +210,7 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                }
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -226,7 +226,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadataUrl: "http://sts/metadata"
+                metadataUrl: "http://sts/metadata",
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const error = new Error("test");
@@ -246,8 +246,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    issuer: "http://sts"
-                }
+                    issuer: "http://sts",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -267,8 +267,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    authorization_endpoint: "http://sts/authorize"
-                }
+                    authorization_endpoint: "http://sts/authorize",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -288,8 +288,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    userinfo_endpoint: "http://sts/userinfo"
-                }
+                    userinfo_endpoint: "http://sts/userinfo",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -309,8 +309,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    token_endpoint: "http://sts/tokeninfo"
-                }
+                    token_endpoint: "http://sts/tokeninfo",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -330,8 +330,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    check_session_iframe: "http://sts/check_session"
-                }
+                    check_session_iframe: "http://sts/check_session",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -349,7 +349,7 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                }
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -369,8 +369,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    end_session_endpoint: "http://sts/signout"
-                }
+                    end_session_endpoint: "http://sts/signout",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -388,7 +388,7 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                }
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -408,8 +408,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    revocation_endpoint: "http://sts/revocation"
-                }
+                    revocation_endpoint: "http://sts/revocation",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -427,7 +427,7 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                }
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -446,7 +446,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                signingKeys: [{ kid: "test" }]
+                signingKeys: [{ kid: "test" }],
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -463,7 +463,7 @@ describe("MetadataService", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadata: { issuer: "test" }
+                metadata: { issuer: "test" },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
 
@@ -480,8 +480,8 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    jwks_uri: "http://sts/metadata/keys"
-                }
+                    jwks_uri: "http://sts/metadata/keys",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
@@ -500,16 +500,16 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    jwks_uri: "http://sts/metadata/keys"
-                }
+                    jwks_uri: "http://sts/metadata/keys",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
             const json = {
                 keys: [{
                     use:"sig",
-                    kid:"test"
-                }]
+                    kid:"test",
+                }],
             };
             const getJsonMock = jest.spyOn(jsonService, "getJson")
                 .mockImplementation(() => Promise.resolve(json));
@@ -528,17 +528,17 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    jwks_uri: "http://sts/metadata/keys"
-                }
+                    jwks_uri: "http://sts/metadata/keys",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
             const expectedKeys = [{
                 use:"sig",
-                kid:"test"
+                kid:"test",
             }];
             const json = {
-                keys: expectedKeys
+                keys: expectedKeys,
             };
             jest.spyOn(jsonService, "getJson").mockImplementation(() => Promise.resolve(json));
 
@@ -556,17 +556,17 @@ describe("MetadataService", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 metadata: {
-                    jwks_uri: "http://sts/metadata/keys"
-                }
+                    jwks_uri: "http://sts/metadata/keys",
+                },
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
             const expectedKeys = [{
                 use:"sig",
-                kid:"test"
+                kid:"test",
             }];
             const json = {
-                keys: expectedKeys
+                keys: expectedKeys,
             };
             jest.spyOn(jsonService, "getJson").mockImplementation(() => Promise.resolve(json));
 

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -25,7 +25,7 @@ describe("OidcClient", () => {
             authority: "authority",
             client_id: "client",
             redirect_uri: "redirect",
-            post_logout_redirect_uri: "http://app"
+            post_logout_redirect_uri: "http://app",
         };
         subject = new OidcClient(settings);
     });
@@ -53,7 +53,7 @@ describe("OidcClient", () => {
             const args = {
                 redirect_uri: "redirect",
                 response_type: "response",
-                scope: "scope"
+                scope: "scope",
             };
             jest.spyOn(subject.metadataService, "getAuthorizationEndpoint").mockImplementation(() => Promise.resolve("http://sts/authorize"));
 
@@ -71,7 +71,7 @@ describe("OidcClient", () => {
             const args = {
                 redirect_uri: "redirect",
                 response_type: "code",
-                scope: "scope"
+                scope: "scope",
             };
             jest.spyOn(subject.metadataService, "getAuthorizationEndpoint").mockImplementation(() => Promise.resolve("http://sts/authorize"));
 
@@ -102,7 +102,7 @@ describe("OidcClient", () => {
                 acr_values: "av",
                 resource: "res",
                 request: "req",
-                request_uri: "req_uri"
+                request_uri: "req_uri",
             });
 
             // assert
@@ -142,7 +142,7 @@ describe("OidcClient", () => {
                 id_token_hint: "ith",
                 login_hint: "lh",
                 acr_values: "av",
-                resource: "res"
+                resource: "res",
             });
 
             // assert
@@ -167,7 +167,7 @@ describe("OidcClient", () => {
             const args = {
                 redirect_uri: "redirect",
                 scope: "scope",
-                response_type: "id_token"
+                response_type: "id_token",
             };
 
             // act
@@ -186,7 +186,7 @@ describe("OidcClient", () => {
             const args = {
                 redirect_uri: "redirect",
                 response_type: "code",
-                scope: "scope"
+                scope: "scope",
             };
             jest.spyOn(subject.metadataService, "getAuthorizationEndpoint").mockRejectedValue(new Error("test"));
 
@@ -206,7 +206,7 @@ describe("OidcClient", () => {
             const args = {
                 redirect_uri: "redirect",
                 response_type: "code",
-                scope: "scope"
+                scope: "scope",
             };
             jest.spyOn(subject.metadataService, "getAuthorizationEndpoint").mockImplementation(() => Promise.resolve("http://sts/authorize"));
             jest.spyOn(subject.settings.stateStore, "set").mockRejectedValue(new Error("foo"));
@@ -227,7 +227,7 @@ describe("OidcClient", () => {
             const args = {
                 redirect_uri: "redirect",
                 response_type: "code",
-                scope: "scope"
+                scope: "scope",
             };
             jest.spyOn(subject.metadataService, "getAuthorizationEndpoint").mockImplementation(() => Promise.resolve("http://sts/authorize"));
             const setMock = jest.spyOn(subject.settings.stateStore, "set").mockImplementation(() => Promise.resolve());
@@ -290,7 +290,7 @@ describe("OidcClient", () => {
                 client_id: "client",
                 redirect_uri: "http://app/cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             }).toStorageString();
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve(item));
 
@@ -355,7 +355,7 @@ describe("OidcClient", () => {
                 client_id: "client",
                 redirect_uri: "http://app/cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(() => Promise.resolve(item.toStorageString()));
@@ -404,7 +404,7 @@ describe("OidcClient", () => {
             const request = await subject.createSignoutRequest({
                 state: "foo",
                 post_logout_redirect_uri: "bar",
-                id_token_hint: "baz"
+                id_token_hint: "baz",
             });
 
             // assert
@@ -424,7 +424,7 @@ describe("OidcClient", () => {
             const request = await subject.createSignoutRequest({
                 state: "foo",
                 post_logout_redirect_uri: "bar",
-                id_token_hint: "baz"
+                id_token_hint: "baz",
             });
 
             // assert
@@ -559,7 +559,7 @@ describe("OidcClient", () => {
             const item = new State({
                 id: "1",
                 data: "bar",
-                request_type: "type"
+                request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(() => Promise.resolve(item.toStorageString()));
@@ -624,7 +624,7 @@ describe("OidcClient", () => {
             // arrange
             const item = new State({
                 id: "1",
-                request_type: "type"
+                request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(() => Promise.resolve(item.toStorageString()));
@@ -643,7 +643,7 @@ describe("OidcClient", () => {
             const item = new State({
                 id: "1",
                 data: "bar",
-                request_type: "type"
+                request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(() => Promise.resolve(item.toStorageString()));

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -74,7 +74,7 @@ export class OidcClient {
         response_type, scope, redirect_uri,
         state,
         prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
-        resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo
+        resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo,
     }: CreateSigninRequestArgs): Promise<SigninRequest> {
         this._logger.debug("createSigninRequest");
 
@@ -111,7 +111,7 @@ export class OidcClient {
             prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
             resource, request, request_uri, extraQueryParams, extraTokenParams, request_type, response_mode,
             client_secret: this.settings.client_secret,
-            skipUserInfo
+            skipUserInfo,
         });
 
         const signinState = signinRequest.state;
@@ -152,7 +152,7 @@ export class OidcClient {
 
     public async createSignoutRequest({
         state,
-        id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type
+        id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
     }: CreateSignoutRequestArgs = {}): Promise<SignoutRequest> {
         this._logger.debug("createSignoutRequest");
 
@@ -173,7 +173,7 @@ export class OidcClient {
             post_logout_redirect_uri,
             state_data: state,
             extraQueryParams,
-            request_type
+            request_type,
         });
 
         const signoutState = request.state;

--- a/src/OidcClientSettings.test.ts
+++ b/src/OidcClientSettings.test.ts
@@ -18,7 +18,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -33,7 +33,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                client_secret: "secret"
+                client_secret: "secret",
             });
 
             // assert
@@ -48,7 +48,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                response_type: "foo"
+                response_type: "foo",
             });
 
             // assert
@@ -60,7 +60,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -76,7 +76,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                scope: "foo"
+                scope: "foo",
             });
 
             // assert
@@ -88,7 +88,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -103,7 +103,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "http://app"
+                redirect_uri: "http://app",
             });
 
             // assert
@@ -119,7 +119,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                post_logout_redirect_uri: "http://app/loggedout"
+                post_logout_redirect_uri: "http://app/loggedout",
             });
 
             // assert
@@ -134,7 +134,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                prompt: "foo"
+                prompt: "foo",
             });
 
             // assert
@@ -149,7 +149,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                display: "foo"
+                display: "foo",
             });
 
             // assert
@@ -164,7 +164,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                max_age: 22
+                max_age: 22,
             });
 
             // assert
@@ -179,7 +179,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                ui_locales: "foo"
+                ui_locales: "foo",
             });
 
             // assert
@@ -194,7 +194,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                acr_values: "foo"
+                acr_values: "foo",
             });
 
             // assert
@@ -209,7 +209,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                resource: "foo"
+                resource: "foo",
             });
 
             // assert
@@ -224,7 +224,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                response_mode: "query"
+                response_mode: "query",
             });
 
             // assert
@@ -238,7 +238,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 client_id: "client",
                 redirect_uri: "redirect",
-                authority: "http://sts"
+                authority: "http://sts",
             });
 
             // assert
@@ -253,7 +253,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadataUrl: "http://sts/metadata"
+                metadataUrl: "http://sts/metadata",
             });
 
             // assert
@@ -268,7 +268,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                metadata: { issuer: "test" }
+                metadata: { issuer: "test" },
             });
 
             // assert
@@ -283,7 +283,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                signingKeys: [{ kid: "test" }]
+                signingKeys: [{ kid: "test" }],
             });
 
             // assert
@@ -311,7 +311,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                filterProtocolClaims: true
+                filterProtocolClaims: true,
             });
 
             // assert
@@ -322,7 +322,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                filterProtocolClaims: false
+                filterProtocolClaims: false,
             });
 
             // assert
@@ -337,7 +337,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -350,7 +350,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                loadUserInfo: true
+                loadUserInfo: true,
             });
 
             // assert
@@ -361,7 +361,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                loadUserInfo: false
+                loadUserInfo: false,
             });
 
             // assert
@@ -376,7 +376,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -389,7 +389,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                staleStateAgeInSeconds: 100
+                staleStateAgeInSeconds: 100,
             });
 
             // assert
@@ -404,7 +404,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -417,7 +417,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                clockSkewInSeconds: 10
+                clockSkewInSeconds: 10,
             });
 
             // assert
@@ -436,7 +436,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                stateStore: temp
+                stateStore: temp,
             });
 
             // assert
@@ -455,7 +455,7 @@ describe("OidcClientSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                stateStore: temp
+                stateStore: temp,
             });
 
             // assert
@@ -470,7 +470,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -484,8 +484,8 @@ describe("OidcClientSettings", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 extraQueryParams: {
-                    "hd": "domain.com"
-                }
+                    "hd": "domain.com",
+                },
             });
 
             // assert
@@ -500,7 +500,7 @@ describe("OidcClientSettings", () => {
             const subject = new OidcClientSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -514,8 +514,8 @@ describe("OidcClientSettings", () => {
                 client_id: "client",
                 redirect_uri: "redirect",
                 extraTokenParams: {
-                    "resourceServer": "abc"
-                }
+                    "resourceServer": "abc",
+                },
             });
 
             // assert

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -167,7 +167,7 @@ export class OidcClientSettingsStore {
         stateStore = new WebStorageStateStore(),
         // extra query params
         extraQueryParams = {},
-        extraTokenParams = {}
+        extraTokenParams = {},
     }: OidcClientSettings) {
 
         this.authority = authority;

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -145,7 +145,7 @@ export class OidcClientSettingsStore {
 
     // extra
     public readonly extraQueryParams: Record<string, string | number | boolean>;
-    public readonly extraTokenParams: Record<string, any>;
+    public readonly extraTokenParams: Record<string, unknown>;
 
     public constructor({
         // metadata related

--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -10,6 +10,7 @@ import type { SigninResponse } from "./SigninResponse";
 import { ErrorResponse } from "./ErrorResponse";
 import type { UserProfile } from "./User";
 import type { TokenClient } from "./TokenClient";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
 
 // access private methods
 class ResponseValidatorWrapper extends ResponseValidator {
@@ -19,7 +20,7 @@ class ResponseValidatorWrapper extends ResponseValidator {
     public async _processClaims(state: SigninState, response: SigninResponse) {
         return await super._processClaims(state, response);
     }
-    public _mergeClaims(claims1: UserProfile, claims2: any) {
+    public _mergeClaims(claims1: UserProfile, claims2: Record<string, unknown>) {
         return super._mergeClaims(claims1, claims2);
     }
     public _filterProtocolClaims(claims: UserProfile) {
@@ -37,9 +38,9 @@ class ResponseValidatorWrapper extends ResponseValidator {
 }
 
 describe("ResponseValidator", () => {
-    let stubState: any;
-    let stubResponse: any;
-    let settings: any;
+    let stubState: SigninState;
+    let stubResponse: SigninResponse;
+    let settings: OidcClientSettingsStore;
     let subject: ResponseValidatorWrapper;
 
     let metadataService: MetadataService;
@@ -55,15 +56,15 @@ describe("ResponseValidator", () => {
             data: { some: "data" },
             client_id: "client",
             authority: "op"
-        };
+        } as SigninState;
         stubResponse = {
             state_id: "the_id",
             isOpenIdConnect: false
-        };
+        } as SigninResponse;
         settings = {
             authority: "op",
             client_id: "client"
-        };
+        } as OidcClientSettingsStore;
         metadataService = new MetadataService(settings);
 
         // restore spyOn
@@ -79,7 +80,7 @@ describe("ResponseValidator", () => {
     describe("validateSignoutResponse", () => {
         it("should validate that the client state matches response state", () => {
             // arrange
-            stubResponse.state_id = "not_the_id";
+            Object.assign(stubResponse, { state_id: "not_the_id" });
 
             // act
             expect(() => subject.validateSignoutResponse(stubState, stubResponse))
@@ -185,7 +186,7 @@ describe("ResponseValidator", () => {
     describe("_processSigninParams", () => {
         it("should validate that the client state matches response state", () => {
             // arrange
-            stubResponse.state_id = "not_the_id";
+            Object.assign(stubResponse, { state_id: "not_the_id" });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -195,7 +196,7 @@ describe("ResponseValidator", () => {
 
         it("should fail if no client_id on state", () => {
             // arrange
-            delete stubState.client_id;
+            Object.assign(stubState, { client_id: undefined });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -205,7 +206,7 @@ describe("ResponseValidator", () => {
 
         it("should fail if no authority on state", () => {
             // arrange
-            delete stubState.authority;
+            Object.assign(stubState, { authority: undefined });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -215,7 +216,7 @@ describe("ResponseValidator", () => {
 
         it("should fail if the authority on the state is not the same as the settings", () => {
             // arrange
-            stubState.authority = "something different";
+            Object.assign(stubState, { authority: "something different" });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -225,7 +226,7 @@ describe("ResponseValidator", () => {
 
         it("should fail if the client_id on the state is not the same as the settings", () => {
             // arrange
-            stubState.client_id = "something different";
+            Object.assign(stubState, { client_id: "something different" });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -245,8 +246,8 @@ describe("ResponseValidator", () => {
 
         it("should fail if request was code flow but no code in response", () => {
             // arrange
-            stubState.code_verifier = "secret";
-            delete stubResponse.code;
+            Object.assign(stubState, { code_verifier: "secret" });
+            Object.assign(stubResponse, { code: undefined });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -256,8 +257,8 @@ describe("ResponseValidator", () => {
 
         it("should fail if request was not code flow but code in response", () => {
             // arrange
-            delete stubState.code_verifier;
-            stubResponse.code = "code";
+            Object.assign(stubState, { code_verifier: undefined });
+            Object.assign(stubResponse, { code: "code" });
 
             // act
             expect(() => subject._processSigninParams(stubState, stubResponse))
@@ -267,8 +268,8 @@ describe("ResponseValidator", () => {
 
         it("should return data for successful responses", () => {
             // arrange
-            stubState.code_verifier = "secret";
-            stubResponse.code = "code";
+            Object.assign(stubState, { code_verifier: "secret" });
+            Object.assign(stubResponse, { code: "code" });
 
             // act
             const response = subject._processSigninParams(stubState, stubResponse);
@@ -288,8 +289,10 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            stubResponse.isOpenIdConnect = true;
-            stubResponse.profile = { a: "apple", b: "banana" };
+            Object.assign(stubResponse, {
+                isOpenIdConnect: true,
+                profile: { a: "apple", b: "banana" }
+            });
             const _filterProtocolClaimsMock = jest.spyOn(subject, "_filterProtocolClaims")
                 .mockImplementation((profile) => profile);
 
@@ -309,7 +312,7 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            stubResponse.isOpenIdConnect = false;
+            Object.assign(stubResponse, { isOpenIdConnect: false });
             const _filterProtocolClaimsMock = jest.spyOn(subject, "_filterProtocolClaims")
                 .mockImplementation((profile) => profile);
 
@@ -329,12 +332,14 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            settings.loadUserInfo = true;
-            stubResponse.isOpenIdConnect = true;
-            stubResponse.profile = { sub: "sub" };
-            stubResponse.access_token = "access_token";
+            Object.assign(settings, { loadUserInfo: true });
+            Object.assign(stubResponse, {
+                isOpenIdConnect: true,
+                profile: { sub: "sub" },
+                access_token: "access_token",
+            });
             jest.spyOn(userInfoService, "getClaims")
-                .mockImplementation(() => Promise.resolve({ sub: "sub different" } as any));
+                .mockImplementation(() => Promise.resolve({ sub: "sub different" }));
 
             // act
             await expect(subject._processClaims(state, stubResponse))
@@ -351,12 +356,14 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            settings.loadUserInfo = true;
-            stubResponse.isOpenIdConnect = true;
-            stubResponse.profile = { a: "apple", b: "banana" };
-            stubResponse.access_token = "access_token";
+            Object.assign(settings, { loadUserInfo: true });
+            Object.assign(stubResponse, {
+                isOpenIdConnect: true,
+                profile: { a: "apple", b: "banana" },
+                access_token: "access_token",
+            });
             const getClaimMock = jest.spyOn(userInfoService, "getClaims")
-                .mockImplementation(() => Promise.resolve({ c: "carrot" } as any));
+                .mockImplementation(() => Promise.resolve({ c: "carrot" }));
             const _mergeClaimsMock = jest.spyOn(subject, "_mergeClaims")
                 .mockImplementation((profile) => profile);
 
@@ -377,12 +384,14 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            settings.loadUserInfo = true;
-            stubResponse.isOpenIdConnect = false;
-            stubResponse.profile = { a: "apple", b: "banana" };
-            stubResponse.access_token = "access_token";
+            Object.assign(settings, { loadUserInfo: true });
+            Object.assign(stubResponse, {
+                isOpenIdConnect: false,
+                profile: { a: "apple", b: "banana" },
+                access_token: "access_token",
+            });
             const getClaimMock = jest.spyOn(userInfoService, "getClaims")
-                .mockImplementation(() => Promise.resolve({ c: "carrot" } as any));
+                .mockImplementation(() => Promise.resolve({ c: "carrot" }));
 
             // act
             await subject._processClaims(state, stubResponse);
@@ -400,12 +409,14 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            settings.loadUserInfo = false;
-            stubResponse.isOpenIdConnect = true;
-            stubResponse.profile = { a: "apple", b: "banana" };
-            stubResponse.access_token = "access_token";
+            Object.assign(settings, { loadUserInfo: false });
+            Object.assign(stubResponse, {
+                isOpenIdConnect: true,
+                profile: { a: "apple", b: "banana" },
+                access_token: "access_token",
+            });
             const getClaimMock = jest.spyOn(userInfoService, "getClaims")
-                .mockImplementation(() => Promise.resolve({ c: "carrot" } as any));
+                .mockImplementation(() => Promise.resolve({ c: "carrot" }));
 
             // act
             await subject._processClaims(state, stubResponse);
@@ -423,11 +434,13 @@ describe("ResponseValidator", () => {
                 scope: "scope",
                 request_type: "type"
             });
-            settings.loadUserInfo = true;
-            stubResponse.isOpenIdConnect = true;
-            stubResponse.profile = { a: "apple", b: "banana" };
+            Object.assign(settings, { loadUserInfo: true });
+            Object.assign(stubResponse, {
+                isOpenIdConnect: true,
+                profile: { a: "apple", b: "banana" },
+            });
             const getClaimMock = jest.spyOn(userInfoService, "getClaims")
-                .mockImplementation(() => Promise.resolve({ c: "carrot" } as any));
+                .mockImplementation(() => Promise.resolve({ c: "carrot" }));
 
             // act
             await subject._processClaims(state, stubResponse);
@@ -464,7 +477,7 @@ describe("ResponseValidator", () => {
 
         it("should merge claims when claim types are objects when mergeClaims settings is true", () => {
             // arrange
-            settings.mergeClaims = true;
+            Object.assign(settings, { mergeClaims: true });
 
             const c1 = { custom: { "apple": "foo", "pear": "bar" } } as UserProfile;
             const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
@@ -548,7 +561,7 @@ describe("ResponseValidator", () => {
     describe("_filterProtocolClaims", () => {
         it("should filter protocol claims if enabled on settings", () => {
             // arrange
-            settings.filterProtocolClaims = true;
+            Object.assign(settings, { filterProtocolClaims: true });
             const claims = {
                 foo: 1, bar: "test",
                 aud: "some_aud", iss: "issuer",
@@ -571,7 +584,7 @@ describe("ResponseValidator", () => {
 
         it("should not filter protocol claims if not enabled on settings", () => {
             // arrange
-            settings.filterProtocolClaims = false;
+            Object.assign(settings, { filterProtocolClaims: false });
             const claims = {
                 foo: 1, bar: "test",
                 aud: "some_aud", iss: "issuer",
@@ -599,7 +612,7 @@ describe("ResponseValidator", () => {
     describe("_validateTokens", () => {
         it("should process code if response has code", async () => {
             // arrange
-            stubResponse.code = "code";
+            Object.assign(stubResponse, { code: "code" });
             const processCodeMock = jest.spyOn(subject, "_processCode")
                 .mockImplementation(() => Promise.resolve(stubResponse));
 
@@ -612,7 +625,7 @@ describe("ResponseValidator", () => {
 
         it("should not process code if response has no code", async () => {
             // arrange
-            delete stubResponse.code;
+            Object.assign(stubResponse, { code: undefined });
             const processCodeMock = jest.spyOn(subject, "_processCode")
                 .mockImplementation(() => Promise.resolve(stubResponse));
 
@@ -627,10 +640,12 @@ describe("ResponseValidator", () => {
     describe("_processCode", () => {
         it("should date from state to exchange code request", async () => {
             // arrange
-            stubState.client_secret = "client_secret";
-            stubState.redirect_uri = "redirect_uri";
-            stubState.code_verifier = "code_verifier";
-            stubState.extraTokenParams = { a: "a" };
+            Object.assign(stubState, {
+                client_secret: "client_secret",
+                redirect_uri: "redirect_uri",
+                code_verifier: "code_verifier",
+                extraTokenParams: { a: "a" }
+            });
             const exchangeCodeMock = jest.spyOn(tokenClient, "exchangeCode")
                 .mockImplementation(() => Promise.resolve({}));
 
@@ -651,7 +666,7 @@ describe("ResponseValidator", () => {
 
         it("should add code response to exchange code request", async () => {
             // arrange
-            stubResponse.code = "code";
+            Object.assign(stubState, { code: "code" });
             const exchangeCodeMock = jest.spyOn(tokenClient, "exchangeCode")
                 .mockImplementation(() => Promise.resolve({}));
 
@@ -749,7 +764,7 @@ describe("ResponseValidator", () => {
             const id_token = "id_token";
             stubResponse.id_token = id_token;
             jest.spyOn(JwtUtils, "decode")
-                .mockImplementation(() => profile as any);
+                .mockImplementation(() => profile);
 
             // act
             expect(() => subject._validateIdTokenAttributes(stubResponse, id_token))

--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -55,15 +55,15 @@ describe("ResponseValidator", () => {
             id: "the_id",
             data: { some: "data" },
             client_id: "client",
-            authority: "op"
+            authority: "op",
         } as SigninState;
         stubResponse = {
             state_id: "the_id",
-            isOpenIdConnect: false
+            isOpenIdConnect: false,
         } as SigninResponse;
         settings = {
             authority: "op",
-            client_id: "client"
+            client_id: "client",
         } as OidcClientSettingsStore;
         metadataService = new MetadataService(settings);
 
@@ -287,11 +287,11 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(stubResponse, {
                 isOpenIdConnect: true,
-                profile: { a: "apple", b: "banana" }
+                profile: { a: "apple", b: "banana" },
             });
             const _filterProtocolClaimsMock = jest.spyOn(subject, "_filterProtocolClaims")
                 .mockImplementation((profile) => profile);
@@ -310,7 +310,7 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(stubResponse, { isOpenIdConnect: false });
             const _filterProtocolClaimsMock = jest.spyOn(subject, "_filterProtocolClaims")
@@ -330,7 +330,7 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(settings, { loadUserInfo: true });
             Object.assign(stubResponse, {
@@ -354,7 +354,7 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(settings, { loadUserInfo: true });
             Object.assign(stubResponse, {
@@ -382,7 +382,7 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(settings, { loadUserInfo: true });
             Object.assign(stubResponse, {
@@ -407,7 +407,7 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(settings, { loadUserInfo: false });
             Object.assign(stubResponse, {
@@ -432,7 +432,7 @@ describe("ResponseValidator", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "type"
+                request_type: "type",
             });
             Object.assign(settings, { loadUserInfo: true });
             Object.assign(stubResponse, {
@@ -568,7 +568,7 @@ describe("ResponseValidator", () => {
                 sub: "123", email: "foo@gmail.com",
                 role: ["admin", "dev"],
                 at_hash: "athash",
-                iat: 5, nbf: 10, exp: 20
+                iat: 5, nbf: 10, exp: 20,
             };
 
             // act
@@ -578,7 +578,7 @@ describe("ResponseValidator", () => {
             expect(result).toEqual({
                 foo: 1, bar: "test",
                 sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"]
+                role: ["admin", "dev"],
             });
         });
 
@@ -591,7 +591,7 @@ describe("ResponseValidator", () => {
                 sub: "123", email: "foo@gmail.com",
                 role: ["admin", "dev"],
                 at_hash: "athash",
-                iat: 5, nbf: 10, exp: 20
+                iat: 5, nbf: 10, exp: 20,
             };
 
             // act
@@ -604,7 +604,7 @@ describe("ResponseValidator", () => {
                 sub: "123", email: "foo@gmail.com",
                 role: ["admin", "dev"],
                 at_hash: "athash",
-                iat: 5, nbf: 10, exp: 20
+                iat: 5, nbf: 10, exp: 20,
             });
         });
     });
@@ -644,7 +644,7 @@ describe("ResponseValidator", () => {
                 client_secret: "client_secret",
                 redirect_uri: "redirect_uri",
                 code_verifier: "code_verifier",
-                extraTokenParams: { a: "a" }
+                extraTokenParams: { a: "a" },
             });
             const exchangeCodeMock = jest.spyOn(tokenClient, "exchangeCode")
                 .mockImplementation(() => Promise.resolve({}));
@@ -659,8 +659,8 @@ describe("ResponseValidator", () => {
                     client_secret: stubState.client_secret,
                     redirect_uri: stubState.redirect_uri,
                     code_verifier: stubState.code_verifier,
-                    ...stubState.extraTokenParams
-                })
+                    ...stubState.extraTokenParams,
+                }),
             );
         });
 
@@ -676,8 +676,8 @@ describe("ResponseValidator", () => {
             // assert
             expect(exchangeCodeMock).toBeCalledWith(
                 expect.objectContaining({
-                    code: stubResponse.code
-                })
+                    code: stubResponse.code,
+                }),
             );
         });
 
@@ -693,7 +693,7 @@ describe("ResponseValidator", () => {
                 refresh_token: "refresh_token",
                 token_type: "token_type",
                 scope: "scope",
-                expires_at: "expires_at"
+                expires_at: "expires_at",
             };
             jest.spyOn(tokenClient, "exchangeCode")
                 .mockImplementation(() => Promise.resolve(tokenResponse));
@@ -710,7 +710,7 @@ describe("ResponseValidator", () => {
         it("should map token response expires_in to response", async () => {
             // arrange
             const tokenResponse = {
-                expires_in: "42"
+                expires_in: "42",
             };
             jest.spyOn(tokenClient, "exchangeCode")
                 .mockImplementation(() => Promise.resolve(tokenResponse));
@@ -727,7 +727,7 @@ describe("ResponseValidator", () => {
         it("should validate id_token if token response has id_token", async () => {
             // arrange
             const tokenResponse = {
-                id_token: "id_token"
+                id_token: "id_token",
             };
             jest.spyOn(tokenClient, "exchangeCode")
                 .mockImplementation(() => Promise.resolve(tokenResponse));

--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -17,7 +17,7 @@ class ResponseValidatorWrapper extends ResponseValidator {
         return super._processSigninParams(state, response);
     }
     public async _processClaims(state: SigninState, response: SigninResponse) {
-        return super._processClaims(state, response);
+        return await super._processClaims(state, response);
     }
     public _mergeClaims(claims1: UserProfile, claims2: any) {
         return super._mergeClaims(claims1, claims2);
@@ -29,7 +29,7 @@ class ResponseValidatorWrapper extends ResponseValidator {
         return super._validateTokens(state, response);
     }
     public async _processCode(state: SigninState, response: SigninResponse) {
-        return super._processCode(state, response);
+        return await super._processCode(state, response);
     }
     public _validateIdTokenAttributes(response: SigninResponse, id_token: string) {
         return super._validateIdTokenAttributes(response, id_token);

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -213,7 +213,7 @@ export class ResponseValidator {
     protected async _validateTokens(state: SigninState, response: SigninResponse): Promise<SigninResponse> {
         if (response.code) {
             this._logger.debug("_validateTokens: Validating code");
-            return this._processCode(state, response);
+            return await this._processCode(state, response);
         }
 
         this._logger.debug("_validateTokens: No code to process");

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -134,7 +134,7 @@ export class ResponseValidator {
             if (state.skipUserInfo !== true && this._settings.loadUserInfo && response.access_token) {
                 this._logger.debug("_processClaims: loading user info");
 
-                const claims  = await this._userInfoService.getClaims(response.access_token);
+                const claims = await this._userInfoService.getClaims(response.access_token);
                 this._logger.debug("_processClaims: user info claims received from user info endpoint");
 
                 if (claims.sub !== response.profile.sub) {
@@ -221,7 +221,7 @@ export class ResponseValidator {
             client_secret: state.client_secret,
             code : response.code,
             redirect_uri: state.redirect_uri,
-            code_verifier: state.code_verifier || ""
+            code_verifier: state.code_verifier || "",
         };
 
         if (state.extraTokenParams && typeof(state.extraTokenParams) === "object") {

--- a/src/SessionMonitor.ts
+++ b/src/SessionMonitor.ts
@@ -53,8 +53,8 @@ export class SessionMonitor {
                     session_state: session.session_state,
                     profile: session.sub && session.sid ? {
                         sub: session.sub,
-                        sid: session.sid
-                    } : null
+                        sid: session.sid,
+                    } : null,
                 };
                 void this._start(tmpUser);
             }
@@ -65,7 +65,7 @@ export class SessionMonitor {
         user: User | {
             session_state: string;
             profile: { sub: string; sid: string } | null;
-        }
+        },
     ): Promise<void> => {
         const session_state = user.session_state;
         if (!session_state) {
@@ -135,8 +135,8 @@ export class SessionMonitor {
                             session_state: session.session_state,
                             profile: session.sub && session.sid ? {
                                 sub: session.sub,
-                                sid: session.sid
-                            } : null
+                                sid: session.sid,
+                            } : null,
                         };
                         void this._start(tmpUser);
                     }

--- a/src/SigninRequest.test.ts
+++ b/src/SigninRequest.test.ts
@@ -16,7 +16,7 @@ describe("SigninRequest", () => {
             response_type: "code",
             scope: "openid",
             authority : "op",
-            state_data: { data: "test" }
+            state_data: { data: "test" },
         };
         subject = new SigninRequest(settings);
     });
@@ -190,7 +190,7 @@ describe("SigninRequest", () => {
             // arrange
             settings.extraQueryParams = {
                 "hd": "domain.com",
-                "foo": "bar"
+                "foo": "bar",
             };
 
             // act
@@ -211,7 +211,7 @@ describe("SigninRequest", () => {
 
             // assert
             expect(subject.state.extraTokenParams).toEqual({
-                "resourceServer": "abc"
+                "resourceServer": "abc",
             });
         });
 

--- a/src/SigninRequest.test.ts
+++ b/src/SigninRequest.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { SigninRequest } from "./SigninRequest";
+import { SigninRequest, SigninRequestArgs } from "./SigninRequest";
 
 describe("SigninRequest", () => {
 
     let subject: SigninRequest;
-    let settings: any;
+    let settings: SigninRequestArgs;
 
     beforeEach(() => {
         settings = {
@@ -16,101 +16,20 @@ describe("SigninRequest", () => {
             response_type: "code",
             scope: "openid",
             authority : "op",
-            data: { data: "test" }
+            state_data: { data: "test" }
         };
         subject = new SigninRequest(settings);
     });
 
     describe("constructor", () => {
-
-        it("should require a url param", () => {
+        it.each(["url", "client_id", "redirect_uri", "response_type", "scope", "authority"])("should require a %s param", (param) => {
             // arrange
-            delete settings.url;
+            Object.assign(settings, { [param]: undefined });
 
             // act
-            try {
-                new SigninRequest(settings);
-                fail("should not come here");
-            }
-            catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect((err as Error).message).toContain("url");
-            }
-        });
-
-        it("should require a client_id param", () => {
-            // arrange
-            delete settings.client_id;
-
-            // act
-            try {
-                new SigninRequest(settings);
-                fail("should not come here");
-            }
-            catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect((err as Error).message).toContain("client_id");
-            }
-        });
-
-        it("should require a redirect_uri param", () => {
-            // arrange
-            delete settings.redirect_uri;
-
-            // act
-            try {
-                new SigninRequest(settings);
-                fail("should not come here");
-            }
-            catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect((err as Error).message).toContain("redirect_uri");
-            }
-        });
-
-        it("should require a response_type param", () => {
-            // arrange
-            delete settings.response_type;
-
-            // act
-            try {
-                new SigninRequest(settings);
-                fail("should not come here");
-            }
-            catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect((err as Error).message).toContain("response_type");
-            }
-        });
-
-        it("should require a scope param", () => {
-            // arrange
-            delete settings.scope;
-
-            // act
-            try {
-                new SigninRequest(settings);
-                fail("should not come here");
-            }
-            catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect((err as Error).message).toContain("scope");
-            }
-        });
-
-        it("should require a authority param", () => {
-            // arrange
-            delete settings.authority;
-
-            // act
-            try {
-                new SigninRequest(settings);
-                fail("should not come here");
-            }
-            catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect((err as Error).message).toContain("authority");
-            }
+            expect(() => new SigninRequest(settings))
+                // assert
+                .toThrow(param);
         });
     });
 
@@ -236,13 +155,13 @@ describe("SigninRequest", () => {
 
         it("should include response_mode", () => {
             // arrange
-            settings.response_mode = "foo";
+            settings.response_mode = "fragment";
 
             // act
             subject = new SigninRequest(settings);
 
             // assert
-            expect(subject.url).toContain("response_mode=foo");
+            expect(subject.url).toContain("response_mode=fragment");
         });
 
         it("should include request", () => {

--- a/src/SigninRequest.ts
+++ b/src/SigninRequest.ts
@@ -91,7 +91,7 @@ export class SigninRequest {
             client_id, authority, redirect_uri,
             response_mode,
             client_secret, scope, extraTokenParams,
-            skipUserInfo
+            skipUserInfo,
         });
 
         const parsedUrl = new URL(url);

--- a/src/SigninState.test.ts
+++ b/src/SigninState.test.ts
@@ -24,7 +24,7 @@ describe("SigninState", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 request_type: "type",
-                scope: "scope"
+                scope: "scope",
             });
 
             // assert
@@ -40,7 +40,7 @@ describe("SigninState", () => {
                 client_id: "client",
                 scope: "scope",
                 request_type: "type",
-                redirect_uri: "http://cb"
+                redirect_uri: "http://cb",
             });
 
             // assert
@@ -55,7 +55,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 scope: "scope",
                 request_type: "type",
-                code_verifier: "5"
+                code_verifier: "5",
             });
 
             // assert
@@ -70,7 +70,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 scope: "scope",
                 request_type: "type",
-                code_verifier: true
+                code_verifier: true,
             });
 
             // assert
@@ -87,7 +87,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 scope: "scope",
                 request_type: "type",
-                code_verifier: true
+                code_verifier: true,
             });
 
             // assert
@@ -101,7 +101,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 scope: "scope",
                 request_type: "type",
-                client_id: "client"
+                client_id: "client",
             });
 
             // assert
@@ -115,7 +115,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 scope: "scope",
                 request_type: "type",
-                authority: "test"
+                authority: "test",
             });
 
             // assert
@@ -129,7 +129,7 @@ describe("SigninState", () => {
                 client_id: "client",
                 redirect_uri: "http://cb",
                 scope: "scope",
-                request_type: "xoxo"
+                request_type: "xoxo",
             });
 
             // assert
@@ -145,8 +145,8 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 extraTokenParams: {
-                    "resourceServer" : "abc"
-                }
+                    "resourceServer" : "abc",
+                },
             });
 
             // assert
@@ -164,7 +164,7 @@ describe("SigninState", () => {
             client_id: "client",
             redirect_uri: "http://cb",
             scope: "scope",
-            request_type: "type"
+            request_type: "type",
         });
 
         // act

--- a/src/SigninState.ts
+++ b/src/SigninState.ts
@@ -88,7 +88,7 @@ export class SigninState extends State {
             client_secret: this.client_secret,
             extraTokenParams : this.extraTokenParams,
             response_mode: this.response_mode,
-            skipUserInfo: this.skipUserInfo
+            skipUserInfo: this.skipUserInfo,
         });
     }
 

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -22,7 +22,7 @@ describe("SignoutRequest", () => {
 
         it("should require a url param", () => {
             // arrange
-            delete (settings as any).url;
+            Object.assign(settings, { url: undefined });
 
             // act
             try {

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -13,7 +13,7 @@ describe("SignoutRequest", () => {
             url: "http://sts/signout",
             id_token_hint: "hint",
             post_logout_redirect_uri: "loggedout",
-            state_data: { data: "test" }
+            state_data: { data: "test" },
         };
         subject = new SignoutRequest(settings);
     });
@@ -95,7 +95,7 @@ describe("SignoutRequest", () => {
             // arrange
             settings.extraQueryParams = {
                 "TargetResource": "logouturl.com",
-                "InErrorResource": "errorurl.com"
+                "InErrorResource": "errorurl.com",
             };
 
             // act

--- a/src/SignoutRequest.ts
+++ b/src/SignoutRequest.ts
@@ -30,7 +30,7 @@ export class SignoutRequest {
 
     public constructor({
         url,
-        state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type
+        state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
     }: SignoutRequestArgs) {
         this._logger = new Logger("SignoutRequest");
 

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -19,7 +19,7 @@ describe("State", () => {
         it("should generate id", () => {
             // act
             const subject = new State({
-                request_type: "type"
+                request_type: "type",
             });
 
             // assert
@@ -30,7 +30,7 @@ describe("State", () => {
             // act
             const subject = new State({
                 request_type: "type",
-                id: "5"
+                id: "5",
             });
 
             // assert
@@ -41,7 +41,7 @@ describe("State", () => {
             // act
             const subject = new State({
                 request_type: "type",
-                data: "test"
+                data: "test",
             });
 
             // assert
@@ -52,7 +52,7 @@ describe("State", () => {
             // act
             const subject = new State({
                 request_type: "type",
-                data: { foo: "test" }
+                data: { foo: "test" },
             });
 
             // assert
@@ -63,7 +63,7 @@ describe("State", () => {
             // act
             const subject = new State({
                 request_type: "type",
-                created: 1000
+                created: 1000,
             });
 
             // assert
@@ -79,7 +79,7 @@ describe("State", () => {
 
             // act
             const subject = new State({
-                request_type: "type"
+                request_type: "type",
             });
 
             // assert
@@ -90,7 +90,7 @@ describe("State", () => {
         it("should accept request_type", () => {
             // act
             const subject = new State({
-                request_type: "xoxo"
+                request_type: "xoxo",
             });
 
             // assert
@@ -101,7 +101,7 @@ describe("State", () => {
     it("can serialize and then deserialize", () => {
         // arrange
         const subject1 = new State({
-            data: { foo: "test" }, created: 1000, request_type:"type"
+            data: { foo: "test" }, created: 1000, request_type:"type",
         });
 
         // act

--- a/src/State.ts
+++ b/src/State.ts
@@ -30,7 +30,7 @@ export class State {
         else {
             this.created = Timer.getEpochTime();
         }
-        this.request_type =  args.request_type;
+        this.request_type = args.request_type;
     }
 
     public toStorageString(): string {
@@ -39,7 +39,7 @@ export class State {
             id: this.id,
             data: this.data,
             created: this.created,
-            request_type: this.request_type
+            request_type: this.request_type,
         });
     }
 

--- a/src/TokenClient.test.ts
+++ b/src/TokenClient.test.ts
@@ -15,7 +15,7 @@ describe("TokenClient", () => {
         settings = {
             authority: "authority",
             client_id: "client_id",
-            redirect_uri: "redirect_uri"
+            redirect_uri: "redirect_uri",
         };
         const settingsStore = new OidcClientSettingsStore(settings);
         metadataService = new MetadataService(settingsStore);
@@ -90,7 +90,7 @@ describe("TokenClient", () => {
             expect(postFormMock).toBeCalledWith(
                 "http://sts/token_endpoint",
                 expect.anything(),
-                expect.anything()
+                expect.anything(),
             );
         });
 
@@ -109,7 +109,7 @@ describe("TokenClient", () => {
             expect(postFormMock).toBeCalledWith(
                 "http://sts/token_endpoint",
                 expect.anything(),
-                undefined
+                undefined,
             );
         });
     });
@@ -174,7 +174,7 @@ describe("TokenClient", () => {
             expect(postFormMock).toBeCalledWith(
                 "http://sts/token_endpoint",
                 expect.anything(),
-                expect.anything()
+                expect.anything(),
             );
         });
 
@@ -193,7 +193,7 @@ describe("TokenClient", () => {
             expect(postFormMock).toBeCalledWith(
                 "http://sts/token_endpoint",
                 expect.anything(),
-                undefined
+                undefined,
             );
         });
     });
@@ -231,13 +231,13 @@ describe("TokenClient", () => {
                 .mockResolvedValue({});
 
             // act
-            await subject.revoke({ token: "token", token_type_hint: "access_token"  });
+            await subject.revoke({ token: "token", token_type_hint: "access_token" });
 
             // assert
             expect(getTokenEndpointMock).toBeCalledWith(false);
             expect(postFormMock).toBeCalledWith(
                 "http://sts/revoke_endpoint",
-                expect.anything()
+                expect.anything(),
             );
         });
     });

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -117,7 +117,7 @@ export class TokenClient {
         client_id = this._settings.client_id,
         client_secret = this._settings.client_secret,
         ...args
-    }: ExchangeRefreshTokenArgs): Promise<any> {
+    }: ExchangeRefreshTokenArgs): Promise<Record<string, unknown>> {
         if (!client_id) {
             this._logger.error("exchangeRefreshToken: No client_id passed");
             throw new Error("A client_id is required");

--- a/src/User.ts
+++ b/src/User.ts
@@ -58,6 +58,8 @@ export interface UserProfile {
     address?: Record<string, unknown>;
     /** Time the End-User's information was last updated. Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time. */
     updated_at?: number;
+
+    [claim: string]: unknown;
 }
 
 /**

--- a/src/User.ts
+++ b/src/User.ts
@@ -161,7 +161,7 @@ export class User {
             token_type: this.token_type,
             scope: this.scope,
             profile: this.profile,
-            expires_at: this.expires_at
+            expires_at: this.expires_at,
         });
     }
 

--- a/src/UserInfoService.test.ts
+++ b/src/UserInfoService.test.ts
@@ -15,7 +15,7 @@ describe("UserInfoService", () => {
         const settings = new OidcClientSettingsStore({
             authority: "authority",
             client_id: "client",
-            redirect_uri: "redirect"
+            redirect_uri: "redirect",
         });
         metadataService = new MetadataService(settings);
 
@@ -86,7 +86,7 @@ describe("UserInfoService", () => {
                 sub:"123", email:"foo@gmail.com",
                 role:["admin", "dev"],
                 nonce:"nonce", at_hash:"athash",
-                iat:5, nbf:10, exp:20
+                iat:5, nbf:10, exp:20,
             };
             jest.spyOn(jsonService, "getJson").mockImplementation(() => Promise.resolve(expectedClaims));
 

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -37,8 +37,8 @@ describe("UserManager", () => {
             userStore: userStoreMock,
             metadata: {
                 authorization_endpoint: "http://sts/oidc/authorize",
-                token_endpoint: "http://sts/oidc/token"
-            }
+                token_endpoint: "http://sts/oidc/token",
+            },
         };
         subject = new UserManager(settings);
 
@@ -46,16 +46,16 @@ describe("UserManager", () => {
             ...Object.getOwnPropertyDescriptors(window.location),
             assign: {
                 enumerable: true,
-                value: jest.fn()
+                value: jest.fn(),
             },
             replace: {
                 enumerable: true,
-                value: jest.fn()
-            }
+                value: jest.fn(),
+            },
         });
         Object.defineProperty(window, "location", {
             enumerable: true,
-            get: () => location
+            get: () => location,
         });
     });
 
@@ -90,7 +90,7 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
             subject["_loadUser"] = jest.fn().mockReturnValue(user);
             const loadMock = jest.spyOn(subject["_events"], "load");
@@ -139,7 +139,7 @@ describe("UserManager", () => {
 
             // assert
             expect(window.location.assign).toHaveBeenCalledWith(
-                expect.stringContaining(settings.metadata!.authorization_endpoint!)
+                expect.stringContaining(settings.metadata!.authorization_endpoint!),
             );
             const [location] = mocked(window.location.assign).mock.calls[0];
             const state = new URL(location).searchParams.get("state");
@@ -152,7 +152,7 @@ describe("UserManager", () => {
             const prepareMock = jest.spyOn(subject["_redirectNavigator"], "prepare");
             subject["_signinStart"] = jest.fn();
             const navParams: SigninRedirectArgs = {
-                redirectMethod: "assign"
+                redirectMethod: "assign",
             };
 
             // act
@@ -169,7 +169,7 @@ describe("UserManager", () => {
             const extraArgs: SigninRedirectArgs = {
                 extraQueryParams: { q : "q" },
                 extraTokenParams: { t: "t" },
-                state: "state"
+                state: "state",
             };
 
             // act
@@ -179,12 +179,12 @@ describe("UserManager", () => {
             expect(subject["_signinStart"]).toBeCalledWith(
                 {
                     request_type: "si:r",
-                    ...extraArgs
+                    ...extraArgs,
                 },
                 expect.objectContaining({
                     close: expect.any(Function),
                     navigate: expect.any(Function),
-                })
+                }),
             );
         });
     });
@@ -237,7 +237,7 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
             const handle = { } as PopupWindow;
             jest.spyOn(subject["_popupNavigator"], "prepare")
@@ -246,7 +246,7 @@ describe("UserManager", () => {
             const extraArgs: SigninPopupArgs = {
                 extraQueryParams: { q : "q" },
                 extraTokenParams: { t: "t" },
-                state: "state"
+                state: "state",
             };
 
             // act
@@ -258,9 +258,9 @@ describe("UserManager", () => {
                     request_type: "si:p",
                     redirect_uri: subject.settings.redirect_uri,
                     display: "popup",
-                    ...extraArgs
+                    ...extraArgs,
                 },
-                handle
+                handle,
             );
         });
     });
@@ -287,13 +287,13 @@ describe("UserManager", () => {
                 id_token: "id_token",
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
 
             settings = {
                 ...settings,
                 silentRequestTimeoutInSeconds: 123,
-                silent_redirect_uri: "http://client/silent_callback"
+                silent_redirect_uri: "http://client/silent_callback",
             };
             subject = new UserManager(settings);
             subject["_signin"] = jest.fn().mockResolvedValue(user);
@@ -311,7 +311,7 @@ describe("UserManager", () => {
             const prepareMock = jest.spyOn(subject["_iframeNavigator"], "prepare");
             subject["_signin"] = jest.fn();
             const navParams: SigninSilentArgs = {
-                silentRequestTimeoutInSeconds: 234
+                silentRequestTimeoutInSeconds: 234,
             };
 
             // act
@@ -326,14 +326,14 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
             jest.spyOn(subject["_popupNavigator"], "prepare");
             subject["_signin"] = jest.fn().mockResolvedValue(user);
             const extraArgs: SigninSilentArgs = {
                 extraQueryParams: { q : "q" },
                 extraTokenParams: { t: "t" },
-                state: "state"
+                state: "state",
             };
 
             // act
@@ -346,13 +346,13 @@ describe("UserManager", () => {
                     redirect_uri: subject.settings.redirect_uri,
                     prompt: "none",
                     id_token_hint: undefined,
-                    ...extraArgs
+                    ...extraArgs,
                 },
                 expect.objectContaining({
                     close: expect.any(Function),
                     navigate: expect.any(Function),
                 }),
-                undefined
+                undefined,
             );
         });
 
@@ -361,11 +361,11 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
             settings = {
                 ...settings,
-                silent_redirect_uri: "http://client/silent_callback"
+                silent_redirect_uri: "http://client/silent_callback",
             };
             subject = new UserManager(settings);
             subject["_signin"] = jest.fn().mockResolvedValue(user);
@@ -395,11 +395,11 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
             const responseState = {
                 state: { request_type: "si:r" } as SigninState,
-                response: { } as SigninResponse
+                response: { } as SigninResponse,
             };
             jest.spyOn(subject["_client"], "readSigninResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -419,7 +419,7 @@ describe("UserManager", () => {
             // arrange
             const responseState = {
                 state: { request_type: "si:p" } as SigninState,
-                response: { } as SigninResponse
+                response: { } as SigninResponse,
             };
             jest.spyOn(subject["_client"], "readSigninResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -438,7 +438,7 @@ describe("UserManager", () => {
             // arrange
             const responseState = {
                 state: { request_type: "si:s" } as SigninState,
-                response: { } as SigninResponse
+                response: { } as SigninResponse,
             };
             jest.spyOn(subject["_client"], "readSigninResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -457,7 +457,7 @@ describe("UserManager", () => {
             // arrange
             const responseState = {
                 state: { request_type: "dummy" } as SigninState,
-                response: { } as SigninResponse
+                response: { } as SigninResponse,
             };
             jest.spyOn(subject["_client"], "readSigninResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -474,7 +474,7 @@ describe("UserManager", () => {
             // arrange
             const responseState = {
                 state: { request_type: "so:r" } as State,
-                response: { } as SignoutResponse
+                response: { } as SignoutResponse,
             };
             jest.spyOn(subject["_client"], "readSignoutResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -493,7 +493,7 @@ describe("UserManager", () => {
             // arrange
             const responseState = {
                 state: { request_type: "so:p" } as State,
-                response: { } as SignoutResponse
+                response: { } as SignoutResponse,
             };
             jest.spyOn(subject["_client"], "readSignoutResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -513,7 +513,7 @@ describe("UserManager", () => {
             // arrange
             const responseState = {
                 state: { request_type: "dummy" } as State,
-                response: { } as SignoutResponse
+                response: { } as SignoutResponse,
             };
             jest.spyOn(subject["_client"], "readSignoutResponseState")
                 .mockImplementation(() => Promise.resolve(responseState));
@@ -531,7 +531,7 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
 
             // act
@@ -547,7 +547,7 @@ describe("UserManager", () => {
             const user = new User({
                 access_token: "access_token",
                 token_type: "token_type",
-                profile: {}
+                profile: {},
             });
             await subject.storeUser(user);
 

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -165,7 +165,7 @@ describe("UserManager", () => {
         it("should pass extra args to _signinStart", async () => {
             // arrange
             jest.spyOn(subject["_redirectNavigator"], "prepare");
-            const signinStartMock = jest.spyOn(subject as any, "_signinStart");
+            subject["_signinStart"] = jest.fn();
             const extraArgs: SigninRedirectArgs = {
                 extraQueryParams: { q : "q" },
                 extraTokenParams: { t: "t" },
@@ -176,7 +176,7 @@ describe("UserManager", () => {
             await subject.signinRedirect(extraArgs);
 
             // assert
-            expect(signinStartMock).toBeCalledWith(
+            expect(subject["_signinStart"]).toBeCalledWith(
                 {
                     request_type: "si:r",
                     ...extraArgs
@@ -242,8 +242,7 @@ describe("UserManager", () => {
             const handle = { } as PopupWindow;
             jest.spyOn(subject["_popupNavigator"], "prepare")
                 .mockImplementation(() => Promise.resolve(handle));
-            const signinMock = jest.spyOn(subject as any, "_signin")
-                .mockImplementation(() => Promise.resolve(user));
+            subject["_signin"] = jest.fn().mockResolvedValue(user);
             const extraArgs: SigninPopupArgs = {
                 extraQueryParams: { q : "q" },
                 extraTokenParams: { t: "t" },
@@ -254,7 +253,7 @@ describe("UserManager", () => {
             await subject.signinPopup(extraArgs);
 
             // assert
-            expect(signinMock).toBeCalledWith(
+            expect(subject["_signin"]).toBeCalledWith(
                 {
                     request_type: "si:p",
                     redirect_uri: subject.settings.redirect_uri,
@@ -330,8 +329,7 @@ describe("UserManager", () => {
                 profile: {}
             });
             jest.spyOn(subject["_popupNavigator"], "prepare");
-            const signinMock = jest.spyOn(subject as any, "_signin")
-                .mockImplementation(() => Promise.resolve(user));
+            subject["_signin"] = jest.fn().mockResolvedValue(user);
             const extraArgs: SigninSilentArgs = {
                 extraQueryParams: { q : "q" },
                 extraTokenParams: { t: "t" },
@@ -342,7 +340,7 @@ describe("UserManager", () => {
             await subject.signinSilent(extraArgs);
 
             // assert
-            expect(signinMock).toBeCalledWith(
+            expect(subject["_signin"]).toBeCalledWith(
                 {
                     request_type: "si:s",
                     redirect_uri: subject.settings.redirect_uri,

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -225,7 +225,7 @@ export class UserManager {
         // first determine if we have a refresh token, or need to use iframe
         let user = await this._loadUser();
         if (user && user.refresh_token) {
-            return this._useRefreshToken(user);
+            return await this._useRefreshToken(user);
         }
 
         const url = this.settings.silent_redirect_uri || this.settings.redirect_uri;
@@ -325,7 +325,7 @@ export class UserManager {
         const { state } = await this._client.readSigninResponseState(url);
         switch (state.request_type) {
             case "si:r":
-                return this.signinRedirectCallback(url);
+                return await this.signinRedirectCallback(url);
             case "si:p":
                 return await this.signinPopupCallback(url);
             case "si:s":
@@ -414,7 +414,7 @@ export class UserManager {
 
     protected async _signin(args: CreateSigninRequestArgs, handle: IWindow, verifySub?: string): Promise<User> {
         const navResponse = await this._signinStart(args, handle);
-        return this._signinEnd(navResponse.url, verifySub);
+        return await this._signinEnd(navResponse.url, verifySub);
     }
     protected async _signinStart(args: CreateSigninRequestArgs, handle: IWindow): Promise<NavigateResponse> {
         this._logger.debug("_signinStart: got navigator window handle");
@@ -519,7 +519,7 @@ export class UserManager {
 
     protected async _signout(args: CreateSignoutRequestArgs, handle: IWindow): Promise<SignoutResponse> {
         const navResponse = await this._signoutStart(args, handle);
-        return this._signoutEnd(navResponse.url);
+        return await this._signoutEnd(navResponse.url);
     }
     protected async _signoutStart(args: CreateSignoutRequestArgs = {}, handle: IWindow): Promise<NavigateResponse> {
         this._logger.debug("_signoutStart: got navigator window handle");

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -383,7 +383,7 @@ export class UserManager {
             this._logger.debug("querySessionStatus: got signin response");
 
             if (signinResponse.session_state && signinResponse.profile.sub) {
-                this._logger.info("querySessionStatus: querySessionStatus success for sub: ",  signinResponse.profile.sub);
+                this._logger.info("querySessionStatus: querySessionStatus success for sub: ", signinResponse.profile.sub);
                 return {
                     session_state: signinResponse.session_state,
                     sub: signinResponse.profile.sub,

--- a/src/UserManagerEvents.test.ts
+++ b/src/UserManagerEvents.test.ts
@@ -12,7 +12,7 @@ describe("UserManagerEvents", () => {
         const settings = new UserManagerSettingsStore({
             authority: "authority",
             client_id: "client",
-            redirect_uri: "redirect"
+            redirect_uri: "redirect",
         });
         subject = new UserManagerEvents(settings);
     });

--- a/src/UserManagerSettings.test.ts
+++ b/src/UserManagerSettings.test.ts
@@ -19,7 +19,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -36,7 +36,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                popup_redirect_uri: "test"
+                popup_redirect_uri: "test",
             });
 
             // assert
@@ -53,7 +53,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                popupWindowFeatures: { status: true }
+                popupWindowFeatures: { status: true },
             });
 
             // assert
@@ -70,7 +70,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                popupWindowTarget: "foo"
+                popupWindowTarget: "foo",
             });
 
             // assert
@@ -87,7 +87,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                redirectMethod: "replace"
+                redirectMethod: "replace",
             });
 
             // assert
@@ -104,7 +104,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                silent_redirect_uri: "test"
+                silent_redirect_uri: "test",
             });
 
             // assert
@@ -121,7 +121,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                silentRequestTimeoutInSeconds: 123
+                silentRequestTimeoutInSeconds: 123,
             });
 
             // assert
@@ -138,7 +138,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                automaticSilentRenew: false
+                automaticSilentRenew: false,
             });
 
             // assert
@@ -150,7 +150,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -167,7 +167,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                validateSubOnSilentRenew: false
+                validateSubOnSilentRenew: false,
             });
 
             // assert
@@ -179,7 +179,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -207,7 +207,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -223,7 +223,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                accessTokenExpiringNotificationTimeInSeconds: 10
+                accessTokenExpiringNotificationTimeInSeconds: 10,
             });
 
             // assert
@@ -235,7 +235,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -253,7 +253,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                userStore : temp
+                userStore : temp,
             });
 
             // assert
@@ -268,7 +268,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                revokeAccessTokenOnSignout : true
+                revokeAccessTokenOnSignout : true,
             });
 
             // assert
@@ -283,7 +283,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                checkSessionIntervalInSeconds: 6
+                checkSessionIntervalInSeconds: 6,
             });
 
             // assert
@@ -294,7 +294,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert
@@ -311,7 +311,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                query_status_response_type : temp
+                query_status_response_type : temp,
             });
 
             // assert
@@ -324,7 +324,7 @@ describe("UserManagerSettings", () => {
                     authority: "authority",
                     client_id: "client",
                     redirect_uri: "redirect",
-                    response_type: "id_token token"
+                    response_type: "id_token token",
                 });
 
                 // assert
@@ -336,7 +336,7 @@ describe("UserManagerSettings", () => {
                     authority: "authority",
                     client_id: "client",
                     redirect_uri: "redirect",
-                    response_type: "code"
+                    response_type: "code",
                 });
 
                 // assert
@@ -352,7 +352,7 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                stopCheckSessionOnError : false
+                stopCheckSessionOnError : false,
             });
 
             // assert
@@ -363,7 +363,7 @@ describe("UserManagerSettings", () => {
             const subject = new UserManagerSettingsStore({
                 authority: "authority",
                 client_id: "client",
-                redirect_uri: "redirect"
+                redirect_uri: "redirect",
             });
 
             // assert

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -112,7 +112,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
             revokeAccessTokenOnSignout = false,
             accessTokenExpiringNotificationTimeInSeconds = DefaultAccessTokenExpiringNotificationTimeInSeconds,
 
-            userStore = new WebStorageStateStore({ store: sessionStorage })
+            userStore = new WebStorageStateStore({ store: sessionStorage }),
         } = args;
 
         super(args);

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -17,7 +17,7 @@ export class IFrameNavigator implements INavigator {
     }
 
     public async prepare({
-        silentRequestTimeoutInSeconds = this._settings.silentRequestTimeoutInSeconds
+        silentRequestTimeoutInSeconds = this._settings.silentRequestTimeoutInSeconds,
     }: IFrameWindowParams): Promise<IFrameWindow> {
         return new IFrameWindow({ silentRequestTimeoutInSeconds });
     }

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -23,7 +23,7 @@ export class IFrameWindow extends AbstractChildWindow {
     private _timeoutInSeconds: number;
 
     public constructor({
-        silentRequestTimeoutInSeconds = defaultTimeoutInSeconds
+        silentRequestTimeoutInSeconds = defaultTimeoutInSeconds,
     }: IFrameWindowParams) {
         super();
         this._timeoutInSeconds = silentRequestTimeoutInSeconds;

--- a/src/navigators/PopupWindow.test.ts
+++ b/src/navigators/PopupWindow.test.ts
@@ -1,9 +1,12 @@
-/* eslint-disable @typescript-eslint/unbound-method */
+import { mocked } from "ts-jest/utils";
 import { PopupWindow } from "./PopupWindow";
 
-describe("PopupWindow", () => {
-    let popupFromWindowOpen: WindowProxy;
+function firstSuccessfulResult<T>(fn: () => T): T {
+    expect(fn).toHaveReturned();
+    return mocked(fn).mock.results[0].value as T;
+}
 
+describe("PopupWindow", () => {
     beforeEach(() => {
         Object.defineProperty(window, "location", {
             writable: true,
@@ -13,15 +16,11 @@ describe("PopupWindow", () => {
         window.opener = {
             postMessage: jest.fn(),
         };
-        window.open = jest.fn().mockImplementation(() => {
-            popupFromWindowOpen = {
-                location: { replace: jest.fn() },
-                focus: jest.fn(),
-                close: jest.fn(),
-            } as any;
-
-            return popupFromWindowOpen;
-        });
+        window.open = jest.fn(() => ({
+            location: { replace: jest.fn() },
+            focus: jest.fn(),
+            close: jest.fn(),
+        } as unknown as WindowProxy));
     });
 
     afterEach(() => {
@@ -45,6 +44,7 @@ describe("PopupWindow", () => {
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
+        const popupFromWindowOpen = firstSuccessfulResult(window.open)!;
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
         expect(popupFromWindowOpen.focus).toHaveBeenCalled();
         expect(popupFromWindowOpen.close).toHaveBeenCalled();
@@ -61,6 +61,7 @@ describe("PopupWindow", () => {
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
+        const popupFromWindowOpen = firstSuccessfulResult(window.open)!;
         expect(popupFromWindowOpen.location.replace).toHaveBeenCalledWith("http://sts/authorize?x=y");
         expect(popupFromWindowOpen.close).not.toHaveBeenCalled();
     });
@@ -85,6 +86,7 @@ describe("PopupWindow", () => {
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid&code=code");
+        const popupFromWindowOpen = firstSuccessfulResult(window.open)!;
         expect(popupFromWindowOpen.focus).toHaveBeenCalled();
         expect(popupFromWindowOpen.close).toHaveBeenCalled();
     });
@@ -93,6 +95,7 @@ describe("PopupWindow", () => {
         const popupWindow = new PopupWindow({});
 
         const promise = popupWindow.navigate({ url: "http://sts/authorize?x=y", state: "someid" });
+        const popupFromWindowOpen = firstSuccessfulResult(window.open)!;
         window.dispatchEvent(new MessageEvent("message", {
             data: { source: "oidc-client", url: "" },
             origin: "http://app",
@@ -107,6 +110,7 @@ describe("PopupWindow", () => {
         const popupWindow = new PopupWindow({});
 
         const promise = popupWindow.navigate({ url: "http://sts/authorize?x=y", state: "someid" });
+        const popupFromWindowOpen = firstSuccessfulResult(window.open);
         Object.defineProperty(popupFromWindowOpen, "closed", {
             enumerable: true,
             value: true,
@@ -126,7 +130,7 @@ describe("PopupWindow", () => {
 
     it("should notify the parent window", async () => {
         PopupWindow.notifyOpener("http://sts/authorize?x=y", false);
-        expect(window.opener.postMessage).toHaveBeenCalledWith({
+        expect((window.opener as WindowProxy).postMessage).toHaveBeenCalledWith({
             source: "oidc-client",
             url: "http://sts/authorize?x=y",
             keepOpen: false,

--- a/src/navigators/PopupWindow.test.ts
+++ b/src/navigators/PopupWindow.test.ts
@@ -10,7 +10,7 @@ describe("PopupWindow", () => {
     beforeEach(() => {
         Object.defineProperty(window, "location", {
             writable: true,
-            value: { origin: "http://app" }
+            value: { origin: "http://app" },
         });
 
         window.opener = {
@@ -40,7 +40,7 @@ describe("PopupWindow", () => {
 
         window.dispatchEvent(new MessageEvent("message", {
             data: { source: "oidc-client", url: "http://app/cb?state=someid" },
-            origin: "http://app"
+            origin: "http://app",
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
@@ -57,7 +57,7 @@ describe("PopupWindow", () => {
 
         window.dispatchEvent(new MessageEvent("message", {
             data: { source: "oidc-client", url: "http://app/cb?state=someid", keepOpen: true },
-            origin: "http://app"
+            origin: "http://app",
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid");
@@ -73,16 +73,16 @@ describe("PopupWindow", () => {
 
         window.dispatchEvent(new MessageEvent("message", {
             data: { source: "oidc-client", url: "http://app/cb?state=someid&code=foreign-origin" },
-            origin: "http://foreign-origin"
+            origin: "http://foreign-origin",
         }));
         window.dispatchEvent(new MessageEvent("message", {
             data: { source: "foreign-lib", url: "http://app/cb?state=someid&code=foreign-lib" },
             origin: "http://app",
-            source: {} as MessageEventSource
+            source: {} as MessageEventSource,
         }));
         window.dispatchEvent(new MessageEvent("message", {
             data: { source: "oidc-client", url: "http://app/cb?state=someid&code=code" },
-            origin: "http://app"
+            origin: "http://app",
         }));
 
         await expect(promise).resolves.toHaveProperty("url", "http://app/cb?state=someid&code=code");

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -22,12 +22,12 @@ export class RedirectNavigator implements INavigator {
     constructor(private _settings: UserManagerSettingsStore) {}
 
     public async prepare({
-        redirectMethod = this._settings.redirectMethod
+        redirectMethod = this._settings.redirectMethod,
     }: RedirectParams): Promise<IWindow> {
         const redirect = window.location[redirectMethod].bind(window.location) as (url: string) => never;
         return {
             navigate: (params) => redirect(params.url),
-            close: () => this._logger.warn("close: cannot close the current window")
+            close: () => this._logger.warn("close: cannot close the current window"),
         };
     }
 }

--- a/src/utils/CryptoUtils.ts
+++ b/src/utils/CryptoUtils.ts
@@ -13,13 +13,13 @@ export class CryptoUtils {
 
     private static _cryptoUUIDv4(): string {
         return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
-            (+c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
+            (+c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16),
         );
     }
 
     private static _UUIDv4(): string {
         return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
-            (+c ^ Math.random() * 16 >> +c / 4).toString(16)
+            (+c ^ Math.random() * 16 >> +c / 4).toString(16),
         );
     }
 

--- a/src/utils/Event.test.ts
+++ b/src/utils/Event.test.ts
@@ -5,7 +5,7 @@ import { Event } from "./Event";
 
 describe("Event", () => {
 
-    let subject: Event<any>;
+    let subject: Event<unknown[]>;
 
     beforeEach(() => {
         subject = new Event("test name");
@@ -80,6 +80,7 @@ describe("Event", () => {
 
         it("should pass params", () => {
             // arrange
+            const typedSubject = subject as Event<[number, number, number]>;
             let a = 10;
             let b = 11;
             let c = 12;
@@ -88,35 +89,15 @@ describe("Event", () => {
                 b = arg_b;
                 c = arg_c;
             };
-            subject.addHandler(cb);
+            typedSubject.addHandler(cb);
 
             // act
-            subject.raise(1, 2, 3);
+            typedSubject.raise(1, 2, 3);
 
             // assert
             expect(a).toEqual(1);
             expect(b).toEqual(2);
             expect(c).toEqual(3);
-        });
-
-        it("should allow passing no params", () => {
-            // arrange
-            let a = 10;
-            let b = 11;
-            let c = 12;
-            const cb = function (arg_a: number, arg_b: number, arg_c: number) {
-                a = arg_a;
-                b = arg_b;
-                c = arg_c;
-            };
-            subject.addHandler(cb);
-
-            subject.raise();
-
-            // assert
-            expect(a).toEqual(undefined);
-            expect(b).toEqual(undefined);
-            expect(c).toEqual(undefined);
         });
     });
 });

--- a/src/utils/JwtUtils.test.ts
+++ b/src/utils/JwtUtils.test.ts
@@ -35,8 +35,8 @@ describe("JwtUtils", () => {
                 "auth_time": 1459129898,
                 "idp": "idsrv",
                 "amr": [
-                    "password"
-                ]
+                    "password",
+                ],
             });
         });
 

--- a/src/utils/JwtUtils.ts
+++ b/src/utils/JwtUtils.ts
@@ -14,6 +14,8 @@ export interface JwtPayload {
     exp?: number;
     sub?: string;
     auth_time?: number;
+
+    [claim: string]: unknown;
 }
 
 /**

--- a/src/utils/Log.test.ts
+++ b/src/utils/Log.test.ts
@@ -130,10 +130,10 @@ class StubLog implements ILogger {
     infoWasCalled: boolean;
     warnWasCalled: boolean;
     errorWasCalled: boolean;
-    debugParam: any;
-    infoParam: any;
-    warnParam: any;
-    errorParam: any;
+    debugParam: string | undefined;
+    infoParam: string | undefined;
+    warnParam: string | undefined;
+    errorParam: string | undefined;
 
     constructor() {
         this.debugWasCalled = false;
@@ -141,19 +141,19 @@ class StubLog implements ILogger {
         this.warnWasCalled = false;
         this.errorWasCalled = false;
     }
-    debug(...args: any[]) {
+    debug(...args: unknown[]) {
         this.debugParam = args.join(" ");
         this.debugWasCalled = true;
     }
-    info(...args: any[]) {
+    info(...args: unknown[]) {
         this.infoParam = args.join(" ");
         this.infoWasCalled = true;
     }
-    warn(...args: any[]) {
+    warn(...args: unknown[]) {
         this.warnParam = args.join(" ");
         this.warnWasCalled = true;
     }
-    error(...args: any[]) {
+    error(...args: unknown[]) {
         this.errorParam = args.join(" ");
         this.errorWasCalled = true;
     }

--- a/src/utils/Log.ts
+++ b/src/utils/Log.ts
@@ -7,10 +7,10 @@
  * @public
  */
 export interface ILogger {
-    debug(...args: any[]): void;
-    info(...args: any[]): void;
-    warn(...args: any[]): void;
-    error(...args: any[]): void;
+    debug(...args: unknown[]): void;
+    info(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
 }
 
 const nopLogger: ILogger = {
@@ -76,36 +76,36 @@ export class Logger {
         this._name = name;
     }
 
-    public debug(...args: any[]): void {
+    public debug(...args: unknown[]): void {
         Logger.debug(this._name, ...args);
     }
-    public info(...args: any[]): void {
+    public info(...args: unknown[]): void {
         Logger.info(this._name, ...args);
     }
-    public warn(...args: any[]): void {
+    public warn(...args: unknown[]): void {
         Logger.warn(this._name, ...args);
     }
-    public error(...args: any[]): void {
+    public error(...args: unknown[]): void {
         Logger.error(this._name, ...args);
     }
 
     // helpers for static class methods
-    public static debug(name: string, ...args: any[]): void {
+    public static debug(name: string, ...args: unknown[]): void {
         if (Log.level >= DEBUG) {
             Log.logger.debug(`[${name}]`, ...args);
         }
     }
-    public static info(name: string, ...args: any[]): void {
+    public static info(name: string, ...args: unknown[]): void {
         if (Log.level >= INFO) {
             Log.logger.info(`[${name}]`, ...args);
         }
     }
-    public static warn(name: string, ...args: any[]): void {
+    public static warn(name: string, ...args: unknown[]): void {
         if (Log.level >= WARN) {
             Log.logger.warn(`[${name}]`, ...args);
         }
     }
-    public static error(name: string, ...args: any[]): void {
+    public static error(name: string, ...args: unknown[]): void {
         if (Log.level >= ERROR) {
             Log.logger.error(`[${name}]`, ...args);
         }

--- a/src/utils/PopupUtils.ts
+++ b/src/utils/PopupUtils.ts
@@ -1,4 +1,3 @@
-
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_features
  *

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -4,7 +4,7 @@
 import { IntervalTimer, Timer } from "./Timer";
 
 class IntervalTimerMock implements IntervalTimer {
-    callback: ((...args: any[]) => void);
+    callback: ((...args: unknown[]) => void);
     duration?: number;
 
     clearTimeoutWasCalled: boolean;
@@ -18,7 +18,7 @@ class IntervalTimerMock implements IntervalTimer {
         this.clearHandle = null;
     }
 
-    setInterval(cb: (...args: any[]) => void, duration?: number) {
+    setInterval(cb: (...args: unknown[]) => void, duration?: number) {
         this.callback = cb;
         this.duration = duration;
         return 5;

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -22,7 +22,7 @@ export const g_timer: IntervalTimer = {
     },
     clearInterval: function (handle: number): void {
         return window.clearInterval(handle);
-    }
+    },
 };
 
 /**

--- a/test/integration/OidcClient.spec.js
+++ b/test/integration/OidcClient.spec.js
@@ -47,12 +47,12 @@ describe("OidcClient", function () {
                     },
                     function (e) {
                         fail(e);
-                    }
+                    },
                 );
             },
             function (e) {
                 fail(e);
-            }
+            },
         );
     });
 
@@ -71,12 +71,12 @@ describe("OidcClient", function () {
                     },
                     function (e) {
                         fail(e);
-                    }
+                    },
                 );
             },
             function (e) {
                 fail(e);
-            }
+            },
         );
     });
 });


### PR DESCRIPTION
Resolves #243 and enforces a few more rules which should hopefully make sense:

* [`return-await`](https://typescript-eslint.io/rules/return-await/) - setting this to `always` ensures that async stack traces don't skip over functions that return promises. It also removes the ambiguity over when it's correct to `return await` inside of a try/catch.
* [`comma-dangle`](https://eslint.org/docs/rules/comma-dangle) - enables dangling commas for multiline functions and properties. This permits cleaner diffs when keys/arguments are appended or reordered
* [`no-multi-spaces`](https://eslint.org/docs/rules/no-multi-spaces) - this rule is sometimes controversial when you want to do fancy alignment across multiple lines where the space between operators is padded with whitespace to make things line up.

no-unsafe-call, no-unsafe-member-access, no-unsafe-return, and explicit-module-boundary-types were re-enabled by the `@typescript-eslint/recommended` preset since I was able to remove the remaining `any` types from the project.