### PR TITLE
fix: add scope to refresh tokens

### DIFF
--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -359,7 +359,9 @@ describe("OidcClient", () => {
             const tokenResponse = {
                 access_token: "new_access_token",
             };
-            jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken").mockResolvedValue(tokenResponse);
+            const exchangeRefreshTokenMock =
+                jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken")
+                    .mockResolvedValue(tokenResponse);
             jest.spyOn(JwtUtils, "decode").mockReturnValue({ sub: "sub" });
             const state = new RefreshState({
                 refresh_token: "refresh_token",
@@ -371,6 +373,10 @@ describe("OidcClient", () => {
             const response = await subject.useRefreshToken({ state });
 
             // assert
+            expect(exchangeRefreshTokenMock).toHaveBeenCalledWith( {
+                refresh_token: "refresh_token",
+                scope: "openid",
+            });
             expect(response).toBeInstanceOf(SigninResponse);
             expect(response).toMatchObject(tokenResponse);
             expect(response).toHaveProperty("scope", state.scope);

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -167,6 +167,7 @@ export class OidcClient {
 
         const result = await this._tokenClient.exchangeRefreshToken({
             refresh_token: state.refresh_token,
+            scope: state.scope,
             timeoutInSeconds,
         });
         const response = new SigninResponse(new URLSearchParams());

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -28,6 +28,7 @@ export interface ExchangeRefreshTokenArgs {
 
     grant_type?: string;
     refresh_token: string;
+    scope?: string;
 
     timeoutInSeconds?: number;
 }


### PR DESCRIPTION
As described in #364 Azure AD requires the scope to be sent when refreshing the access token. This adds scope to the `exchangeRefreshToken` call from `useRefreshTokens`

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #364

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [X] I have included links for closing relevant issue numbers
