### PR TITLE
Attempt to fix iframe leak

### DIFF
--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -54,8 +54,12 @@ export class IFrameWindow extends AbstractChildWindow {
     close(): void {
         if (this._frame) {
             if (this._frame.parentNode) {
-                this._frame.parentNode.removeChild(this._frame);
-                this._abort.raise(new Error("IFrame removed from DOM"));
+                this._frame.addEventListener("load", (ev) => {
+                    const frame = ev.target as HTMLIFrameElement;
+                    frame.parentNode?.removeChild(frame);
+                    this._abort.raise(new Error("IFrame removed from DOM"));
+                }, true);
+                this._frame.contentWindow?.location.replace("about:blank");
             }
             this._frame = null;
         }


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #138

I'm not sure if this fixes the whole problem but I'm also not sure what else will. This navigates the iframe to `about:blank` and waits for the page to load before removing it from DOM. In my testing, this allows for sources to unload from the "Sources" devtools panel but I'm not sure how to analyze the heap snapshots.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
