### PR TITLE
chore(package.json): add module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/authts/oidc-client-ts#readme",
   "license": "Apache-2.0",
   "main": "dist/umd/oidc-client-ts.js",
+  "module": "dist/esm/oidc-client-ts.js",
   "types": "dist/types/oidc-client-ts.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
This PR is simply adding a `module` field, to the `package.json` file, which points to the `esm` version of the library.

----

#### Reasoning

While trying to import `oidc-client-ts` (as a module) over a CDN I noticed the following:

```html
<script type="module" src="https://unpkg.com/oidc-client-ts@latest?module"></script>

=> Package oidc-client-ts@2.0.1 does not contain an ES module
``` 

The issue here is that the `package.json` file of `oidc-client-ts` is missing a `module` field.

This field is not official but is a common convention among bundlers to designate how to import an ESM version ([stackoverflow#47537198](https://stackoverflow.com/a/47537198)).





