### PR TITLE
fix(RedirectNavigator): wait for 'unload' instead of 'beforeunload'

### DIFF
--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -32,7 +32,7 @@ export class RedirectNavigator implements INavigator {
                 this._logger.create("navigate");
                 const promise = new Promise((resolve, reject) => {
                     abort = reject;
-                    window.addEventListener("beforeunload", () => resolve(null));
+                    window.addEventListener("unload", () => resolve(null));
                 });
                 redirect(params.url);
                 return await (promise as Promise<never>);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,7 +3,7 @@ import { Log } from "../src";
 beforeAll(() => {
     globalThis.fetch = jest.fn();
 
-    const unload = () => window.dispatchEvent(new Event("beforeunload"));
+    const unload = () => window.dispatchEvent(new Event("unload"));
 
     const location = Object.defineProperties({}, {
         ...Object.getOwnPropertyDescriptors(window.location),


### PR DESCRIPTION
### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers

I didn't test the fix in #329 thoroughly enough, in Edge (and presumably Chrome) I was still seeing my React app rerender and trigger another redirect, canceling the unload, and causing an infinite loop. Ideally the promise should just never resolve by the time the page is unloading, but I was having a hard time writing tests using functions that never resolve.

The use of `'unload'` here is discouraged but this case in particular seems fine to me. We don't care about browser consistency since we don't even necessarily need the promise to ever resolve, and we are truly waiting for the page to unload rather than the page visibility changing.