### PR TITLE
Refactor revoke token

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,35 +1,44 @@
 ## oidc-client v1.11.5 &rarr; oidc-client-ts v2.0.0
 
 Ported library from JavaScript to TypeScript. The API is largely
-backwards-compatible. The support for the outdated implicit flow has been
+backwards-compatible. The support for the deprecated implicit flow has been
 removed.
 
 ### [OidcClientSettings](https://authts.github.io/oidc-client-ts/interfaces/OidcClientSettings.html)
 
 - the following properties are now **required**: `authority`, `client_id`,
   `redirect_uri`
-- renamed `clockSkew` &rarr; `clockSkewInSeconds`
-- renamed `staleStateAge` &rarr; `staleStateAgeInSeconds`
+- the following properties were **renamed**:
+  - `clockSkew` &rarr; `clockSkewInSeconds`
+  - `staleStateAge` &rarr; `staleStateAgeInSeconds`
+- default of `loadUserInfo` changed from `true` &rarr; `false`
 - removed `ResponseValidatorCtor` and `MetadataServiceCtor`
-  - if necessary `OidcClient` / `UserManager` classes may be extended
+  - if necessary `OidcClient` / `UserManager` classes may be extended to alter
+    their behavior
 - restricted `response_type` to `code` flow only (PKCE remains optional)
   - as in oidc-client 1.x, OAuth 2.0 hybrid flows are not supported
-- default of `loadUserInfo` changed from `true` &rarr; `false`
 
 ### [UserManagerSettings](https://authts.github.io/oidc-client-ts/interfaces/UserManagerSettings.html)
 
-- renamed `accessTokenExpiringNotificationTime` &rarr;
-  `accessTokenExpiringNotificationTimeInSeconds`
-- changed `silentRequestTimeout` (milliseconds) &rarr;
-  `silentRequestTimeoutInSeconds`
-- changed `checkSessionInterval` (milliseconds) &rarr;
-  `checkSessionIntervalInSeconds`
-- default of `automaticSilentRenew` changed from `false` &rarr; `true`
-- default of `validateSubOnSilentRenew` changed from `false` &rarr; `true`
-- default of `includeIdTokenInSilentRenew` changed from `true` &rarr; `false`
-- default of `monitorSession` changed from `true` &rarr; `false`
+- the following properties were **renamed**:
+  - `accessTokenExpiringNotificationTime` &rarr;
+    `accessTokenExpiringNotificationTimeInSeconds`
+  - `silentRequestTimeout` (milliseconds) &rarr; `silentRequestTimeoutInSeconds`
+  - `checkSessionInterval` (milliseconds) &rarr; `checkSessionIntervalInSeconds`
+  - `revokeAccessTokenOnSignout` &rarr; `revokeTokensOnSignout`
+- the following properties have new **default values**:
+  - `automaticSilentRenew` changed from `false` &rarr; `true`
+  - `validateSubOnSilentRenew` changed from `false` &rarr; `true`
+  - `includeIdTokenInSilentRenew` changed from `true` &rarr; `false`
+  - `monitorSession` changed from `true` &rarr; `false`
 - type of `popupWindowFeatures` changed from a string to a dictionary
-  - additionally, its defaults are responsive to the opener window's dimensions
+  - additionally, its default dimensions are now responsive to the opener
+    window's
+- a new property `revokeTokenTypes: ('access_token' | 'refresh_token')[]` was
+  added
+  - by default, `UserManager` will attempt revoking both token types when
+    `revokeTokensOnSignout` is `true`. Compared to 1.x, sign out will now fail
+    if revocations fail.
 
 ### [UserManager](https://authts.github.io/oidc-client-ts/classes/UserManager.html)
 
@@ -37,3 +46,7 @@ removed.
   `signoutPopupCallback(true)` is no longer supported. Instead use
   `signoutPopupCallback(undefined, true)` or preferably,
   `signoutPopupCallback(location.href, true)`.
