### PR TITLE
Additional `window` updates

### DIFF
--- a/src/CheckSessionIFrame.ts
+++ b/src/CheckSessionIFrame.ts
@@ -10,7 +10,7 @@ export class CheckSessionIFrame {
     private readonly _logger: Logger;
     private _frame_origin: string;
     private _frame: HTMLIFrameElement;
-    private _timer: number | null = null
+    private _timer: ReturnType<typeof setInterval> | null = null
     private _session_state: string | null = null;
 
     public constructor(
@@ -92,7 +92,7 @@ export class CheckSessionIFrame {
         send();
 
         // and setup timer
-        this._timer = window.setInterval(send, this._intervalInSeconds * 1000);
+        this._timer = setInterval(send, this._intervalInSeconds * 1000);
     }
 
     public stop(): void {
@@ -101,7 +101,7 @@ export class CheckSessionIFrame {
         if (this._timer) {
             this._logger.debug("stop");
 
-            window.clearInterval(this._timer);
+            clearInterval(this._timer);
             this._timer = null;
         }
     }

--- a/src/SessionMonitor.ts
+++ b/src/SessionMonitor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger, IntervalTimer, g_timer } from "./utils";
+import { Logger } from "./utils";
 import { CheckSessionIFrame } from "./CheckSessionIFrame";
 import type { UserManager } from "./UserManager";
 import type { User } from "./User";
@@ -13,7 +13,6 @@ export class SessionMonitor {
     private readonly _logger: Logger;
 
     private readonly _userManager: UserManager;
-    private readonly _timer: IntervalTimer;
     private _sub: string | undefined;
     private _sid: string | undefined;
     private _checkSessionIFrame?: CheckSessionIFrame;
@@ -27,7 +26,6 @@ export class SessionMonitor {
         }
 
         this._userManager = userManager;
-        this._timer = g_timer;
 
         this._userManager.events.addUserLoaded(this._start);
         this._userManager.events.addUserUnloaded(this._stop);
@@ -125,8 +123,8 @@ export class SessionMonitor {
             // using a timer to delay re-initialization to avoid race conditions during signout
             // TODO rewrite to use promise correctly
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            const timerHandle = this._timer.setInterval(async () => {
-                this._timer.clearInterval(timerHandle);
+            const timerHandle = setInterval(async () => {
+                clearInterval(timerHandle);
 
                 try {
                     const session = await this._userManager.querySessionStatus();

--- a/src/utils/CryptoUtils.ts
+++ b/src/utils/CryptoUtils.ts
@@ -1,3 +1,4 @@
+import CryptoJS from "crypto-js/core.js";
 import sha256 from "crypto-js/sha256.js";
 import Base64 from "crypto-js/enc-base64.js";
 import Utf8 from "crypto-js/enc-utf8.js";
@@ -10,26 +11,17 @@ const UUID_V4_TEMPLATE = "10000000-1000-4000-8000-100000000000";
  * @internal
  */
 export class CryptoUtils {
-
-    private static _cryptoUUIDv4(): string {
-        return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
-            (+c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16),
-        );
-    }
-
-    private static _UUIDv4(): string {
-        return UUID_V4_TEMPLATE.replace(/[018]/g, c =>
-            (+c ^ Math.random() * 16 >> +c / 4).toString(16),
-        );
+    private static _randomWord(): number {
+        return CryptoJS.lib.WordArray.random(1).words[0];
     }
 
     /**
      * Generates RFC4122 version 4 guid
      */
     public static generateUUIDv4(): string {
-        const hasRandomValues = typeof window !== "undefined" && window.crypto &&
-            Object.prototype.hasOwnProperty.call(window.crypto, "getRandomValues");
-        const uuid = hasRandomValues ? CryptoUtils._cryptoUUIDv4() : CryptoUtils._UUIDv4();
+        const uuid = UUID_V4_TEMPLATE.replace(/[018]/g, c =>
+            (+c ^ CryptoUtils._randomWord() & 15 >> +c / 4).toString(16),
+        );
         return uuid.replace(/-/g, "");
     }
 
@@ -49,7 +41,7 @@ export class CryptoUtils {
             return Base64.stringify(hashed).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
         }
         catch (err) {
-            Logger.error("CryptoUtils", err instanceof Error ? err.message : err);
+            Logger.error("CryptoUtils", err);
             throw err;
         }
     }

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -8,29 +8,8 @@ const DefaultTimerDurationInSeconds = 5; // seconds
 /**
  * @internal
  */
-export type IntervalTimer = {
-    setInterval: (cb: () => void, duration?: number | undefined) => number;
-    clearInterval: (handle: number) => void;
-};
-
-/**
- * @internal
- */
-export const g_timer: IntervalTimer = {
-    setInterval: function (cb: () => void, duration?: number): number {
-        return setInterval(cb, duration);
-    },
-    clearInterval: function (handle: number): void {
-        return clearInterval(handle);
-    },
-};
-
-/**
- * @internal
- */
 export class Timer extends Event<[void]> {
-    private _timer = g_timer;
-    private _timerHandle: number | null = null;
+    private _timerHandle: ReturnType<typeof setInterval> | null = null;
     private _expiration = 0;
 
     // get the time
@@ -63,7 +42,7 @@ export class Timer extends Event<[void]> {
         if (durationInSeconds < timerDurationInSeconds) {
             timerDurationInSeconds = durationInSeconds;
         }
-        this._timerHandle = this._timer.setInterval(this._callback, timerDurationInSeconds * 1000);
+        this._timerHandle = setInterval(this._callback, timerDurationInSeconds * 1000);
     }
 
     public get expiration(): number {
@@ -73,7 +52,7 @@ export class Timer extends Event<[void]> {
     public cancel(): void {
         if (this._timerHandle) {
             this._logger.debug("cancel: ", this._name);
-            this._timer.clearInterval(this._timerHandle);
+            clearInterval(this._timerHandle);
             this._timerHandle = null;
         }
     }


### PR DESCRIPTION
This removes more unnecessary usage of `window`. The most important change here is that `window.crypto.getRandomValues()` is replaced by `CryptoJS.lib.WordArray.random()`. Under the hood, CryptoJS uses `window.crypto` but falls back to `window.msCrypto` (IE11) and `require('crypto')` (Node.js).