### PR TITLE
refactor: align arguments of useRefreshToken to other functions

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -305,10 +305,8 @@ export class OidcClient {
     //
     // (undocumented)
     protected readonly _tokenClient: TokenClient;
-    // Warning: (ae-forgotten-export) The symbol "RefreshState" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    useRefreshToken(state: RefreshState): Promise<SigninResponse>;
+    useRefreshToken({ state, }: UseRefreshTokenArgs): Promise<SigninResponse>;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -833,6 +831,14 @@ export class User {
     token_type: string;
     // (undocumented)
     toStorageString(): string;
+}
+
+// @public (undocumented)
+export interface UseRefreshTokenArgs {
+    // Warning: (ae-forgotten-export) The symbol "RefreshState" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    state: RefreshState;
 }
 
 // @public (undocumented)

--- a/src/JsonService.test.ts
+++ b/src/JsonService.test.ts
@@ -3,6 +3,7 @@
 
 import { ErrorResponse } from "./errors";
 import { JsonService } from "./JsonService";
+
 import { mocked } from "jest-mock";
 
 describe("JsonService", () => {
@@ -18,10 +19,13 @@ describe("JsonService", () => {
             await expect(subject.getJson("http://test")).rejects.toThrow();
 
             // assert
-            expect(fetch).toBeCalledWith("http://test", {
-                headers: { Accept: "application/json" },
-                method: "GET",
-            });
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: { Accept: "application/json" },
+                    method: "GET",
+                }),
+            );
         });
 
         it("should set token as authorization header", async () => {
@@ -29,10 +33,13 @@ describe("JsonService", () => {
             await expect(subject.getJson("http://test", "token")).rejects.toThrow();
 
             // assert
-            expect(fetch).toBeCalledWith("http://test", {
-                headers: { Accept: "application/json", Authorization: "Bearer token" },
-                method: "GET",
-            });
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: { Accept: "application/json", Authorization: "Bearer token" },
+                    method: "GET",
+                }),
+            );
         });
 
         it("should fulfill promise when http response is 200", async () => {

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -347,7 +347,7 @@ describe("OidcClient", () => {
             });
 
             // act
-            const response = await subject.useRefreshToken(state);
+            const response = await subject.useRefreshToken({ state });
 
             // assert
             expect(response).toBeInstanceOf(SigninResponse);
@@ -368,7 +368,7 @@ describe("OidcClient", () => {
             });
 
             // act
-            const response = await subject.useRefreshToken(state);
+            const response = await subject.useRefreshToken({ state });
 
             // assert
             expect(response).toBeInstanceOf(SigninResponse);
@@ -399,7 +399,7 @@ describe("OidcClient", () => {
             });
 
             // act
-            await expect(subject.useRefreshToken(state))
+            await expect(subject.useRefreshToken({ state }))
                 // assert
                 .rejects.toThrow("sub in id_token does not match current sub");
         });

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -47,6 +47,13 @@ export interface CreateSigninRequestArgs {
 /**
  * @public
  */
+export interface UseRefreshTokenArgs {
+    state: RefreshState;
+}
+
+/**
+ * @public
+ */
 export type CreateSignoutRequestArgs = Omit<SignoutRequestArgs, "url" | "state_data"> & { state?: unknown };
 
 /**
@@ -151,7 +158,9 @@ export class OidcClient {
         return response;
     }
 
-    public async useRefreshToken(state: RefreshState): Promise<SigninResponse> {
+    public async useRefreshToken({
+        state,
+    }: UseRefreshTokenArgs): Promise<SigninResponse> {
         const logger = this._logger.create("useRefreshToken");
 
         const result = await this._tokenClient.exchangeRefreshToken({

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -421,7 +421,11 @@ describe("UserManager", () => {
             const refreshedUser = await subject.signinSilent();
             expect(refreshedUser).toHaveProperty("access_token", "new_access_token");
             expect(refreshedUser!.profile).toHaveProperty("nickname", "Nicholas");
-            expect(useRefreshTokenSpy).toBeCalledWith(expect.objectContaining({ refresh_token: user.refresh_token }));
+            expect(useRefreshTokenSpy).toBeCalledWith(
+                expect.objectContaining({
+                    state: { refresh_token: user.refresh_token },
+                }),
+            );
         });
     });
 

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -263,7 +263,7 @@ export class UserManager {
     }
 
     protected async _useRefreshToken(state: RefreshState): Promise<User> {
-        const response = await this._client.useRefreshToken(state);
+        const response = await this._client.useRefreshToken({ state });
         const user = new User({ ...state, ...response });
 
         await this.storeUser(user);


### PR DESCRIPTION
When working on #338 i saw this, but i think it better to merge them independently as it will make the other MR simpler to review.

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