+- renamed `revokeAccessToken()` &rarr; `revokeTokens(types?)`
+  - Compared to 1.x, this function will now throw if _any_ revocation of the
+    types specified fail. Uses the `revokeTokenTypes` setting when no `types`
+    are passed.

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -93,10 +93,12 @@ export class ErrorResponse extends Error {
         error_uri?: string;
         state?: unknown;
         session_state?: string;
-    });
+    },
+    form?: URLSearchParams | undefined);
     readonly error: string;
     readonly error_description: string | undefined;
     readonly error_uri: string | undefined;
+    readonly form?: URLSearchParams | undefined;
     readonly name: string;
     // (undocumented)
     readonly session_state: string | undefined;

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -180,21 +180,23 @@ export class MetadataService {
     // (undocumented)
     getIssuer(): Promise<string>;
     // (undocumented)
-    getKeysEndpoint(optional?: true): Promise<string | undefined>;
-    // (undocumented)
     getKeysEndpoint(optional: false): Promise<string>;
+    // (undocumented)
+    getKeysEndpoint(optional?: true): Promise<string | undefined>;
     // (undocumented)
     getMetadata(): Promise<Partial<OidcMetadata>>;
     // (undocumented)
     protected _getMetadataProperty(name: keyof OidcMetadata, optional?: boolean): Promise<string | boolean | string[] | undefined>;
     // (undocumented)
-    getRevocationEndpoint(optional?: boolean): Promise<string | undefined>;
+    getRevocationEndpoint(optional: false): Promise<string>;
+    // (undocumented)
+    getRevocationEndpoint(optional?: true): Promise<string | undefined>;
     // (undocumented)
     getSigningKeys(): Promise<SigningKey[] | null>;
     // (undocumented)
-    getTokenEndpoint(optional?: true): Promise<string | undefined>;
-    // (undocumented)
     getTokenEndpoint(optional: false): Promise<string>;
+    // (undocumented)
+    getTokenEndpoint(optional?: true): Promise<string | undefined>;
     // (undocumented)
     getUserInfoEndpoint(): Promise<string>;
     // (undocumented)
@@ -439,6 +441,9 @@ export interface RedirectParams {
     // (undocumented)
     redirectMethod?: "replace" | "assign";
 }
+
+// @public (undocumented)
+export type RevokeTokensTypes = UserManagerSettings["revokeTokenTypes"];
 
 // @public (undocumented)
 export class SessionMonitor {
@@ -766,9 +771,9 @@ export class UserManager {
     protected readonly _redirectNavigator: RedirectNavigator;
     removeUser(): Promise<void>;
     // (undocumented)
-    revokeAccessToken(): Promise<void>;
+    protected _revokeInternal(user: User | null, types?: ("access_token" | "refresh_token")[]): Promise<void>;
     // (undocumented)
-    protected _revokeInternal(user: User | null, optional: boolean): Promise<boolean>;
+    revokeTokens(types?: RevokeTokensTypes): Promise<void>;
     // (undocumented)
     protected readonly _sessionMonitor: SessionMonitor | null;
     readonly settings: UserManagerSettingsStore;
@@ -868,7 +873,8 @@ export interface UserManagerSettings extends OidcClientSettings {
     // (undocumented)
     query_status_response_type?: string;
     redirectMethod?: "replace" | "assign";
-    revokeAccessTokenOnSignout?: boolean;
+    revokeTokensOnSignout?: boolean;
+    revokeTokenTypes?: ("access_token" | "refresh_token")[];
     silent_redirect_uri?: string;
     silentRequestTimeoutInSeconds?: number;
     // (undocumented)
@@ -905,7 +911,9 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     // (undocumented)
     readonly redirectMethod: "replace" | "assign";
     // (undocumented)
-    readonly revokeAccessTokenOnSignout: boolean;
+    readonly revokeTokensOnSignout: boolean;
+    // (undocumented)
+    readonly revokeTokenTypes: ("access_token" | "refresh_token")[];
     // (undocumented)
     readonly silent_redirect_uri: string | undefined;
     // (undocumented)

--- a/src/ErrorResponse.ts
+++ b/src/ErrorResponse.ts
@@ -12,7 +12,7 @@ import { Logger } from "./utils";
  */
 export class ErrorResponse extends Error {
     /** Marker to detect class: "ErrorResponse" */
-    public readonly name: string;
+    public readonly name: string = "ErrorResponse";
 
     /** An error code string that can be used to classify the types of errors that occur and to respond to errors. */
     public readonly error: string;
@@ -29,18 +29,20 @@ export class ErrorResponse extends Error {
 
     public readonly session_state: string | undefined;
 
-    public constructor(args: {
-        error?: string; error_description?: string; error_uri?: string;
-        state?: unknown; session_state?: string;
-    }) {
+    public constructor(
+        args: {
+            error?: string; error_description?: string; error_uri?: string;
+            state?: unknown; session_state?: string;
+        },
+        /** The x-www-form-urlencoded request body sent to the authority server */
+        public readonly form?: URLSearchParams,
+    ) {
         super(args.error_description || args.error);
 
         if (!args.error) {
             Logger.error("ErrorResponse", "No error passed");
             throw new Error("No error passed");
         }
-
-        this.name = "ErrorResponse";
 
         this.error = args.error;
         this.error_description = args.error_description;

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -117,7 +117,7 @@ export class JsonService {
         if (!response.ok) {
             this._logger.error("postForm: Error from server:", json);
             if (json.error) {
-                throw new ErrorResponse(json);
+                throw new ErrorResponse(json, body);
             }
             throw new Error(`${response.statusText} (${response.status}): ${JSON.stringify(json)}`);
         }

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -86,8 +86,8 @@ export class MetadataService {
         return this._getMetadataProperty("userinfo_endpoint") as Promise<string>;
     }
 
-    public getTokenEndpoint(optional?: true): Promise<string | undefined>
     public getTokenEndpoint(optional: false): Promise<string>
+    public getTokenEndpoint(optional?: true): Promise<string | undefined>
     public getTokenEndpoint(optional = true): Promise<string | undefined> {
         return this._getMetadataProperty("token_endpoint", optional) as Promise<string | undefined>;
     }
@@ -100,12 +100,14 @@ export class MetadataService {
         return this._getMetadataProperty("end_session_endpoint", true) as Promise<string | undefined>;
     }
 
+    public getRevocationEndpoint(optional: false): Promise<string>
+    public getRevocationEndpoint(optional?: true): Promise<string | undefined>
     public getRevocationEndpoint(optional = true): Promise<string | undefined> {
         return this._getMetadataProperty("revocation_endpoint", optional) as Promise<string | undefined>;
     }
 
-    public getKeysEndpoint(optional?: true): Promise<string | undefined>
     public getKeysEndpoint(optional: false): Promise<string>
+    public getKeysEndpoint(optional?: true): Promise<string | undefined>
     public getKeysEndpoint(optional = true): Promise<string | undefined> {
         return this._getMetadataProperty("jwks_uri", optional) as Promise<string | undefined>;
     }

--- a/src/TokenClient.test.ts
+++ b/src/TokenClient.test.ts
@@ -206,20 +206,6 @@ describe("TokenClient", () => {
                 .rejects.toThrow(Error);
         });
 
-        it("should gracefully handle optional", async () => {
-            // arrange
-            jest.spyOn(subject["_metadataService"], "getRevocationEndpoint")
-                .mockResolvedValue(undefined);
-            const postFormMock = jest.spyOn(subject["_jsonService"], "postForm")
-                .mockResolvedValue({});
-
-            // act
-            await subject.revoke({ token: "token", token_type_hint: "access_token" });
-
-            // assert
-            expect(postFormMock).not.toBeCalled();
-        });
-
         it("should call postForm", async () => {
             // arrange
             settings.client_secret = "client_secret";

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -36,8 +36,6 @@ export interface ExchangeRefreshTokenArgs {
 export interface RevokeArgs {
     token: string;
     token_type_hint: "access_token" | "refresh_token";
-
-    optional?: boolean;
 }
 
 /**
@@ -159,20 +157,13 @@ export class TokenClient {
         return response;
     }
 
-    public async revoke({
-        optional = false,
-        ...args
-    }: RevokeArgs): Promise<void> {
+    public async revoke(args: RevokeArgs): Promise<void> {
         if (!args.token) {
             this._logger.error("revoke: No token passed");
             throw new Error("A token is required");
         }
 
-        const url = await this._metadataService.getRevocationEndpoint(optional);
-        if (!url) {
-            // not required, so don't error and just return
-            return;
-        }
+        const url = await this._metadataService.getRevocationEndpoint(false);
 
         this._logger.debug("revoke: Received revocation endpoint, revoking " + args.token_type_hint);
 

--- a/src/UserManagerSettings.test.ts
+++ b/src/UserManagerSettings.test.ts
@@ -268,11 +268,11 @@ describe("UserManagerSettings", () => {
                 authority: "authority",
                 client_id: "client",
                 redirect_uri: "redirect",
-                revokeAccessTokenOnSignout : true,
+                revokeTokensOnSignout : true,
             });
 
             // assert
-            expect(subject.revokeAccessTokenOnSignout).toEqual(true);
+            expect(subject.revokeTokensOnSignout).toEqual(true);
         });
     });
 

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -48,8 +48,14 @@ export interface UserManagerSettings extends OidcClientSettings {
     query_status_response_type?: string;
     stopCheckSessionOnError?: boolean;
 
+    /**
+     * The `token_type_hint`s to pass to the authority server by default (default: ["access_token", "refresh_token"])
+     *
+     * Token types will be revoked in the same order as they are given here.
+     */
+    revokeTokenTypes?: ("access_token" | "refresh_token")[];
     /** Will invoke the revocation endpoint on signout if there is an access token for the user (default: false) */
-    revokeAccessTokenOnSignout?: boolean;
+    revokeTokensOnSignout?: boolean;
     /** The number of seconds before an access token is to expire to raise the accessTokenExpiring event (default: 60) */
     accessTokenExpiringNotificationTimeInSeconds?: number;
 
@@ -85,7 +91,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     public readonly query_status_response_type: string | undefined;
     public readonly stopCheckSessionOnError: boolean;
 
-    public readonly revokeAccessTokenOnSignout: boolean;
+    public readonly revokeTokenTypes: ("access_token" | "refresh_token")[];
+    public readonly revokeTokensOnSignout: boolean;
     public readonly accessTokenExpiringNotificationTimeInSeconds: number;
 
     public readonly userStore: WebStorageStateStore;
@@ -110,7 +117,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
             query_status_response_type,
             stopCheckSessionOnError = true,
 
-            revokeAccessTokenOnSignout = false,
+            revokeTokenTypes = ["access_token", "refresh_token"],
+            revokeTokensOnSignout = false,
             accessTokenExpiringNotificationTimeInSeconds = DefaultAccessTokenExpiringNotificationTimeInSeconds,
 
             userStore,
@@ -141,7 +149,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
             this.query_status_response_type = "code";
         }
 
-        this.revokeAccessTokenOnSignout = revokeAccessTokenOnSignout;
+        this.revokeTokenTypes = revokeTokenTypes;
+        this.revokeTokensOnSignout = revokeTokensOnSignout;
         this.accessTokenExpiringNotificationTimeInSeconds = accessTokenExpiringNotificationTimeInSeconds;
 
         if (userStore) {


### PR DESCRIPTION
Resolves #262.

There's two questions that I couldn't really answer for myself while refactoring this:

1. Why does revoking tokens mutate the User? I see that since 1.x, `access_token`, `refresh_token`, `token_type`, etc. were updated to be set to empty strings after revocation rather than `null`. I don't see any benefit to doing this client-side since it would lead to unnecessarily opaque errors. If I make an API request after revoking a token, I'd rather be alerted by the API that my token is revoked and no longer valid rather than it rejecting it because I'm suddenly sending an empty string for an access token. I can see an argument for removing `refresh_token`, but everything else seems like it should stay put until the user signs out.

2. Why is revocation success optional on sign out? `revokeTokensOnSignout` needs to be explicitly opted into, so it feels sloppy to not alert the application when revocation fails there.