### PR TITLE
refactor: consolidate defaults into settings

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -385,7 +385,7 @@ export class OidcClientSettingsStore {
     // (undocumented)
     readonly metadataSeed: Partial<OidcMetadata> | undefined;
     // (undocumented)
-    readonly metadataUrl: string | undefined;
+    readonly metadataUrl: string;
     // (undocumented)
     readonly post_logout_redirect_uri: string | undefined;
     // (undocumented)
@@ -994,13 +994,13 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     // (undocumented)
     readonly popup_post_logout_redirect_uri: string | undefined;
     // (undocumented)
-    readonly popup_redirect_uri: string | undefined;
+    readonly popup_redirect_uri: string;
     // (undocumented)
-    readonly popupWindowFeatures: PopupWindowFeatures | undefined;
+    readonly popupWindowFeatures: PopupWindowFeatures;
     // (undocumented)
-    readonly popupWindowTarget: string | undefined;
+    readonly popupWindowTarget: string;
     // (undocumented)
-    readonly query_status_response_type: string | undefined;
+    readonly query_status_response_type: string;
     // (undocumented)
     readonly redirectMethod: "replace" | "assign";
     // (undocumented)
@@ -1008,9 +1008,9 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     // (undocumented)
     readonly revokeTokenTypes: ("access_token" | "refresh_token")[];
     // (undocumented)
-    readonly silent_redirect_uri: string | undefined;
+    readonly silent_redirect_uri: string;
     // (undocumented)
-    readonly silentRequestTimeoutInSeconds: number | undefined;
+    readonly silentRequestTimeoutInSeconds: number;
     // (undocumented)
     readonly stopCheckSessionOnError: boolean;
     // (undocumented)

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -6,8 +6,6 @@ import { JsonService } from "./JsonService";
 import type { OidcClientSettingsStore, SigningKey } from "./OidcClientSettings";
 import type { OidcMetadata } from "./OidcMetadata";
 
-const OidcMetadataUrlPath = ".well-known/openid-configuration";
-
 /**
  * @public
  */
@@ -16,20 +14,12 @@ export class MetadataService {
     private readonly _jsonService = new JsonService(["application/jwk-set+json"]);
 
     // cache
-    private _metadataUrl: string | null = null;
+    private _metadataUrl: string;
     private _signingKeys: SigningKey[] | null = null;
     private _metadata: Partial<OidcMetadata> | null = null;
 
     public constructor(private readonly _settings: OidcClientSettingsStore) {
-        if (this._settings.metadataUrl) {
-            this._metadataUrl = this._settings.metadataUrl;
-        } else if (this._settings.authority) {
-            this._metadataUrl = this._settings.authority;
-            if (!this._metadataUrl.endsWith("/")) {
-                this._metadataUrl += "/";
-            }
-            this._metadataUrl += OidcMetadataUrlPath;
-        }
+        this._metadataUrl = this._settings.metadataUrl;
 
         if (this._settings.signingKeys) {
             this._logger.debug("using signingKeys from settings");

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -111,7 +111,7 @@ export interface OidcClientSettings {
 export class OidcClientSettingsStore {
     // metadata
     public readonly authority: string;
-    public readonly metadataUrl: string | undefined;
+    public readonly metadataUrl: string;
     public readonly metadata: Partial<OidcMetadata> | undefined;
     public readonly metadataSeed: Partial<OidcMetadata> | undefined;
     public readonly signingKeys: SigningKey[] | undefined;
@@ -172,7 +172,19 @@ export class OidcClientSettingsStore {
     }: OidcClientSettings) {
 
         this.authority = authority;
-        this.metadataUrl = metadataUrl;
+
+        if (metadataUrl) {
+            this.metadataUrl = metadataUrl;
+        } else {
+            this.metadataUrl = authority;
+            if (authority) {
+                if (!this.metadataUrl.endsWith("/")) {
+                    this.metadataUrl += "/";
+                }
+                this.metadataUrl += ".well-known/openid-configuration";
+            }
+        }
+
         this.metadata = metadata;
         this.metadataSeed = metadataSeed;
         this.signingKeys = signingKeys;

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -181,9 +181,9 @@ export class UserManager {
             popupWindowTarget,
             ...requestArgs
         } = args;
-        const url = this.settings.popup_redirect_uri || this.settings.redirect_uri;
+        const url = this.settings.popup_redirect_uri;
         if (!url) {
-            logger.throw(new Error("No popup_redirect_uri or redirect_uri configured"));
+            logger.throw(new Error("No popup_redirect_uri configured"));
         }
 
         const handle = await this._popupNavigator.prepare({ popupWindowFeatures, popupWindowTarget });
@@ -231,7 +231,7 @@ export class UserManager {
             return await this._useRefreshToken(state);
         }
 
-        const url = this.settings.silent_redirect_uri || this.settings.redirect_uri;
+        const url = this.settings.silent_redirect_uri;
         if (!url) {
             logger.throw(new Error("No silent_redirect_uri configured"));
         }
@@ -321,7 +321,7 @@ export class UserManager {
             silentRequestTimeoutInSeconds,
             ...requestArgs
         } = args;
-        const url = this.settings.silent_redirect_uri || this.settings.redirect_uri;
+        const url = this.settings.silent_redirect_uri;
         if (!url) {
             logger.throw(new Error("No silent_redirect_uri configured"));
         }
@@ -452,7 +452,7 @@ export class UserManager {
             popupWindowTarget,
             ...requestArgs
         } = args;
-        const url = this.settings.popup_post_logout_redirect_uri || this.settings.post_logout_redirect_uri;
+        const url = this.settings.popup_post_logout_redirect_uri;
 
         const handle = await this._popupNavigator.prepare({ popupWindowFeatures, popupWindowTarget });
         await this._signout({

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -2,12 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { OidcClientSettings, OidcClientSettingsStore } from "./OidcClientSettings";
-import type { PopupWindowFeatures } from "./utils";
+import type { PopupWindowFeatures } from "./utils/PopupUtils";
 import { WebStorageStateStore } from "./WebStorageStateStore";
 import { InMemoryWebStorage } from "./InMemoryWebStorage";
 
+export const DefaultPopupWindowFeatures: PopupWindowFeatures = {
+    location: false,
+    toolbar: false,
+    height: 640,
+};
+export const DefaultPopupTarget = "_blank";
 const DefaultAccessTokenExpiringNotificationTimeInSeconds = 60;
 const DefaultCheckSessionIntervalInSeconds = 2;
+export const DefaultSilentRequestTimeoutInSeconds = 10;
 
 /**
  * The settings used to configure the {@link UserManager}.
@@ -73,14 +80,14 @@ export interface UserManagerSettings extends OidcClientSettings {
  * @public
  */
 export class UserManagerSettingsStore extends OidcClientSettingsStore {
-    public readonly popup_redirect_uri: string | undefined;
+    public readonly popup_redirect_uri: string;
     public readonly popup_post_logout_redirect_uri: string | undefined;
-    public readonly popupWindowFeatures: PopupWindowFeatures | undefined;
-    public readonly popupWindowTarget: string | undefined;
+    public readonly popupWindowFeatures: PopupWindowFeatures;
+    public readonly popupWindowTarget: string;
     public readonly redirectMethod: "replace" | "assign";
 
-    public readonly silent_redirect_uri: string | undefined;
-    public readonly silentRequestTimeoutInSeconds: number | undefined;
+    public readonly silent_redirect_uri: string;
+    public readonly silentRequestTimeoutInSeconds: number;
     public readonly automaticSilentRenew: boolean;
     public readonly validateSubOnSilentRenew: boolean;
     public readonly includeIdTokenInSilentRenew: boolean;
@@ -88,7 +95,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     public readonly monitorSession: boolean;
     public readonly monitorAnonymousSession: boolean;
     public readonly checkSessionIntervalInSeconds: number;
-    public readonly query_status_response_type: string | undefined;
+    public readonly query_status_response_type: string;
     public readonly stopCheckSessionOnError: boolean;
 
     public readonly revokeTokenTypes: ("access_token" | "refresh_token")[];
@@ -99,14 +106,14 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
 
     public constructor(args: UserManagerSettings) {
         const {
-            popup_redirect_uri,
-            popup_post_logout_redirect_uri,
-            popupWindowFeatures,
-            popupWindowTarget,
+            popup_redirect_uri = args.redirect_uri,
+            popup_post_logout_redirect_uri = args.post_logout_redirect_uri,
+            popupWindowFeatures = DefaultPopupWindowFeatures,
+            popupWindowTarget = DefaultPopupTarget,
             redirectMethod = "assign",
 
-            silent_redirect_uri,
-            silentRequestTimeoutInSeconds,
+            silent_redirect_uri = args.redirect_uri,
+            silentRequestTimeoutInSeconds = DefaultSilentRequestTimeoutInSeconds,
             automaticSilentRenew = true,
             validateSubOnSilentRenew = true,
             includeIdTokenInSilentRenew = false,
@@ -114,7 +121,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
             monitorSession = false,
             monitorAnonymousSession = false,
             checkSessionIntervalInSeconds = DefaultCheckSessionIntervalInSeconds,
-            query_status_response_type,
+            query_status_response_type = "code",
             stopCheckSessionOnError = true,
 
             revokeTokenTypes = ["access_token", "refresh_token"],
@@ -142,12 +149,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
         this.monitorAnonymousSession = monitorAnonymousSession;
         this.checkSessionIntervalInSeconds = checkSessionIntervalInSeconds;
         this.stopCheckSessionOnError = stopCheckSessionOnError;
-        if (query_status_response_type) {
-            this.query_status_response_type = query_status_response_type;
-        }
-        else {
-            this.query_status_response_type = "code";
-        }
+        this.query_status_response_type = query_status_response_type;
 
         this.revokeTokenTypes = revokeTokenTypes;
         this.revokeTokensOnSignout = revokeTokensOnSignout;

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -5,8 +5,7 @@ import { Logger } from "../utils";
 import { ErrorTimeout } from "../errors";
 import type { NavigateParams, NavigateResponse } from "./IWindow";
 import { AbstractChildWindow } from "./AbstractChildWindow";
-
-const defaultTimeoutInSeconds = 10;
+import { DefaultSilentRequestTimeoutInSeconds } from "../UserManagerSettings";
 
 /**
  * @public
@@ -24,7 +23,7 @@ export class IFrameWindow extends AbstractChildWindow {
     private _timeoutInSeconds: number;
 
     public constructor({
-        silentRequestTimeoutInSeconds = defaultTimeoutInSeconds,
+        silentRequestTimeoutInSeconds = DefaultSilentRequestTimeoutInSeconds,
     }: IFrameWindowParams) {
         super();
         this._timeoutInSeconds = silentRequestTimeoutInSeconds;

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -2,17 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Logger, PopupUtils, PopupWindowFeatures } from "../utils";
+import { DefaultPopupWindowFeatures, DefaultPopupTarget } from "../UserManagerSettings";
 import { AbstractChildWindow } from "./AbstractChildWindow";
 import type { NavigateParams, NavigateResponse } from "./IWindow";
 
 const checkForPopupClosedInterval = 500;
-const defaultPopupWindowFeatures: PopupWindowFeatures = {
-    location: false,
-    toolbar: false,
-    height: 640,
-};
-
-const defaultPopupTarget = "_blank";
 
 /**
  * @public
@@ -31,11 +25,11 @@ export class PopupWindow extends AbstractChildWindow {
     protected _window: WindowProxy | null;
 
     public constructor({
-        popupWindowTarget = defaultPopupTarget,
+        popupWindowTarget = DefaultPopupTarget,
         popupWindowFeatures = {},
     }: PopupWindowParams) {
         super();
-        const centeredPopup = PopupUtils.center({ ...defaultPopupWindowFeatures, ...popupWindowFeatures });
+        const centeredPopup = PopupUtils.center({ ...DefaultPopupWindowFeatures, ...popupWindowFeatures });
         this._window = window.open(undefined, popupWindowTarget, PopupUtils.serialize(centeredPopup));
     }
 


### PR DESCRIPTION
When working on timeout for fetch i saw that it would be better to have access to the `silentRequestTimeoutInSeconds` including default applied. This was something on my to-do list for some time. And it is easier to verify the defaults, as you only have to look into the settings and not search all over the code...

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
