### PR TITLE
Fix redundant window logs

### DIFF
--- a/samples/Parcel/src/code-flow-identityserver/sample-callback.js
+++ b/samples/Parcel/src/code-flow-identityserver/sample-callback.js
@@ -1,8 +1,5 @@
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.DEBUG);
 
 new UserManager(settings).signinCallback().then(function(user) {
     log("signin response success", user);

--- a/samples/Parcel/src/code-flow-identityserver/sample-popup-signin.js
+++ b/samples/Parcel/src/code-flow-identityserver/sample-popup-signin.js
@@ -1,8 +1,5 @@
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.DEBUG);
 
 new UserManager(settings).signinCallback().then(function(user) {
     log("signin response success", user);

--- a/samples/Parcel/src/code-flow-identityserver/sample-popup-signout.js
+++ b/samples/Parcel/src/code-flow-identityserver/sample-popup-signout.js
@@ -1,8 +1,5 @@
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 // can pass true param and will keep popup window open
 new UserManager(settings).signoutCallback().then(function() {

--- a/samples/Parcel/src/code-flow-identityserver/sample-settings.js
+++ b/samples/Parcel/src/code-flow-identityserver/sample-settings.js
@@ -1,4 +1,7 @@
-import { Log, UserManager} from "../../../../src";
+import { Log, UserManager } from "../../../../src";
+
+Log.setLogger(console);
+Log.setLevel(Log.INFO);
 
 const url = window.location.origin + "/code-flow-identityserver";
 

--- a/samples/Parcel/src/code-flow-identityserver/sample-silent.js
+++ b/samples/Parcel/src/code-flow-identityserver/sample-silent.js
@@ -1,8 +1,5 @@
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 new UserManager(settings).signinCallback().then(function(user) {
     log("signin callback response success", user);

--- a/samples/Parcel/src/code-flow-identityserver/sample.js
+++ b/samples/Parcel/src/code-flow-identityserver/sample.js
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 
 ///////////////////////////////
 // UI event handlers
@@ -26,8 +26,6 @@ document.getElementById("popupSignout").addEventListener("click", popupSignout, 
 ///////////////////////////////
 // config
 ///////////////////////////////
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 function log() {
     document.getElementById("out").innerText = "";

--- a/samples/Parcel/src/oidc-client/sample-callback.js
+++ b/samples/Parcel/src/oidc-client/sample-callback.js
@@ -1,8 +1,5 @@
-import { Log, settings } from "./sample-settings";
+import { settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 new OidcClient(settings).processSigninResponse().then(function(response) {
     log("signin response success", response);

--- a/samples/Parcel/src/oidc-client/sample-settings.js
+++ b/samples/Parcel/src/oidc-client/sample-settings.js
@@ -1,4 +1,7 @@
-import { Log, OidcClient} from "../../../../src";
+import { Log, OidcClient } from "../../../../src";
+
+Log.setLogger(console);
+Log.setLevel(Log.INFO);
 
 const url = window.location.origin + "/oidc-client";
 

--- a/samples/Parcel/src/oidc-client/sample.js
+++ b/samples/Parcel/src/oidc-client/sample.js
@@ -15,8 +15,6 @@ document.getElementById("links").addEventListener("change", toggleLinks, false);
 ///////////////////////////////
 // OidcClient config
 ///////////////////////////////
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 function log() {
     document.getElementById("out").innerText = "";

--- a/samples/Parcel/src/user-manager/sample-popup-signin.js
+++ b/samples/Parcel/src/user-manager/sample-popup-signin.js
@@ -1,9 +1,6 @@
 import { Log, UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
 
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
-
 new UserManager(settings).signinPopupCallback().then(function() {
     log("signin popup callback response success");
 }).catch(function(err) {

--- a/samples/Parcel/src/user-manager/sample-popup-signout.js
+++ b/samples/Parcel/src/user-manager/sample-popup-signout.js
@@ -1,8 +1,5 @@
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 new UserManager(settings).signoutPopupCallback(undefined, true).then(function() {
     log("signout popup callback response success");

--- a/samples/Parcel/src/user-manager/sample-settings.js
+++ b/samples/Parcel/src/user-manager/sample-settings.js
@@ -1,5 +1,8 @@
 import { Log, UserManager} from "../../../../src";
 
+Log.setLogger(console);
+Log.setLevel(Log.INFO);
+
 const url = window.location.origin + "/user-manager";
 
 export const settings = {

--- a/samples/Parcel/src/user-manager/sample-silent.js
+++ b/samples/Parcel/src/user-manager/sample-silent.js
@@ -1,8 +1,5 @@
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 import { log } from "./sample";
-
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 new UserManager(settings).signinSilentCallback().then(function() {
     log("signin silent callback response success");

--- a/samples/Parcel/src/user-manager/sample.js
+++ b/samples/Parcel/src/user-manager/sample.js
@@ -2,7 +2,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log, UserManager, settings } from "./sample-settings";
+import { UserManager, settings } from "./sample-settings";
 
 ///////////////////////////////
 // UI event handlers
@@ -25,8 +25,6 @@ document.getElementById("popupSignout").addEventListener("click", popupSignout, 
 ///////////////////////////////
 // config
 ///////////////////////////////
-Log.setLogger(console);
-Log.setLevel(Log.INFO);
 
 function log() {
     document.getElementById("out").innerText = "";

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -55,8 +55,8 @@ export class IFrameWindow extends AbstractChildWindow {
         if (this._frame) {
             if (this._frame.parentNode) {
                 this._frame.parentNode.removeChild(this._frame);
+                this._abort.raise(new Error("IFrame removed from DOM"));
             }
-            this._abort.raise(new Error("IFrame removed from DOM"));
             this._frame = null;
         }
         this._window = null;

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -56,8 +56,8 @@ export class PopupWindow extends AbstractChildWindow {
         if (this._window) {
             if (!this._window.closed) {
                 this._window.close();
+                this._abort.raise(new Error("Popup closed"));
             }
-            this._abort.raise(new Error("Popup closed"));
         }
         this._window = null;
     }


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #326

This only avoids the duplicate events raised when a popup is closed by the user or when a the iframe window times out. There are still debug logs that show when the window is closed programmatically; avoiding these would result in more complicated code that I'm not sure is worth the trouble.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers

