### PR TITLE
fix(RedirectNavigator): wait until the window is unloading to resolve

### DIFF
--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -36,22 +36,6 @@ describe("UserManager", () => {
                 revocation_endpoint: "http://sts/oidc/revoke",
             },
         });
-
-        const location = Object.defineProperties({}, {
-            ...Object.getOwnPropertyDescriptors(window.location),
-            assign: {
-                enumerable: true,
-                value: jest.fn(),
-            },
-            replace: {
-                enumerable: true,
-                value: jest.fn(),
-            },
-        });
-        Object.defineProperty(window, "location", {
-            enumerable: true,
-            get: () => location,
-        });
     });
 
     describe("constructor", () => {

--- a/src/navigators/PopupWindow.test.ts
+++ b/src/navigators/PopupWindow.test.ts
@@ -9,7 +9,7 @@ function firstSuccessfulResult<T>(fn: () => T): T {
 describe("PopupWindow", () => {
     beforeEach(() => {
         Object.defineProperty(window, "location", {
-            writable: true,
+            enumerable: true,
             value: { origin: "http://app" },
         });
 

--- a/src/navigators/RedirectNavigator.test.ts
+++ b/src/navigators/RedirectNavigator.test.ts
@@ -1,0 +1,35 @@
+import { mocked } from "jest-mock";
+import type { UserManagerSettingsStore } from "../UserManagerSettings";
+import { RedirectNavigator } from "./RedirectNavigator";
+
+describe("RedirectNavigator", () => {
+    const settings = { redirectMethod: "assign" } as UserManagerSettingsStore;
+    const navigator = new RedirectNavigator(settings);
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should redirect to the authority server using the default redirect method", async () => {
+        const handle = await navigator.prepare({});
+        void handle.navigate({ url: "http://sts/authorize" });
+
+        expect(window.location.assign).toHaveBeenCalledWith("http://sts/authorize");
+    });
+
+    it("should redirect to the authority server using a specific redirect method", async () => {
+        const handle = await navigator.prepare({ redirectMethod: "replace" });
+        await handle.navigate({ url: "http://sts/authorize" });
+
+        expect(window.location.replace).toHaveBeenCalledWith("http://sts/authorize");
+    });
+
+    it("should reject when the navigation is stopped programmatically", async () => {
+        const handle = await navigator.prepare({});
+        mocked(window.location.assign).mockReturnValue(undefined);
+        const promise = handle.navigate({ url: "http://sts/authorize" });
+
+        handle.close();
+        await expect(promise).rejects.toThrow("Redirect aborted");
+    });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,6 +2,24 @@ import { Log } from "../src";
 
 beforeAll(() => {
     globalThis.fetch = jest.fn();
+
+    const unload = () => window.dispatchEvent(new Event("beforeunload"));
+
+    const location = Object.defineProperties({}, {
+        ...Object.getOwnPropertyDescriptors(window.location),
+        assign: {
+            enumerable: true,
+            value: jest.fn(unload),
+        },
+        replace: {
+            enumerable: true,
+            value: jest.fn(unload),
+        },
+    });
+    Object.defineProperty(window, "location", {
+        enumerable: true,
+        get: () => location,
+    });
 });
 
 beforeEach(() => {


### PR DESCRIPTION
### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers

While testing the new `activeNavigator` prop in react-oidc-context, I noticed that `signinRedirect` returns synchronously and was causing the component to immediately rerender since the redirect navigator would close immediately after invocation. To fix this, I've made it so that `navigate()` returns a promise that only resolves as the page is exiting. The timing of `beforeunload` is late enough that the tasks in the async queue waiting for the promise to resolve are never run.