### PR TITLE
Misc cleanup

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -9,7 +9,7 @@ export type AccessTokenCallback = (...ev: unknown[]) => void;
 
 // @public (undocumented)
 export class AccessTokenEvents {
-    constructor({ expiringNotificationTimeInSeconds }: {
+    constructor(args: {
         expiringNotificationTimeInSeconds: number;
     });
     addAccessTokenExpired(cb: AccessTokenCallback): () => void;
@@ -17,7 +17,7 @@ export class AccessTokenEvents {
     // (undocumented)
     load(container: User): void;
     // (undocumented)
-    protected _logger: Logger;
+    protected readonly _logger: Logger;
     removeAccessTokenExpired(cb: AccessTokenCallback): void;
     removeAccessTokenExpiring(cb: AccessTokenCallback): void;
     // (undocumented)
@@ -129,7 +129,6 @@ export interface ILogger {
 
 // @public (undocumented)
 export class InMemoryWebStorage implements Storage {
-    constructor();
     // (undocumented)
     clear(): void;
     // (undocumented)
@@ -189,7 +188,7 @@ export class Logger {
 
 // @public (undocumented)
 export class MetadataService {
-    constructor(settings: OidcClientSettingsStore);
+    constructor(_settings: OidcClientSettingsStore);
     // (undocumented)
     getAuthorizationEndpoint(): Promise<string>;
     // (undocumented)
@@ -476,7 +475,7 @@ export type RevokeTokensTypes = UserManagerSettings["revokeTokenTypes"];
 
 // @public (undocumented)
 export class SessionMonitor {
-    constructor(userManager: UserManager);
+    constructor(_userManager: UserManager);
     // (undocumented)
     protected _callback: () => Promise<void>;
     // (undocumented)
@@ -861,6 +860,8 @@ export class UserManagerEvents extends AccessTokenEvents {
     addUserUnloaded(cb: UserUnloadedCallback): () => void;
     // (undocumented)
     load(user: User, raiseEvent?: boolean): void;
+    // (undocumented)
+    protected readonly _logger: Logger;
     // @internal (undocumented)
     _raiseSilentRenewError(e: Error): void;
     // @internal (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -86,21 +86,21 @@ export type CreateSignoutRequestArgs = Omit<SignoutRequestArgs, "url" | "state_d
 // @public
 export class ErrorResponse extends Error {
     constructor(args: {
-        error?: string;
-        error_description?: string;
-        error_uri?: string;
-        state?: unknown;
-        session_state?: string;
+        error?: string | null;
+        error_description?: string | null;
+        error_uri?: string | null;
+        userState?: unknown;
+        session_state?: string | null;
     },
     form?: URLSearchParams | undefined);
-    readonly error: string;
-    readonly error_description: string | undefined;
-    readonly error_uri: string | undefined;
+    readonly error: string | null;
+    readonly error_description: string | null;
+    readonly error_uri: string | null;
     readonly form?: URLSearchParams | undefined;
     readonly name: string;
     // (undocumented)
-    readonly session_state: string | undefined;
-    state: unknown | undefined;
+    readonly session_state: string | null;
+    state?: unknown;
 }
 
 // @public (undocumented)
@@ -572,39 +572,35 @@ export class SigninResponse {
     // (undocumented)
     access_token: string;
     // (undocumented)
-    readonly code: string | undefined;
+    readonly code: string | null;
     // (undocumented)
-    error: string | undefined;
+    readonly error: string | null;
     // (undocumented)
-    error_description: string | undefined;
+    readonly error_description: string | null;
     // (undocumented)
-    error_uri: string | undefined;
+    readonly error_uri: string | null;
     // (undocumented)
-    get expired(): boolean | undefined;
-    // (undocumented)
-    expires_at: number | undefined;
+    expires_at?: number;
     // (undocumented)
     get expires_in(): number | undefined;
     set expires_in(value: number | undefined);
     // (undocumented)
-    id_token: string | undefined;
+    id_token?: string;
     // (undocumented)
-    get isOpenIdConnect(): boolean;
+    get isOpenId(): boolean;
     // (undocumented)
     profile: UserProfile;
     // (undocumented)
-    refresh_token: string | undefined;
+    refresh_token?: string;
     // (undocumented)
-    scope: string | undefined;
+    scope?: string;
     // (undocumented)
-    get scopes(): string[];
+    readonly session_state: string | null;
     // (undocumented)
-    session_state: string | undefined;
-    state: unknown;
-    // (undocumented)
-    readonly state_id: string | undefined;
+    readonly state: string | null;
     // (undocumented)
     token_type: string;
+    userState: unknown;
 }
 
 // @public (undocumented)
@@ -686,14 +682,14 @@ export interface SignoutRequestArgs {
 export class SignoutResponse {
     constructor(params: URLSearchParams);
     // (undocumented)
-    error: string | undefined;
+    error: string | null;
     // (undocumented)
-    error_description: string | undefined;
+    error_description: string | null;
     // (undocumented)
-    error_uri: string | undefined;
-    state: unknown;
+    error_uri: string | null;
     // (undocumented)
-    readonly state_id: string | undefined;
+    readonly state: string | null;
+    userState: unknown;
 }
 
 // @public (undocumented)
@@ -738,14 +734,14 @@ export interface StateStore {
 export class User {
     constructor(args: {
         id_token?: string;
-        session_state?: string;
+        session_state?: string | null;
         access_token: string;
         refresh_token?: string;
         token_type: string;
         scope?: string;
         profile: UserProfile;
         expires_at?: number;
-        state?: unknown;
+        userState?: unknown;
     });
     access_token: string;
     get expired(): boolean | undefined;
@@ -759,7 +755,7 @@ export class User {
     refresh_token?: string;
     scope?: string;
     get scopes(): string[];
-    session_state?: string;
+    session_state: string | null;
     readonly state: unknown;
     token_type: string;
     // (undocumented)

--- a/src/AccessTokenEvents.test.ts
+++ b/src/AccessTokenEvents.test.ts
@@ -18,8 +18,10 @@ describe("AccessTokenEvents", () => {
         subject = new AccessTokenEvents({ expiringNotificationTimeInSeconds: 60 });
 
         // access private members
-        subject["_expiringTimer"] = expiringTimer;
-        subject["_expiredTimer"] = expiredTimer;
+        Object.assign(subject, {
+            _expiringTimer: expiringTimer,
+            _expiredTimer: expiredTimer,
+        });
     });
 
     describe("constructor", () => {

--- a/src/AccessTokenEvents.ts
+++ b/src/AccessTokenEvents.ts
@@ -13,18 +13,14 @@ export type AccessTokenCallback = (...ev: unknown[]) => void;
  * @public
  */
 export class AccessTokenEvents {
-    protected _logger: Logger;
+    protected readonly _logger = new Logger("AccessTokenEvents");
 
-    private _expiringNotificationTimeInSeconds: number
-    private _expiringTimer: Timer
-    private _expiredTimer: Timer
+    private readonly _expiringTimer = new Timer("Access token expiring");
+    private readonly _expiredTimer = new Timer("Access token expired");
+    private readonly _expiringNotificationTimeInSeconds: number;
 
-    public constructor({ expiringNotificationTimeInSeconds }: { expiringNotificationTimeInSeconds: number }) {
-        this._logger = new Logger("AccessTokenEvents");
-
-        this._expiringNotificationTimeInSeconds = expiringNotificationTimeInSeconds;
-        this._expiringTimer = new Timer("Access token expiring");
-        this._expiredTimer = new Timer("Access token expired");
+    public constructor(args: { expiringNotificationTimeInSeconds: number }) {
+        this._expiringNotificationTimeInSeconds = args.expiringNotificationTimeInSeconds;
     }
 
     public load(container: User): void {

--- a/src/CheckSessionIFrame.ts
+++ b/src/CheckSessionIFrame.ts
@@ -7,7 +7,7 @@ import { Logger } from "./utils";
  * @internal
  */
 export class CheckSessionIFrame {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("CheckSessionIFrame");
     private _frame_origin: string;
     private _frame: HTMLIFrameElement;
     private _timer: ReturnType<typeof setInterval> | null = null
@@ -20,8 +20,6 @@ export class CheckSessionIFrame {
         private _intervalInSeconds: number,
         private _stopOnError: boolean,
     ) {
-        this._logger = new Logger("CheckSessionIFrame");
-
         const idx = url.indexOf("/", url.indexOf("//") + 2);
         this._frame_origin = url.substr(0, idx);
 

--- a/src/ErrorResponse.test.ts
+++ b/src/ErrorResponse.test.ts
@@ -47,7 +47,7 @@ describe("ErrorResponse", () => {
 
         it("should read state", () => {
             // act
-            const subject = new ErrorResponse({ error:"error", state:"foo" });
+            const subject = new ErrorResponse({ error:"error", userState:"foo" });
 
             // assert
             expect(subject.state).toEqual("foo");

--- a/src/ErrorResponse.ts
+++ b/src/ErrorResponse.ts
@@ -15,29 +15,29 @@ export class ErrorResponse extends Error {
     public readonly name: string = "ErrorResponse";
 
     /** An error code string that can be used to classify the types of errors that occur and to respond to errors. */
-    public readonly error: string;
+    public readonly error: string | null;
     /** additional information that can help a developer identify the cause of the error.*/
-    public readonly error_description: string | undefined;
+    public readonly error_description: string | null;
     /**
      * URI identifying a human-readable web page with information about the error, used to provide the client
        developer with additional information about the error.
     */
-    public readonly error_uri: string | undefined;
+    public readonly error_uri: string | null;
 
-    /** custom "state", which can be used by a caller to have "data" round tripped */
-    public state: unknown | undefined;
+    /** custom state data set during the initial signin request */
+    public state?: unknown;
 
-    public readonly session_state: string | undefined;
+    public readonly session_state: string | null;
 
     public constructor(
         args: {
-            error?: string; error_description?: string; error_uri?: string;
-            state?: unknown; session_state?: string;
+            error?: string | null; error_description?: string | null; error_uri?: string | null;
+            userState?: unknown; session_state?: string | null;
         },
         /** The x-www-form-urlencoded request body sent to the authority server */
         public readonly form?: URLSearchParams,
     ) {
-        super(args.error_description || args.error);
+        super(args.error_description || args.error || "");
 
         if (!args.error) {
             Logger.error("ErrorResponse", "No error passed");
@@ -45,10 +45,10 @@ export class ErrorResponse extends Error {
         }
 
         this.error = args.error;
-        this.error_description = args.error_description;
-        this.error_uri = args.error_uri;
+        this.error_description = args.error_description ?? null;
+        this.error_uri = args.error_uri ?? null;
 
-        this.state = args.state;
-        this.session_state = args.session_state;
+        this.state = args.userState;
+        this.session_state = args.session_state ?? null;
     }
 }

--- a/src/InMemoryWebStorage.ts
+++ b/src/InMemoryWebStorage.ts
@@ -7,13 +7,8 @@ import { Logger } from "./utils";
  * @public
  */
 export class InMemoryWebStorage implements Storage {
-    private readonly _logger: Logger;
-    private _data: Record<string, string>;
-
-    public constructor() {
-        this._logger = new Logger("InMemoryWebStorage");
-        this._data = {};
-    }
+    private readonly _logger = new Logger("InMemoryWebStorage");
+    private _data: Record<string, string> = {};
 
     public clear(): void {
         this._logger.debug("clear");

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -13,7 +13,7 @@ export type JwtHandler = (text: string) => Promise<Record<string, unknown>>;
  * @internal
  */
 export class JsonService {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("JsonService");
 
     private _contentTypes: string[] = [];
 
@@ -21,8 +21,6 @@ export class JsonService {
         additionalContentTypes: string[] = [],
         private _jwtHandler: JwtHandler | null = null,
     ) {
-        this._logger = new Logger("JsonService");
-
         this._contentTypes.push(...additionalContentTypes, "application/json");
         if (_jwtHandler) {
             this._contentTypes.push("application/jwt");

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -12,21 +12,15 @@ const OidcMetadataUrlPath = ".well-known/openid-configuration";
  * @public
  */
 export class MetadataService {
-    private readonly _settings: OidcClientSettingsStore;
-    private readonly _logger: Logger;
-    private readonly _jsonService: JsonService;
+    private readonly _logger = new Logger("MetadataService");
+    private readonly _jsonService = new JsonService(["application/jwk-set+json"]);
 
     // cache
-    private _metadataUrl: string | null;
-    private _signingKeys: SigningKey[] | null;
-    private _metadata: Partial<OidcMetadata> | null;
+    private _metadataUrl: string | null = null;
+    private _signingKeys: SigningKey[] | null = null;
+    private _metadata: Partial<OidcMetadata> | null = null;
 
-    public constructor(settings: OidcClientSettingsStore) {
-        this._settings = settings;
-        this._logger = new Logger("MetadataService");
-        this._jsonService = new JsonService(["application/jwk-set+json"]);
-
-        this._metadataUrl = null;
+    public constructor(private readonly _settings: OidcClientSettingsStore) {
         if (this._settings.metadataUrl) {
             this._metadataUrl = this._settings.metadataUrl;
         } else if (this._settings.authority) {
@@ -37,13 +31,11 @@ export class MetadataService {
             this._metadataUrl += OidcMetadataUrlPath;
         }
 
-        this._signingKeys = null;
         if (this._settings.signingKeys) {
             this._logger.debug("ctor: Using signingKeys from settings");
             this._signingKeys = this._settings.signingKeys;
         }
 
-        this._metadata = null;
         if (this._settings.metadata) {
             this._logger.debug("ctor: Using metadata from settings");
             this._metadata = this._settings.metadata;

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -276,7 +276,7 @@ describe("OidcClient", () => {
             expect(state.authority).toEqual("authority");
             expect(state.client_id).toEqual("client");
             expect(state.request_type).toEqual("type");
-            expect(response.state_id).toEqual("1");
+            expect(response.state).toEqual("1");
         });
     });
 
@@ -362,6 +362,7 @@ describe("OidcClient", () => {
                 access_token: "new_access_token",
             };
             jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken").mockResolvedValue(tokenResponse);
+            jest.spyOn(JwtUtils, "decode").mockReturnValue({ sub: "sub" });
             const state = new RefreshState({
                 refresh_token: "refresh_token",
                 id_token: "id_token",
@@ -573,7 +574,7 @@ describe("OidcClient", () => {
             expect(state).toBeDefined();
             expect(state?.id).toEqual("1");
             expect(state?.request_type).toEqual("type");
-            expect(response.state_id).toEqual("1");
+            expect(response.state).toEqual("1");
         });
 
         it("should call validator with state even if error in response", async () => {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -59,7 +59,7 @@ export type CreateSignoutRequestArgs = Omit<SignoutRequestArgs, "url" | "state_d
  */
 export class OidcClient {
     public readonly settings: OidcClientSettingsStore;
-    protected readonly _logger: Logger;
+    protected readonly _logger = new Logger("OidcClient")
 
     public readonly metadataService: MetadataService;
     protected readonly _validator: ResponseValidator;
@@ -67,7 +67,6 @@ export class OidcClient {
 
     public constructor(settings: OidcClientSettings) {
         this.settings = new OidcClientSettingsStore(settings);
-        this._logger = new Logger("OidcClient");
 
         this.metadataService = new MetadataService(this.settings);
         this._validator = new ResponseValidator(this.settings, this.metadataService);

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -126,16 +126,12 @@ export class OidcClient {
         this._logger.debug("readSigninResponseState");
 
         const response = new SigninResponse(UrlUtils.readParams(url, this.settings.response_mode));
-        const stateKey = response.state_id;
-        if (!stateKey) {
+        if (!response.state) {
             this._logger.error("readSigninResponseState: No state in response");
             throw new Error("No state in response");
         }
 
-        const stateStore = this.settings.stateStore;
-        const stateApi = removeState ? stateStore.remove.bind(stateStore) : stateStore.get.bind(stateStore);
-
-        const storedStateString = await stateApi(stateKey);
+        const storedStateString = await this.settings.stateStore[removeState ? "remove" : "get"](response.state);
         if (!storedStateString) {
             this._logger.error("readSigninResponseState: No matching state found in storage");
             throw new Error("No matching state found in storage");
@@ -206,8 +202,7 @@ export class OidcClient {
         this._logger.debug("readSignoutResponseState");
 
         const response = new SignoutResponse(UrlUtils.readParams(url, this.settings.response_mode));
-        const stateKey = response.state_id;
-        if (!stateKey) {
+        if (!response.state) {
             this._logger.debug("readSignoutResponseState: No state in response");
 
             if (response.error) {
@@ -218,10 +213,7 @@ export class OidcClient {
             return { state: undefined, response };
         }
 
-        const stateStore = this.settings.stateStore;
-
-        const stateApi = removeState ? stateStore.remove.bind(stateStore) : stateStore.get.bind(stateStore);
-        const storedStateString = await stateApi(stateKey);
+        const storedStateString = await this.settings.stateStore[removeState ? "remove" : "get"](response.state);
         if (!storedStateString) {
             this._logger.error("readSignoutResponseState: No matching state found in storage");
             throw new Error("No matching state found in storage");

--- a/src/RefreshState.ts
+++ b/src/RefreshState.ts
@@ -1,7 +1,7 @@
 import type { State } from "./State";
 
 /**
- * Fake state store implementation necessary for validating a refresh token requests.
+ * Fake state store implementation necessary for validating refresh token requests.
  *
  * @internal
  */
@@ -19,10 +19,12 @@ export class RefreshState implements State {
         refresh_token: string;
         id_token: string;
         scope: string;
+        state?: unknown;
     }) {
         this.refresh_token = args.refresh_token;
         this.id_token = args.id_token;
         this.scope = args.scope;
+        this.data = args.state;
     }
 
     public toStorageString(): string {

--- a/src/SessionMonitor.ts
+++ b/src/SessionMonitor.ts
@@ -10,22 +10,17 @@ import type { User } from "./User";
  * @public
  */
 export class SessionMonitor {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("SessionMonitor");
 
-    private readonly _userManager: UserManager;
     private _sub: string | undefined;
     private _sid: string | undefined;
     private _checkSessionIFrame?: CheckSessionIFrame;
 
-    public constructor(userManager: UserManager) {
-        this._logger = new Logger("SessionMonitor");
-
-        if (!userManager) {
+    public constructor(private readonly _userManager: UserManager) {
+        if (!_userManager) {
             this._logger.error("ctor: No user manager passed to SessionMonitor");
             throw new Error("userManager");
         }
-
-        this._userManager = userManager;
 
         this._userManager.events.addUserLoaded(this._start);
         this._userManager.events.addUserUnloaded(this._stop);

--- a/src/SigninRequest.ts
+++ b/src/SigninRequest.ts
@@ -42,7 +42,7 @@ export interface SigninRequestArgs {
  * @public
  */
 export class SigninRequest {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("SigninRequest");
 
     public readonly url: string;
     public readonly state: SigninState;
@@ -57,8 +57,6 @@ export class SigninRequest {
         extraTokenParams,
         ...optionalParams
     }: SigninRequestArgs) {
-        this._logger = new Logger("SigninRequest");
-
         if (!url) {
             this._logger.error("ctor: No url passed");
             throw new Error("url");

--- a/src/SignoutRequest.ts
+++ b/src/SignoutRequest.ts
@@ -23,7 +23,7 @@ export interface SignoutRequestArgs {
  * @public
  */
 export class SignoutRequest {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("SignoutRequest");
 
     public readonly url: string
     public readonly state?: State
@@ -32,8 +32,6 @@ export class SignoutRequest {
         url,
         state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
     }: SignoutRequestArgs) {
-        this._logger = new Logger("SignoutRequest");
-
         if (!url) {
             this._logger.error("ctor: No url passed");
             throw new Error("url");

--- a/src/SignoutResponse.test.ts
+++ b/src/SignoutResponse.test.ts
@@ -36,7 +36,7 @@ describe("SignoutResponse", () => {
             const subject = new SignoutResponse(new URLSearchParams("state=foo"));
 
             // assert
-            expect(subject.state_id).toEqual("foo");
+            expect(subject.state).toEqual("foo");
         });
     });
 });

--- a/src/SignoutResponse.ts
+++ b/src/SignoutResponse.ts
@@ -5,27 +5,24 @@
  * @public
  */
 export class SignoutResponse {
-    public readonly state_id: string | undefined;
+    public readonly state: string | null;
 
-    // updated by ResponseValidator
+    // error props
     /** @see {@link ErrorResponse.error} */
-    public error: string | undefined;
+    public error: string | null;
     /** @see {@link ErrorResponse.error_description} */
-    public error_description: string | undefined;
+    public error_description: string | null;
     /** @see {@link ErrorResponse.error_uri} */
-    public error_uri: string | undefined;
+    public error_uri: string | null;
 
-    // set by ResponseValidator
-    /** custom "state", which can be used by a caller to have "data" round tripped */
-    public state: unknown;
+    /** custom state data set during the initial signin request */
+    public userState: unknown;
 
     public constructor(params: URLSearchParams) {
-        const values = new Map(params);
+        this.state = params.get("state");
 
-        this.error = values.get("error");
-        this.error_description = values.get("error_description");
-        this.error_uri = values.get("error_uri");
-
-        this.state_id = values.get("state");
+        this.error = params.get("error");
+        this.error_description = params.get("error_description");
+        this.error_uri = params.get("error_uri");
     }
 }

--- a/src/SilentRenewService.ts
+++ b/src/SilentRenewService.ts
@@ -9,12 +9,10 @@ import type { AccessTokenCallback } from "./AccessTokenEvents";
  * @internal
  */
 export class SilentRenewService {
-    protected _logger: Logger;
+    protected _logger = new Logger("SilentRenewService");
     private _isStarted = false;
 
-    public constructor(private _userManager: UserManager) {
-        this._logger = new Logger("SilentRenewService");
-    }
+    public constructor(private _userManager: UserManager) {}
 
     public async start(): Promise<void> {
         if (!this._isStarted) {

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -42,17 +42,13 @@ export interface RevokeArgs {
  * @internal
  */
 export class TokenClient {
-    private readonly _settings: OidcClientSettingsStore;
-    private readonly _logger: Logger;
-    private readonly _jsonService: JsonService;
-    private readonly _metadataService: MetadataService;
+    private readonly _logger = new Logger("TokenClient");
+    private readonly _jsonService = new JsonService();
 
-    public constructor(settings: OidcClientSettingsStore, metadataService: MetadataService) {
-        this._settings = settings;
-        this._logger = new Logger("TokenClient");
-        this._jsonService = new JsonService();
-        this._metadataService = metadataService;
-    }
+    public constructor(
+        private readonly _settings: OidcClientSettingsStore,
+        private readonly _metadataService: MetadataService,
+    ) {}
 
     public async exchangeCode({
         grant_type = "authorization_code",

--- a/src/User.test.ts
+++ b/src/User.test.ts
@@ -1,0 +1,48 @@
+import { User } from "./User";
+import { Timer } from "./utils";
+
+describe("User", () => {
+
+    let now: number;
+
+    beforeEach(() => {
+        now = 0;
+        jest.spyOn(Timer, "getEpochTime").mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("expired", () => {
+        it("should calculate how much time left", () => {
+            const subject = new User({ expires_at: 100 } as never);
+            expect(subject.expired).toEqual(false);
+
+            // act
+            now += 100;
+
+            // assert
+            expect(subject.expired).toEqual(true);
+        });
+    });
+
+    describe("scopes", () => {
+        it("should return list of scopes", () => {
+            let subject = new User({ scope: "foo" } as never);
+
+            // assert
+            expect(subject.scopes).toEqual(["foo"]);
+
+            subject = new User({ scope: "foo bar" } as never);
+
+            // assert
+            expect(subject.scopes).toEqual(["foo", "bar"]);
+
+            subject = new User({ scope: "foo bar baz" } as never);
+
+            // assert
+            expect(subject.scopes).toEqual(["foo", "bar", "baz"]);
+        });
+    });
+});

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -9,14 +9,11 @@ import type { MetadataService } from "./MetadataService";
  * @internal
  */
 export class UserInfoService {
-    protected readonly _logger: Logger;
-    private _jsonService: JsonService;
-    private _metadataService: MetadataService;
+    protected readonly _logger = new Logger("UserInfoService");
+    private readonly _jsonService: JsonService;
 
-    public constructor(metadataService: MetadataService) {
-        this._logger = new Logger("UserInfoService");
+    public constructor(private readonly _metadataService: MetadataService) {
         this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
-        this._metadataService = metadataService;
     }
 
     public async getClaims(token: string): Promise<JwtPayload> {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -265,7 +265,6 @@ export class UserManager {
     }
 
     protected async _useRefreshToken(state: RefreshState): Promise<User> {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const response = await this._client.useRefreshToken(state);
         const user = new User({ ...state, ...response });
 

--- a/src/UserManagerEvents.ts
+++ b/src/UserManagerEvents.ts
@@ -35,23 +35,17 @@ export type UserSessionChangedCallback = () => Promise<void> | void;
  * @public
  */
 export class UserManagerEvents extends AccessTokenEvents {
-    private _userLoaded: Event<[User]>;
-    private _userUnloaded: Event<[void]>;
-    private _silentRenewError: Event<[Error]>;
-    private _userSignedIn: Event<[void]>;
-    private _userSignedOut: Event<[void]>;
-    private _userSessionChanged: Event<[void]>;
+    protected readonly _logger = new Logger("UserManagerEvents")
+
+    private readonly _userLoaded = new Event<[User]>("User loaded");
+    private readonly _userUnloaded = new Event<[]>("User unloaded");
+    private readonly _silentRenewError = new Event<[Error]>("Silent renew error");
+    private readonly _userSignedIn = new Event<[]>("User signed in");
+    private readonly _userSignedOut = new Event<[]>("User signed out");
+    private readonly _userSessionChanged = new Event<[]>("User session changed");
 
     public constructor(settings: UserManagerSettingsStore) {
         super({ expiringNotificationTimeInSeconds: settings.accessTokenExpiringNotificationTimeInSeconds });
-        this._logger = new Logger("UserManagerEvents");
-
-        this._userLoaded = new Event("User loaded");
-        this._userUnloaded = new Event("User unloaded");
-        this._silentRenewError = new Event("Silent renew error");
-        this._userSignedIn = new Event("User signed in");
-        this._userSignedOut = new Event("User signed out");
-        this._userSessionChanged = new Event("User session changed");
     }
 
     public load(user: User, raiseEvent=true): void {

--- a/src/WebStorageStateStore.ts
+++ b/src/WebStorageStateStore.ts
@@ -8,14 +8,12 @@ import type { StateStore } from "./StateStore";
  * @public
  */
 export class WebStorageStateStore implements StateStore {
-    private _logger: Logger;
+    private readonly _logger = new Logger("WebStorageStateStore");
 
-    private _store: Storage
-    private _prefix: string
+    private readonly _store: Storage
+    private readonly _prefix: string
 
     public constructor({ prefix = "oidc.", store = localStorage } = {}) {
-        this._logger = new Logger("WebStorageStateStore");
-
         this._store = store;
         this._prefix = prefix;
     }

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -10,11 +10,9 @@ import type { INavigator } from "./INavigator";
  * @internal
  */
 export class IFrameNavigator implements INavigator {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("IFrameNavigator");
 
-    constructor(private _settings: UserManagerSettingsStore) {
-        this._logger = new Logger("IFrameNavigator");
-    }
+    constructor(private _settings: UserManagerSettingsStore) {}
 
     public async prepare({
         silentRequestTimeoutInSeconds = this._settings.silentRequestTimeoutInSeconds,

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -10,11 +10,9 @@ import type { UserManagerSettingsStore } from "../UserManagerSettings";
  * @internal
  */
 export class PopupNavigator implements INavigator {
-    private readonly _logger: Logger;
+    private readonly _logger = new Logger("PopupNavigator");
 
-    constructor(private _settings: UserManagerSettingsStore) {
-        this._logger = new Logger("PopupNavigator");
-    }
+    constructor(private _settings: UserManagerSettingsStore) {}
 
     public async prepare({
         popupWindowFeatures = this._settings.popupWindowFeatures,

--- a/src/utils/Event.ts
+++ b/src/utils/Event.ts
@@ -12,15 +12,11 @@ export type Callback<EventType extends unknown[]> = (...ev: EventType) => (Promi
  * @internal
  */
 export class Event<EventType extends unknown[]> {
-    protected readonly _name: string;
-    protected readonly _logger: Logger;
+    protected readonly _logger = new Logger(`Event(${this._name})`);
 
     private _callbacks: Array<Callback<EventType>> = [];
 
-    public constructor(name: string) {
-        this._name = name;
-        this._logger = new Logger(`Event(${name})`);
-    }
+    public constructor(protected readonly _name: string) {}
 
     public addHandler(cb: Callback<EventType>): () => void {
         this._callbacks.push(cb);

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -3,8 +3,6 @@
 
 import { Event } from "./Event";
 
-const DefaultTimerDurationInSeconds = 5; // seconds
-
 /**
  * @internal
  */
@@ -18,11 +16,7 @@ export class Timer extends Event<[void]> {
     }
 
     public init(durationInSeconds: number): void {
-        if (durationInSeconds <= 0) {
-            durationInSeconds = 1;
-        }
-
-        durationInSeconds = Math.floor(durationInSeconds);
+        durationInSeconds = Math.max(Math.floor(durationInSeconds), 1);
         const expiration = Timer.getEpochTime() + durationInSeconds;
         if (this.expiration === expiration && this._timerHandle) {
             // no need to reinitialize to same expiration, so bail out
@@ -38,10 +32,7 @@ export class Timer extends Event<[void]> {
         // we're using a fairly short timer and then checking the expiration in the
         // callback to handle scenarios where the browser device sleeps, and then
         // the timers end up getting delayed.
-        let timerDurationInSeconds = DefaultTimerDurationInSeconds;
-        if (durationInSeconds < timerDurationInSeconds) {
-            timerDurationInSeconds = durationInSeconds;
-        }
+        const timerDurationInSeconds = Math.min(durationInSeconds, 5);
         this._timerHandle = setInterval(this._callback, timerDurationInSeconds * 1000);
     }
 


### PR DESCRIPTION
After implementing the refresh token fixes I have a much better understanding of the SigninResponse/ResponseValidator relationship and was able to clean up code a bit further.

The `SigninResponse` constructor was originally built to take in a list of URL params. For the implicit `token` grant, there are a bunch of these - `access_token`, `token_type`, `expires_in`, etc. In the `code` flow, there are only a handful - `code`, `state`, `session_state`, and the error params.

In this PR I've limited the `SigninResponse` constructor to only read properties expected for the `code` grant type. I've also renamed `state_id` back to `state` and `state` to `userState`. This doesn't affect the public User API since the `User` constructor maps `userState` to `state`.

Within all of these changes is also a really minor fix to preserve user state after performing a refresh token grant.