### PR TITLE
retry silent renew for fetch timeout

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -306,7 +306,7 @@ export class OidcClient {
     // (undocumented)
     protected readonly _tokenClient: TokenClient;
     // (undocumented)
-    useRefreshToken({ state, }: UseRefreshTokenArgs): Promise<SigninResponse>;
+    useRefreshToken({ state, timeoutInSeconds, }: UseRefreshTokenArgs): Promise<SigninResponse>;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -839,6 +839,8 @@ export interface UseRefreshTokenArgs {
     //
     // (undocumented)
     state: RefreshState;
+    // (undocumented)
+    timeoutInSeconds?: number;
 }
 
 // @public (undocumented)

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -49,6 +49,7 @@ export interface CreateSigninRequestArgs {
  */
 export interface UseRefreshTokenArgs {
     state: RefreshState;
+    timeoutInSeconds?: number;
 }
 
 /**
@@ -160,11 +161,13 @@ export class OidcClient {
 
     public async useRefreshToken({
         state,
+        timeoutInSeconds,
     }: UseRefreshTokenArgs): Promise<SigninResponse> {
         const logger = this._logger.create("useRefreshToken");
 
         const result = await this._tokenClient.exchangeRefreshToken({
             refresh_token: state.refresh_token,
+            timeoutInSeconds,
         });
         const response = new SigninResponse(new URLSearchParams());
         Object.assign(response, result);

--- a/src/TokenClient.test.ts
+++ b/src/TokenClient.test.ts
@@ -198,6 +198,7 @@ describe("TokenClient", () => {
                 "http://sts/token_endpoint",
                 expect.any(URLSearchParams),
                 expect.stringContaining(""),
+                undefined,
             );
         });
 
@@ -220,6 +221,7 @@ describe("TokenClient", () => {
                 "http://sts/token_endpoint",
                 expect.any(URLSearchParams),
                 undefined,
+                undefined,
             );
             const params = Object.fromEntries(postFormMock.mock.calls[0][1]);
             expect(params).toHaveProperty("client_secret", "client_secret");
@@ -240,6 +242,7 @@ describe("TokenClient", () => {
             expect(postFormMock).toBeCalledWith(
                 "http://sts/token_endpoint",
                 expect.any(URLSearchParams),
+                undefined,
                 undefined,
             );
         });

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -28,6 +28,8 @@ export interface ExchangeRefreshTokenArgs {
 
     grant_type?: string;
     refresh_token: string;
+
+    timeoutInSeconds?: number;
 }
 
 /**
@@ -143,7 +145,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, params, basicAuth);
+        const response = await this._jsonService.postForm(url, params, basicAuth, args.timeoutInSeconds);
         logger.debug("got response");
 
         return response;

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -263,7 +263,10 @@ export class UserManager {
     }
 
     protected async _useRefreshToken(state: RefreshState): Promise<User> {
-        const response = await this._client.useRefreshToken({ state });
+        const response = await this._client.useRefreshToken({
+            state,
+            timeoutInSeconds: this.settings.silentRequestTimeoutInSeconds,
+        });
         const user = new User({ ...state, ...response });
 
         await this.storeUser(user);


### PR DESCRIPTION
By default a `fetch()` request timeouts at the time indicated by the browser. In Chrome a network request timeouts at 300 seconds, while in Firefox at 90 seconds.
The implementation is inspired by this [blog](https://dmitripavlutin.com/timeout-fetch-request/).

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes part of #251

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
