### PR TITLE
Update user profile after refresh token requests

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -563,7 +563,7 @@ export class SigninResponse {
     // (undocumented)
     access_token: string;
     // (undocumented)
-    readonly code: string;
+    readonly code: string | undefined;
     // (undocumented)
     error: string | undefined;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -228,9 +228,9 @@ export class OidcClient {
     // (undocumented)
     clearStaleState(): Promise<void>;
     // (undocumented)
-    createSigninRequest({ response_type, scope, redirect_uri, state, prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values, resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo, }: CreateSigninRequestArgs): Promise<SigninRequest>;
+    createSigninRequest({ state, request, request_uri, request_type, id_token_hint, login_hint, skipUserInfo, response_type, scope, redirect_uri, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, extraQueryParams, extraTokenParams, }: CreateSigninRequestArgs): Promise<SigninRequest>;
     // (undocumented)
-    createSignoutRequest({ state, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
+    createSignoutRequest({ state, id_token_hint, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
     // (undocumented)
     protected readonly _logger: Logger;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -250,7 +250,17 @@ export class OidcClient {
         response: SignoutResponse;
     }>;
     // (undocumented)
+    revokeToken(token: string, type?: "access_token" | "refresh_token"): Promise<void>;
+    // (undocumented)
     readonly settings: OidcClientSettingsStore;
+    // Warning: (ae-forgotten-export) The symbol "TokenClient" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected readonly _tokenClient: TokenClient;
+    // Warning: (ae-forgotten-export) The symbol "RefreshState" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    useRefreshToken(state: RefreshState): Promise<SigninResponse>;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -740,18 +750,18 @@ export class User {
     });
     access_token: string;
     get expired(): boolean | undefined;
-    expires_at: number | undefined;
+    expires_at?: number;
     get expires_in(): number | undefined;
     set expires_in(value: number | undefined);
     // (undocumented)
     static fromStorageString(storageString: string): User;
-    id_token: string | undefined;
+    id_token?: string;
     profile: UserProfile;
-    refresh_token: string | undefined;
-    scope: string | undefined;
+    refresh_token?: string;
+    scope?: string;
     get scopes(): string[];
-    session_state: string | undefined;
-    readonly state: unknown | undefined;
+    session_state?: string;
+    readonly state: unknown;
     token_type: string;
     // (undocumented)
     toStorageString(): string;
@@ -834,16 +844,10 @@ export class UserManager {
     stopSilentRenew(): void;
     // (undocumented)
     storeUser(user: User | null): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "TokenClient" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    protected readonly _tokenClient: TokenClient;
-    // (undocumented)
-    protected _useRefreshToken(user: User): Promise<User>;
+    protected _useRefreshToken(state: RefreshState): Promise<User>;
     // (undocumented)
     protected get _userStoreKey(): string;
-    // (undocumented)
-    protected _validateIdTokenFromTokenRefreshToken(profile: UserProfile, id_token: string): Promise<void>;
 }
 
 // @public (undocumented)

--- a/samples/Parcel/oidc.js
+++ b/samples/Parcel/oidc.js
@@ -29,6 +29,13 @@ function prependBaseUrlToMetadata(baseUrl) {
     }
 }
 
+function encodeBase64Url(str) {
+    return Buffer.from(str).toString('base64')
+        .replace(/=/g, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}
+
 var keys = {
     keys: [
         {
@@ -62,7 +69,7 @@ module.exports = function(baseUrl, app) {
 
     app.get(authorizationPath, function(req, res) {
         var url = new URL(req.query.redirect_uri);
-        const paramsKey = req.query.response_mode === "fragment" ? "hash" : "query";
+        const paramsKey = req.query.response_mode === "fragment" ? "hash" : "search";
         const params = new URLSearchParams(url[paramsKey].slice(1));
         var state = req.query.state;
         if (state) {
@@ -77,8 +84,7 @@ module.exports = function(baseUrl, app) {
         if (req.query.display === 'popup') {
             res.status(200);
             res.type('text/html')
-            res.send(`
-<!DOCTYPE html>
+            res.send(`<!DOCTYPE html>
 <html>
     <head>
         <meta http-equiv="refresh" content="3;url=${url.href}" />
@@ -112,7 +118,13 @@ module.exports = function(baseUrl, app) {
     });
 
     app.post(tokenPath, function(req, res) {
-        res.json({});
+        res.json({
+            access_token: 'foobar',
+            token_type: 'Bearer',
+            id_token: [{ alg: 'none' }, claims]
+                .map(obj => JSON.stringify(obj))
+                .map(encodeBase64Url).join('.') + '.',
+        });
     });
 
 };

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -358,15 +358,15 @@ describe("OidcClient", () => {
                 request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
-                .mockImplementation(() => Promise.resolve(item.toStorageString()));
+                .mockImplementation(async () => item.toStorageString());
             const validateSigninResponseMock = jest.spyOn(subject["_validator"], "validateSigninResponse")
-                .mockImplementation((_s, r) => Promise.resolve(r));
+                .mockResolvedValue();
 
             // act
             const response = await subject.processSigninResponse("http://app/cb?state=1");
 
             // assert
-            expect(validateSigninResponseMock).toBeCalledWith(item, response);
+            expect(validateSigninResponseMock).toBeCalledWith(response, item);
         });
     });
 
@@ -564,13 +564,13 @@ describe("OidcClient", () => {
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(() => Promise.resolve(item.toStorageString()));
             const validateSignoutResponse = jest.spyOn(subject["_validator"], "validateSignoutResponse")
-                .mockImplementation((_s, r) => r);
+                .mockReturnValue();
 
             // act
             const response = await subject.processSignoutResponse("http://app/cb?state=1&error=foo");
 
             // assert
-            expect(validateSignoutResponse).toBeCalledWith(item, response);
+            expect(validateSignoutResponse).toBeCalledWith(response, item);
         });
     });
 
@@ -627,15 +627,15 @@ describe("OidcClient", () => {
                 request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
-                .mockImplementation(() => Promise.resolve(item.toStorageString()));
+                .mockImplementation(async () => item.toStorageString());
             const validateSignoutResponse = jest.spyOn(subject["_validator"], "validateSignoutResponse")
-                .mockImplementation((_s, r) => r);
+                .mockReturnValue();
 
             // act
             const response = await subject.processSignoutResponse("http://app/cb?state=1");
 
             // assert
-            expect(validateSignoutResponse).toBeCalledWith(item, response);
+            expect(validateSignoutResponse).toBeCalledWith(response, item);
         });
 
         it("should call validator with state even if error in response", async () => {
@@ -646,15 +646,15 @@ describe("OidcClient", () => {
                 request_type: "type",
             });
             jest.spyOn(subject.settings.stateStore, "remove")
-                .mockImplementation(() => Promise.resolve(item.toStorageString()));
+                .mockImplementation(async () => item.toStorageString());
             const validateSignoutResponse = jest.spyOn(subject["_validator"], "validateSignoutResponse")
-                .mockImplementation((_s, r) => r);
+                .mockReturnValue();
 
             // act
             const response = await subject.processSignoutResponse("http://app/cb?state=1&error=foo");
 
             // assert
-            expect(validateSignoutResponse).toBeCalledWith(item, response);
+            expect(validateSignoutResponse).toBeCalledWith(response, item);
         });
     });
 

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -1,15 +1,17 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "./utils";
+import { JwtPayload, JwtUtils, Log } from "./utils";
 import { OidcClient } from "./OidcClient";
-import { OidcClientSettings, OidcClientSettingsStore } from "./OidcClientSettings";
+import { OidcClientSettingsStore } from "./OidcClientSettings";
 import { SigninState } from "./SigninState";
 import { State } from "./State";
 import { SigninRequest } from "./SigninRequest";
 import { SignoutRequest } from "./SignoutRequest";
 import { SignoutResponse } from "./SignoutResponse";
 import type { ErrorResponse } from "./ErrorResponse";
+import { RefreshState } from "./RefreshState";
+import { SigninResponse } from "./SigninResponse";
 
 describe("OidcClient", () => {
     let subject: OidcClient;
@@ -18,16 +20,16 @@ describe("OidcClient", () => {
         Log.logger = console;
         Log.level = Log.NONE;
 
-        // restore spyOn
-        jest.restoreAllMocks();
-
-        const settings: OidcClientSettings = {
+        subject = new OidcClient({
             authority: "authority",
             client_id: "client",
             redirect_uri: "redirect",
             post_logout_redirect_uri: "http://app",
-        };
-        subject = new OidcClient(settings);
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     describe("constructor", () => {
@@ -47,24 +49,6 @@ describe("OidcClient", () => {
     });
 
     describe("createSigninRequest", () => {
-
-        it("should return a promise", async () => {
-            // arrange
-            const args = {
-                redirect_uri: "redirect",
-                response_type: "response",
-                scope: "scope",
-            };
-            jest.spyOn(subject.metadataService, "getAuthorizationEndpoint").mockImplementation(() => Promise.resolve("http://sts/authorize"));
-
-            // act
-            const p = subject.createSigninRequest(args);
-
-            // assert
-            expect(p).toBeInstanceOf(Promise);
-            // eslint-disable-next-line no-empty
-            try { await p; } catch {}
-        });
 
         it("should return SigninRequest", async () => {
             // arrange
@@ -242,16 +226,6 @@ describe("OidcClient", () => {
 
     describe("readSigninResponseState", () => {
 
-        it("should return a promise", async () => {
-            // act
-            const p = subject.readSigninResponseState("http://app/cb?state=state");
-
-            // asssert
-            expect(p).toBeInstanceOf(Promise);
-            // eslint-disable-next-line no-empty
-            try { await p; } catch {}
-        });
-
         it("should fail if no state on response", async () => {
             // arrange
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve("state"));
@@ -307,16 +281,6 @@ describe("OidcClient", () => {
     });
 
     describe("processSigninResponse", () => {
-        it("should return a promise", async () => {
-            // act
-            const p = subject.processSigninResponse("http://app/cb?state=state");
-
-            // assert
-            expect(p).toBeInstanceOf(Promise);
-            // eslint-disable-next-line no-empty
-            try { await p; } catch {}
-        });
-
         it("should fail if no state on response", async () => {
             // arrange
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve("state"));
@@ -370,21 +334,79 @@ describe("OidcClient", () => {
         });
     });
 
-    describe("createSignoutRequest", () => {
-
-        it("should return a promise", async () => {
+    describe("useRefreshToken", () => {
+        it("should return a SigninResponse", async () => {
             // arrange
-            jest.spyOn(subject.metadataService, "getEndSessionEndpoint").mockImplementation(() => Promise.resolve("http://sts/signout"));
+            const tokenResponse = {
+                access_token: "new_access_token",
+                scope: "replacement scope",
+            };
+            jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken").mockResolvedValue(tokenResponse);
+            const state = new RefreshState({
+                refresh_token: "refresh_token",
+                id_token: "id_token",
+                scope: "openid",
+            });
 
             // act
-            const p = subject.createSignoutRequest();
+            const response = await subject.useRefreshToken(state);
 
             // assert
-            expect(p).toBeInstanceOf(Promise);
-            // eslint-disable-next-line no-empty
-            try { await p; } catch {}
+            expect(response).toBeInstanceOf(SigninResponse);
+            expect(response).toMatchObject(tokenResponse);
         });
 
+        it("should preserve the scope", async () => {
+            // arrange
+            const tokenResponse = {
+                access_token: "new_access_token",
+            };
+            jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken").mockResolvedValue(tokenResponse);
+            const state = new RefreshState({
+                refresh_token: "refresh_token",
+                id_token: "id_token",
+                scope: "openid",
+            });
+
+            // act
+            const response = await subject.useRefreshToken(state);
+
+            // assert
+            expect(response).toBeInstanceOf(SigninResponse);
+            expect(response).toMatchObject(tokenResponse);
+            expect(response).toHaveProperty("scope", state.scope);
+        });
+
+        it("should enforce a matching sub claim", async () => {
+            // arrange
+            const profiles: Record<string, JwtPayload> = {
+                id_token: {
+                    sub: "current_sub",
+                },
+                new_id_token: {
+                    sub: "new_sub",
+                },
+            };
+            const tokenResponse = {
+                access_token: "new_access_token",
+                id_token: "new_id_token",
+            };
+            jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken").mockResolvedValue(tokenResponse);
+            jest.spyOn(JwtUtils, "decode").mockImplementation((token) => profiles[token]);
+            const state = new RefreshState({
+                refresh_token: "refresh_token",
+                id_token: "id_token",
+                scope: "openid",
+            });
+
+            // act
+            await expect(subject.useRefreshToken(state))
+                // assert
+                .rejects.toThrow("sub in id_token does not match current sub");
+        });
+    });
+
+    describe("createSignoutRequest", () => {
         it("should return SignoutRequest", async () => {
             // arrange
             jest.spyOn(subject.metadataService, "getEndSessionEndpoint").mockImplementation(() => Promise.resolve("http://sts/signout"));
@@ -660,16 +682,6 @@ describe("OidcClient", () => {
 
     describe("clearStaleState", () => {
 
-        it("should return a promise", async () => {
-            // act
-            const p = subject.clearStaleState();
-
-            // assert
-            expect(p).toBeInstanceOf(Promise);
-            // eslint-disable-next-line no-empty
-            try { await p; } catch {}
-        });
-
         it("should call State.clearStaleState", async () => {
             // arrange
             const clearStaleState = jest.spyOn(State, "clearStaleState");
@@ -679,6 +691,22 @@ describe("OidcClient", () => {
 
             // assert
             expect(clearStaleState).toBeCalled();
+        });
+    });
+
+    describe("revokeToken", () => {
+        it("revokes a token type", async () => {
+            // arrange
+            const revokeSpy = jest.spyOn(subject["_tokenClient"], "revoke").mockResolvedValue();
+
+            // act
+            await subject.revokeToken("token", "access_token");
+
+            // assert
+            expect(revokeSpy).toHaveBeenCalledWith({
+                token: "token",
+                token_type_hint: "access_token",
+            });
         });
     });
 });

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -71,27 +71,27 @@ export class OidcClient {
     }
 
     public async createSigninRequest({
-        response_type, scope, redirect_uri,
         state,
-        prompt, display, max_age, ui_locales, id_token_hint, login_hint, acr_values,
-        resource, request, request_uri, response_mode, extraQueryParams, extraTokenParams, request_type, skipUserInfo,
+        request,
+        request_uri,
+        request_type,
+        id_token_hint,
+        login_hint,
+        skipUserInfo,
+        response_type = this.settings.response_type,
+        scope = this.settings.scope,
+        redirect_uri = this.settings.redirect_uri,
+        prompt = this.settings.prompt,
+        display = this.settings.display,
+        max_age = this.settings.max_age,
+        ui_locales = this.settings.ui_locales,
+        acr_values = this.settings.acr_values,
+        resource = this.settings.resource,
+        response_mode = this.settings.response_mode,
+        extraQueryParams = this.settings.extraQueryParams,
+        extraTokenParams = this.settings.extraTokenParams,
     }: CreateSigninRequestArgs): Promise<SigninRequest> {
         this._logger.debug("createSigninRequest");
-
-        response_type = response_type || this.settings.response_type;
-        scope = scope || this.settings.scope;
-        redirect_uri = redirect_uri || this.settings.redirect_uri;
-
-        // id_token_hint, login_hint aren't allowed on _settings
-        prompt = prompt || this.settings.prompt;
-        display = display || this.settings.display;
-        max_age = max_age || this.settings.max_age;
-        ui_locales = ui_locales || this.settings.ui_locales;
-        acr_values = acr_values || this.settings.acr_values;
-        resource = resource || this.settings.resource;
-        response_mode = response_mode || this.settings.response_mode;
-        extraQueryParams = extraQueryParams || this.settings.extraQueryParams;
-        extraTokenParams = extraTokenParams || this.settings.extraTokenParams;
 
         if (response_type !== "code") {
             throw new Error("Only the Authorization Code flow (with PKCE) is supported");
@@ -152,12 +152,12 @@ export class OidcClient {
 
     public async createSignoutRequest({
         state,
-        id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
+        id_token_hint,
+        request_type,
+        post_logout_redirect_uri = this.settings.post_logout_redirect_uri,
+        extraQueryParams = this.settings.extraQueryParams,
     }: CreateSignoutRequestArgs = {}): Promise<SignoutRequest> {
         this._logger.debug("createSignoutRequest");
-
-        post_logout_redirect_uri = post_logout_redirect_uri || this.settings.post_logout_redirect_uri;
-        extraQueryParams = extraQueryParams || this.settings.extraQueryParams;
 
         const url = await this.metadataService.getEndSessionEndpoint();
         if (!url) {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -147,7 +147,8 @@ export class OidcClient {
 
         const { state, response } = await this.readSigninResponseState(url, true);
         this._logger.debug("processSigninResponse: Received state from storage; validating response");
-        return await this._validator.validateSigninResponse(state, response);
+        await this._validator.validateSigninResponse(response, state);
+        return response;
     }
 
     public async createSignoutRequest({
@@ -220,10 +221,11 @@ export class OidcClient {
         const { state, response } = await this.readSignoutResponseState(url, true);
         if (state) {
             this._logger.debug("processSignoutResponse: Received state from storage; validating response");
-            return this._validator.validateSignoutResponse(state, response);
+            this._validator.validateSignoutResponse(response, state);
+        } else {
+            this._logger.debug("processSignoutResponse: No state from storage; skipping validating response");
         }
 
-        this._logger.debug("processSignoutResponse: No state from storage; skipping validating response");
         return response;
     }
 

--- a/src/RefreshState.ts
+++ b/src/RefreshState.ts
@@ -1,6 +1,8 @@
 import type { State } from "./State";
 
 /**
+ * Fake state store implementation necessary for validating a refresh token requests.
+ *
  * @internal
  */
 export class RefreshState implements State {
@@ -24,6 +26,6 @@ export class RefreshState implements State {
     }
 
     public toStorageString(): string {
-        throw new Error("Method not implemented.");
+        throw new Error("This method was called in error - refresh requests do not store persistent state.");
     }
 }

--- a/src/RefreshState.ts
+++ b/src/RefreshState.ts
@@ -1,0 +1,29 @@
+import type { State } from "./State";
+
+/**
+ * @internal
+ */
+export class RefreshState implements State {
+    public readonly id = undefined as never;
+    public readonly created = undefined as never;
+    public readonly request_type = undefined;
+    public readonly data: unknown;
+
+    public readonly refresh_token: string;
+    public readonly id_token: string;
+    public readonly scope: string;
+
+    constructor(args: {
+        refresh_token: string;
+        id_token: string;
+        scope: string;
+    }) {
+        this.refresh_token = args.refresh_token;
+        this.id_token = args.id_token;
+        this.scope = args.scope;
+    }
+
+    public toStorageString(): string {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/src/SigninResponse.ts
+++ b/src/SigninResponse.ts
@@ -10,7 +10,7 @@ const OidcScope = "openid";
  * @public
  */
 export class SigninResponse {
-    public readonly code: string;
+    public readonly code: string | undefined;
     public readonly state_id: string | undefined;
 
     // updated by ResponseValidator
@@ -54,10 +54,10 @@ export class SigninResponse {
 
         // the default values here are for type safety only
         // ResponseValidator should check if these are empty and throw accordingly
-        this.code = values.get("code") ?? "";
         this.access_token = values.get("access_token") ?? "";
         this.token_type = values.get("token_type") ?? "";
 
+        this.code = values.get("code");
         this.state_id = values.get("state");
         this.id_token = values.get("id_token");
         this.session_state = values.get("session_state");

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -35,7 +35,7 @@ export interface ExchangeRefreshTokenArgs {
  */
 export interface RevokeArgs {
     token: string;
-    token_type_hint: "access_token" | "refresh_token";
+    token_type_hint?: "access_token" | "refresh_token";
 }
 
 /**
@@ -165,7 +165,7 @@ export class TokenClient {
 
         const url = await this._metadataService.getRevocationEndpoint(false);
 
-        this._logger.debug("revoke: Received revocation endpoint, revoking " + args.token_type_hint);
+        this._logger.debug(`revoke: Received revocation endpoint, revoking ${args.token_type_hint ?? "default type"}`);
 
         const params = new URLSearchParams();
         for (const [key, value] of Object.entries(args)) {

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -16,7 +16,7 @@ export interface ExchangeCodeArgs {
 
     grant_type?: string;
     code: string;
-    code_verifier: string;
+    code_verifier?: string;
 }
 
 /**

--- a/src/User.ts
+++ b/src/User.ts
@@ -70,10 +70,10 @@ export class User {
      * A JSON Web Token (JWT). Only provided if `openid` scope was requested.
      * The application can access the data decoded by using the `profile` property.
      */
-    public id_token: string | undefined;
+    public id_token?: string;
 
     /** The session state value returned from the OIDC provider. */
-    public session_state: string | undefined;
+    public session_state?: string;
 
     /**
      * The requested access token returned from the OIDC provider. The application can use this token to
@@ -86,22 +86,22 @@ export class User {
      * current access token expires. Refresh tokens are long-lived and can be used to maintain access to resources
      * for extended periods of time.
      */
-    public refresh_token: string | undefined;
+    public refresh_token?: string;
 
     /** Typically "Bearer" */
     public token_type: string;
 
     /** The scopes that the requested access token is valid for. */
-    public scope: string | undefined;
+    public scope?: string;
 
     /** The claims represented by a combination of the `id_token` and the user info endpoint. */
     public profile: UserProfile;
 
     /** The expires at returned from the OIDC provider. */
-    public expires_at: number | undefined;
+    public expires_at?: number;
 
     /** custom "state", which can be used by a caller to have "data" round tripped */
-    public readonly state: unknown | undefined;
+    public readonly state: unknown;
 
     public constructor(args: {
         id_token?: string; session_state?: string;

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -141,21 +141,15 @@ describe("UserManager", () => {
                 refresh_token: "bar",
             };
             subject["_loadUser"] = jest.fn().mockReturnValue(user);
-            const revokeSpy = jest.spyOn(subject["_tokenClient"], "revoke").mockResolvedValue(undefined);
+            const revokeSpy = jest.spyOn(subject["_client"], "revokeToken").mockResolvedValue(undefined);
             const storeUserSpy = jest.spyOn(subject, "storeUser").mockResolvedValue(undefined);
 
             // act
             await subject.revokeTokens(["access_token", "refresh_token"]);
 
             // assert
-            expect(revokeSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
-                token_type_hint: "access_token",
-                token: "foo",
-            }));
-            expect(revokeSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
-                token_type_hint: "refresh_token",
-                token: "bar",
-            }));
+            expect(revokeSpy).toHaveBeenNthCalledWith(1, "foo", "access_token");
+            expect(revokeSpy).toHaveBeenNthCalledWith(2, "bar", "refresh_token");
             expect(user).toMatchObject({
                 access_token: "foo",
                 refresh_token: null,
@@ -168,7 +162,7 @@ describe("UserManager", () => {
             subject["_loadUser"] = jest.fn().mockReturnValue({
                 access_token: "foo",
             });
-            const revokeSpy = jest.spyOn(subject["_tokenClient"], "revoke").mockResolvedValue(undefined);
+            const revokeSpy = jest.spyOn(subject["_client"], "revokeToken").mockResolvedValue(undefined);
             jest.spyOn(subject, "storeUser").mockResolvedValue(undefined);
 
             // act
@@ -176,9 +170,7 @@ describe("UserManager", () => {
 
             // assert
             expect(revokeSpy).toHaveBeenCalledTimes(1);
-            expect(revokeSpy).not.toHaveBeenCalledWith(expect.objectContaining({
-                token_type_hint: "refresh_token",
-            }));
+            expect(revokeSpy).not.toHaveBeenCalledWith(expect.anything(), "refresh_token");
         });
 
         it("should succeed with no user session", async () => {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -405,9 +405,7 @@ export class UserManager {
                 this._logger.debug("_signinEnd: current user does not match user returned from signin. sub from signin: ", user.profile.sub);
                 throw new Error("login_required");
             }
-            else {
-                this._logger.debug("_signinEnd: current user matches user returned from signin");
-            }
+            this._logger.debug("_signinEnd: current user matches user returned from signin");
         }
 
         await this.storeUser(user);


### PR DESCRIPTION
Resolves #276.

When planning this out, I would've like to simply reuse the logic declared in `ResponseValidator`, but its private methods (and unfortunately its tests) were coupled to the use of the `SigninState` object.

In this PR I've refactored `ResponseValidator` tests to only use the public methods. I excluded `_mergeClaims` and `_filterProtocolClaims` from this since those methods are essentially utility functions that probably should be public exports in their own file(s). This allowed me to more easily refactor  `_validateTokens` and `_processClaims` to work without signin state. This will be necessary for validating refresh token responses as they do not require the same kind of state.