### PR TITLE
feat: return destructor functions from event listener methods

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -12,8 +12,8 @@ export class AccessTokenEvents {
     constructor({ expiringNotificationTimeInSeconds }: {
         expiringNotificationTimeInSeconds: number;
     });
-    addAccessTokenExpired(cb: AccessTokenCallback): void;
-    addAccessTokenExpiring(cb: AccessTokenCallback): void;
+    addAccessTokenExpired(cb: AccessTokenCallback): () => void;
+    addAccessTokenExpiring(cb: AccessTokenCallback): () => void;
     // (undocumented)
     load(container: User): void;
     // Warning: (ae-forgotten-export) The symbol "Logger" needs to be exported by the entry point index.d.ts
@@ -823,12 +823,12 @@ export class UserManager {
 // @public (undocumented)
 export class UserManagerEvents extends AccessTokenEvents {
     constructor(settings: UserManagerSettingsStore);
-    addSilentRenewError(cb: SilentRenewErrorCallback): void;
-    addUserLoaded(cb: UserLoadedCallback): void;
-    addUserSessionChanged(cb: UserSessionChangedCallback): void;
-    addUserSignedIn(cb: UserSignedInCallback): void;
-    addUserSignedOut(cb: UserSignedOutCallback): void;
-    addUserUnloaded(cb: UserUnloadedCallback): void;
+    addSilentRenewError(cb: SilentRenewErrorCallback): () => void;
+    addUserLoaded(cb: UserLoadedCallback): () => void;
+    addUserSessionChanged(cb: UserSessionChangedCallback): () => void;
+    addUserSignedIn(cb: UserSignedInCallback): () => void;
+    addUserSignedOut(cb: UserSignedOutCallback): () => void;
+    addUserUnloaded(cb: UserUnloadedCallback): () => void;
     // (undocumented)
     load(user: User, raiseEvent?: boolean): void;
     // @internal (undocumented)

--- a/src/AccessTokenEvents.ts
+++ b/src/AccessTokenEvents.ts
@@ -68,8 +68,8 @@ export class AccessTokenEvents {
     /**
      * Add callback: Raised prior to the access token expiring.
      */
-    public addAccessTokenExpiring(cb: AccessTokenCallback): void {
-        this._expiringTimer.addHandler(cb);
+    public addAccessTokenExpiring(cb: AccessTokenCallback): () => void {
+        return this._expiringTimer.addHandler(cb);
     }
     /**
      * Remove callback: Raised prior to the access token expiring.
@@ -81,8 +81,8 @@ export class AccessTokenEvents {
     /**
      * Add callback: Raised after the access token has expired.
      */
-    public addAccessTokenExpired(cb: AccessTokenCallback): void {
-        this._expiredTimer.addHandler(cb);
+    public addAccessTokenExpired(cb: AccessTokenCallback): () => void {
+        return this._expiredTimer.addHandler(cb);
     }
     /**
      * Remove callback: Raised after the access token has expired.

--- a/src/UserManagerEvents.ts
+++ b/src/UserManagerEvents.ts
@@ -70,40 +70,40 @@ export class UserManagerEvents extends AccessTokenEvents {
     /**
      * Add callback: Raised when a user session has been established (or re-established).
      */
-    public addUserLoaded(cb: UserLoadedCallback): void {
-        this._userLoaded.addHandler(cb);
+    public addUserLoaded(cb: UserLoadedCallback): () => void {
+        return this._userLoaded.addHandler(cb);
     }
     /**
      * Remove callback: Raised when a user session has been established (or re-established).
      */
     public removeUserLoaded(cb: UserLoadedCallback): void {
-        this._userLoaded.removeHandler(cb);
+        return this._userLoaded.removeHandler(cb);
     }
 
     /**
      * Add callback: Raised when a user session has been terminated.
      */
-    public addUserUnloaded(cb: UserUnloadedCallback): void {
-        this._userUnloaded.addHandler(cb);
+    public addUserUnloaded(cb: UserUnloadedCallback): () => void {
+        return this._userUnloaded.addHandler(cb);
     }
     /**
      * Remove callback: Raised when a user session has been terminated.
      */
     public removeUserUnloaded(cb: UserUnloadedCallback): void {
-        this._userUnloaded.removeHandler(cb);
+        return this._userUnloaded.removeHandler(cb);
     }
 
     /**
      * Add callback: Raised when the automatic silent renew has failed.
      */
-    public addSilentRenewError(cb: SilentRenewErrorCallback): void {
-        this._silentRenewError.addHandler(cb);
+    public addSilentRenewError(cb: SilentRenewErrorCallback): () => void {
+        return this._silentRenewError.addHandler(cb);
     }
     /**
      * Remove callback: Raised when the automatic silent renew has failed.
      */
     public removeSilentRenewError(cb: SilentRenewErrorCallback): void {
-        this._silentRenewError.removeHandler(cb);
+        return this._silentRenewError.removeHandler(cb);
     }
     /**
      * @internal
@@ -116,8 +116,8 @@ export class UserManagerEvents extends AccessTokenEvents {
     /**
      * Add callback: Raised when the user is signed in.
      */
-    public addUserSignedIn(cb: UserSignedInCallback): void {
-        this._userSignedIn.addHandler(cb);
+    public addUserSignedIn(cb: UserSignedInCallback): () => void {
+        return this._userSignedIn.addHandler(cb);
     }
     /**
      * Remove callback: Raised when the user is signed in.
@@ -136,8 +136,8 @@ export class UserManagerEvents extends AccessTokenEvents {
     /**
      * Add callback: Raised when the user's sign-in status at the OP has changed.
      */
-    public addUserSignedOut(cb: UserSignedOutCallback): void {
-        this._userSignedOut.addHandler(cb);
+    public addUserSignedOut(cb: UserSignedOutCallback): () => void {
+        return this._userSignedOut.addHandler(cb);
     }
     /**
      * Remove callback: Raised when the user's sign-in status at the OP has changed.
@@ -156,8 +156,8 @@ export class UserManagerEvents extends AccessTokenEvents {
     /**
      * Add callback: Raised when the user session changed (when `monitorSession` is set)
      */
-    public addUserSessionChanged(cb: UserSessionChangedCallback): void {
-        this._userSessionChanged.addHandler(cb);
+    public addUserSessionChanged(cb: UserSessionChangedCallback): () => void {
+        return this._userSessionChanged.addHandler(cb);
     }
     /**
      * Remove callback: Raised when the user session changed (when `monitorSession` is set)


### PR DESCRIPTION
This updates the `addAccessTokenExpired`, `addUserLoaded`, etc. methods to forward the destructor function returned by the underlying `Events` class. This is a nice pattern to support since React users can integrate it into a useEffect hook:

```javascript
useEffect(() => {
  return userManager.events.addAccessTokenExpiring(() => setSessionExpiring(true));
}, [userManager.events])