### PR TITLE
Type change to allow id_token_hint arg for signoutRedirect

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -113,7 +113,7 @@ export class ErrorTimeout extends Error {
 export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "extraQueryParams" | "extraTokenParams" | "state">;
 
 // @public (undocumented)
-export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state">;
+export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint">;
 
 // Warning: (ae-forgotten-export) The symbol "Mandatory" needs to be exported by the entry point index.d.ts
 //

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -23,7 +23,7 @@ export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "extraQueryPa
 /**
  * @public
  */
-export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state">;
+export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint">;
 
 /**
  * @public


### PR DESCRIPTION
Allow passing id_token_hint to a signout redirect call.
Certain OIDC providers require this for their logout calls.

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #407

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
