### PR TITLE
reinstate clock service

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -11,6 +11,7 @@ export type AccessTokenCallback = (...ev: unknown[]) => (Promise<void> | void);
 export class AccessTokenEvents {
     constructor(args: {
         expiringNotificationTimeInSeconds: number;
+        clockService: ClockService;
     });
     addAccessTokenExpired(cb: AccessTokenCallback): () => void;
     addAccessTokenExpiring(cb: AccessTokenCallback): () => void;
@@ -33,6 +34,12 @@ export class CheckSessionIFrame {
     start(session_state: string): void;
     // (undocumented)
     stop(): void;
+}
+
+// @public
+export class ClockService {
+    // (undocumented)
+    getEpochTime(): number;
 }
 
 // @public (undocumented)
@@ -323,6 +330,7 @@ export interface OidcClientSettings {
     client_id: string;
     // (undocumented)
     client_secret?: string;
+    clockService?: ClockService;
     clockSkewInSeconds?: number;
     display?: string;
     extraQueryParams?: Record<string, string | number | boolean>;
@@ -353,7 +361,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, clockService, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -364,6 +372,8 @@ export class OidcClientSettingsStore {
     readonly client_id: string;
     // (undocumented)
     readonly client_secret: string | undefined;
+    // (undocumented)
+    readonly clockService: ClockService;
     // (undocumented)
     readonly clockSkewInSeconds: number;
     // (undocumented)
@@ -583,7 +593,7 @@ export type SigninRedirectArgs = RedirectParams & ExtraSigninRequestArgs;
 
 // @public (undocumented)
 export class SigninRequest {
-    constructor({ url, authority, client_id, redirect_uri, response_type, scope, state_data, response_mode, request_type, client_secret, skipUserInfo, extraQueryParams, extraTokenParams, ...optionalParams }: SigninRequestArgs);
+    constructor({ url, authority, client_id, redirect_uri, response_type, scope, state_data, response_mode, request_type, client_secret, skipUserInfo, extraQueryParams, extraTokenParams, ...optionalParams }: SigninRequestArgs, clockService: ClockService);
     // (undocumented)
     readonly state: SigninState;
     // (undocumented)
@@ -641,7 +651,7 @@ export interface SigninRequestArgs {
 
 // @public (undocumented)
 export class SigninResponse {
-    constructor(params: URLSearchParams);
+    constructor(params: URLSearchParams, _clockService: ClockService);
     // (undocumented)
     access_token: string;
     // (undocumented)
@@ -695,7 +705,7 @@ export class SigninState extends State {
         extraTokenParams?: Record<string, unknown>;
         response_mode?: "query" | "fragment";
         skipUserInfo?: boolean;
-    });
+    }, clockService: ClockService);
     // (undocumented)
     readonly authority: string;
     // (undocumented)
@@ -707,7 +717,7 @@ export class SigninState extends State {
     // (undocumented)
     readonly extraTokenParams: Record<string, unknown> | undefined;
     // (undocumented)
-    static fromStorageString(storageString: string): SigninState;
+    static fromStorageString(storageString: string, clockService: ClockService): SigninState;
     // (undocumented)
     readonly redirect_uri: string;
     // (undocumented)
@@ -728,7 +738,7 @@ export type SignoutRedirectArgs = RedirectParams & ExtraSignoutRequestArgs;
 
 // @public (undocumented)
 export class SignoutRequest {
-    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }: SignoutRequestArgs);
+    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }: SignoutRequestArgs, clockService: ClockService);
     // (undocumented)
     readonly state?: State;
     // (undocumented)
@@ -775,14 +785,16 @@ export class State {
         data?: unknown;
         created?: number;
         request_type?: string;
-    });
+    }, _clockService: ClockService);
     // (undocumented)
-    static clearStaleState(storage: StateStore, age: number): Promise<void>;
+    static clearStaleState(storage: StateStore, age: number, clockService: ClockService): Promise<void>;
+    // (undocumented)
+    readonly _clockService: ClockService;
     // (undocumented)
     readonly created: number;
     readonly data: unknown | undefined;
     // (undocumented)
-    static fromStorageString(storageString: string): State;
+    static fromStorageString(storageString: string, clockService: ClockService): State;
     // (undocumented)
     readonly id: string;
     // (undocumented)
@@ -815,14 +827,14 @@ export class User {
         profile: UserProfile;
         expires_at?: number;
         userState?: unknown;
-    });
+    }, _clockService: ClockService);
     access_token: string;
     get expired(): boolean | undefined;
     expires_at?: number;
     get expires_in(): number | undefined;
     set expires_in(value: number | undefined);
     // (undocumented)
-    static fromStorageString(storageString: string): User;
+    static fromStorageString(storageString: string, clockService: ClockService): User;
     id_token?: string;
     profile: UserProfile;
     refresh_token?: string;

--- a/src/AccessTokenEvents.test.ts
+++ b/src/AccessTokenEvents.test.ts
@@ -4,6 +4,7 @@
 import { Timer } from "./utils";
 import { AccessTokenEvents } from "./AccessTokenEvents";
 import type { User } from "./User";
+import { ClockService } from "./ClockService";
 
 describe("AccessTokenEvents", () => {
 
@@ -12,10 +13,11 @@ describe("AccessTokenEvents", () => {
     let expiredTimer: StubTimer;
 
     beforeEach(() => {
-        expiringTimer = new StubTimer("stub expiring timer");
-        expiredTimer = new StubTimer("stub expired timer");
+        const clockService = new ClockService();
+        expiringTimer = new StubTimer("stub expiring timer", clockService);
+        expiredTimer = new StubTimer("stub expired timer", clockService);
 
-        subject = new AccessTokenEvents({ expiringNotificationTimeInSeconds: 60 });
+        subject = new AccessTokenEvents({ expiringNotificationTimeInSeconds: 60, clockService });
 
         // access private members
         Object.assign(subject, {
@@ -128,8 +130,8 @@ class StubTimer extends Timer {
     cancelWasCalled: boolean;
     duration: number | undefined;
 
-    constructor(name: string) {
-        super(name);
+    constructor(name: string, clockService: ClockService) {
+        super(name, clockService);
         this.cancelWasCalled = false;
         this.duration = undefined;
     }

--- a/src/AccessTokenEvents.ts
+++ b/src/AccessTokenEvents.ts
@@ -3,6 +3,7 @@
 
 import { Logger, Timer } from "./utils";
 import type { User } from "./User";
+import type { ClockService } from "./ClockService";
 
 /**
  * @public
@@ -15,11 +16,13 @@ export type AccessTokenCallback = (...ev: unknown[]) => (Promise<void> | void);
 export class AccessTokenEvents {
     protected readonly _logger = new Logger("AccessTokenEvents");
 
-    private readonly _expiringTimer = new Timer("Access token expiring");
-    private readonly _expiredTimer = new Timer("Access token expired");
+    private readonly _expiringTimer: Timer;
+    private readonly _expiredTimer: Timer;
     private readonly _expiringNotificationTimeInSeconds: number;
 
-    public constructor(args: { expiringNotificationTimeInSeconds: number }) {
+    public constructor(args: { expiringNotificationTimeInSeconds: number; clockService: ClockService }) {
+        this._expiringTimer = new Timer("Access token expiring", args.clockService);
+        this._expiredTimer = new Timer("Access token expired", args.clockService);
         this._expiringNotificationTimeInSeconds = args.expiringNotificationTimeInSeconds;
     }
 

--- a/src/ClockService.ts
+++ b/src/ClockService.ts
@@ -1,0 +1,37 @@
+// Copyright (C) AuthTS Contributors
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/**
+ * A clock service (and accompanying server side time API) is required for large scale applications as incorrect user
+ * clocks are not uncommon.
+ *
+ * Examples where clock skew occurs due to an incorrect client side clock, where the clock is still "correct" in terms
+ * of wall clock time:
+ * - Incorrect DST settings
+ * - Incorrect timezone settings
+ * - Incorrect 12 hour clock (AM/PM switched by user error)
+ *
+ * Default implementation is using `Math.floor(Date.now() / 1000)`
+ *
+ * The clock service can be implemented like:
+ * ```jsx
+ * class ServerClockService extends ClockService {
+ *   private _offset = 0;
+ *   public getEpochTime(): number {
+ *     return super.getEpochTime() + _offset;
+ *   }
+ *
+ *   public async synchronize(): Promise<void> {
+ *     const serverTime = await fetchServerTime();
+ *     this._offset = serverTime - super.getEpochTime();
+ *   }
+ * }
+ * ```
+ *
+ * @public
+ */
+export class ClockService {
+    public getEpochTime(): number {
+        return Math.floor(Date.now() / 1000);
+    }
+}

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -13,11 +13,14 @@ import { SignoutRequest } from "./SignoutRequest";
 import { SignoutResponse } from "./SignoutResponse";
 import { RefreshState } from "./RefreshState";
 import { SigninResponse } from "./SigninResponse";
+import { ClockService } from "./ClockService";
 
 describe("OidcClient", () => {
+    let clockService: ClockService;
     let subject: OidcClient;
 
     beforeEach(() => {
+        clockService = new ClockService();
         subject = new OidcClient({
             authority: "authority",
             client_id: "client",
@@ -263,7 +266,7 @@ describe("OidcClient", () => {
                 redirect_uri: "http://app/cb",
                 scope: "scope",
                 request_type: "type",
-            }).toStorageString();
+            }, clockService).toStorageString();
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve(item));
 
             // act
@@ -318,7 +321,7 @@ describe("OidcClient", () => {
                 redirect_uri: "http://app/cb",
                 scope: "scope",
                 request_type: "type",
-            });
+            }, clockService);
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(async () => item.toStorageString());
             const validateSigninResponseMock = jest.spyOn(subject["_validator"], "validateSigninResponse")
@@ -568,7 +571,7 @@ describe("OidcClient", () => {
 
         it("should deserialize stored state and return state and response", async () => {
             // arrange
-            const item = new State({ id: "1", request_type: "type" }).toStorageString();
+            const item = new State({ id: "1", request_type: "type" }, clockService).toStorageString();
             jest.spyOn(subject.settings.stateStore, "get").mockImplementation(() => Promise.resolve(item));
 
             // act
@@ -587,7 +590,7 @@ describe("OidcClient", () => {
                 id: "1",
                 data: "bar",
                 request_type: "type",
-            });
+            }, clockService);
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(() => Promise.resolve(item.toStorageString()));
             const validateSignoutResponse = jest.spyOn(subject["_validator"], "validateSignoutResponse")
@@ -652,7 +655,7 @@ describe("OidcClient", () => {
             const item = new State({
                 id: "1",
                 request_type: "type",
-            });
+            }, clockService);
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(async () => item.toStorageString());
             const validateSignoutResponse = jest.spyOn(subject["_validator"], "validateSignoutResponse")
@@ -671,7 +674,7 @@ describe("OidcClient", () => {
                 id: "1",
                 data: "bar",
                 request_type: "type",
-            });
+            }, clockService);
             jest.spyOn(subject.settings.stateStore, "remove")
                 .mockImplementation(async () => item.toStorageString());
             const validateSignoutResponse = jest.spyOn(subject["_validator"], "validateSignoutResponse")

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -5,6 +5,7 @@ import { WebStorageStateStore } from "./WebStorageStateStore";
 import type { OidcMetadata } from "./OidcMetadata";
 import type { StateStore } from "./StateStore";
 import { InMemoryWebStorage } from "./InMemoryWebStorage";
+import { ClockService } from "./ClockService";
 
 const DefaultResponseType = "code";
 const DefaultScope = "openid";
@@ -79,6 +80,8 @@ export interface OidcClientSettings {
     staleStateAgeInSeconds?: number;
     /** The window of time (in seconds) to allow the current time to deviate when validating token's iat, nbf, and exp values (default: 300) */
     clockSkewInSeconds?: number;
+    /** Service that can be configured to get the clock time. Used to deal with client machines with incorrect clocks. */
+    clockService?: ClockService;
     userInfoJwtIssuer?: "ANY" | "OP" | string;
 
     /**
@@ -139,6 +142,7 @@ export class OidcClientSettingsStore {
     public readonly loadUserInfo: boolean;
     public readonly staleStateAgeInSeconds: number;
     public readonly clockSkewInSeconds: number;
+    public readonly clockService: ClockService;
     public readonly userInfoJwtIssuer: "ANY" | "OP" | string;
     public readonly mergeClaims: boolean;
 
@@ -162,6 +166,7 @@ export class OidcClientSettingsStore {
         loadUserInfo = false,
         staleStateAgeInSeconds = DefaultStaleStateAgeInSeconds,
         clockSkewInSeconds = DefaultClockSkewInSeconds,
+        clockService = new ClockService(),
         userInfoJwtIssuer = "OP",
         mergeClaims = false,
         // other behavior
@@ -209,6 +214,7 @@ export class OidcClientSettingsStore {
         this.loadUserInfo = !!loadUserInfo;
         this.staleStateAgeInSeconds = staleStateAgeInSeconds;
         this.clockSkewInSeconds = clockSkewInSeconds;
+        this.clockService = clockService;
         this.userInfoJwtIssuer = userInfoJwtIssuer;
         this.mergeClaims = !!mergeClaims;
 

--- a/src/SigninRequest.test.ts
+++ b/src/SigninRequest.test.ts
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { SigninRequest, SigninRequestArgs } from "./SigninRequest";
+import { ClockService } from "./ClockService";
 
 describe("SigninRequest", () => {
-
-    let subject: SigninRequest;
     let settings: SigninRequestArgs;
+    let clockService: ClockService;
+    let subject: SigninRequest;
 
     beforeEach(() => {
         settings = {
@@ -18,7 +19,8 @@ describe("SigninRequest", () => {
             authority : "op",
             state_data: { data: "test" },
         };
-        subject = new SigninRequest(settings);
+        clockService = new ClockService();
+        subject = new SigninRequest(settings, clockService);
     });
 
     describe("constructor", () => {
@@ -27,7 +29,7 @@ describe("SigninRequest", () => {
             Object.assign(settings, { [param]: undefined });
 
             // act
-            expect(() => new SigninRequest(settings))
+            expect(() => new SigninRequest(settings, clockService))
                 // assert
                 .toThrow(param);
         });
@@ -70,7 +72,7 @@ describe("SigninRequest", () => {
             settings.prompt = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("prompt=foo");
@@ -81,7 +83,7 @@ describe("SigninRequest", () => {
             settings.display = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("display=foo");
@@ -92,7 +94,7 @@ describe("SigninRequest", () => {
             settings.max_age = 42;
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("max_age=42");
@@ -103,7 +105,7 @@ describe("SigninRequest", () => {
             settings.ui_locales = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("ui_locales=foo");
@@ -114,7 +116,7 @@ describe("SigninRequest", () => {
             settings.id_token_hint = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("id_token_hint=foo");
@@ -125,7 +127,7 @@ describe("SigninRequest", () => {
             settings.login_hint = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("login_hint=foo");
@@ -136,7 +138,7 @@ describe("SigninRequest", () => {
             settings.acr_values = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("acr_values=foo");
@@ -147,7 +149,7 @@ describe("SigninRequest", () => {
             settings.resource = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("resource=foo");
@@ -158,7 +160,7 @@ describe("SigninRequest", () => {
             settings.response_mode = "fragment";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("response_mode=fragment");
@@ -169,7 +171,7 @@ describe("SigninRequest", () => {
             settings.request = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("request=foo");
@@ -180,7 +182,7 @@ describe("SigninRequest", () => {
             settings.request_uri = "foo";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("request_uri=foo");
@@ -194,7 +196,7 @@ describe("SigninRequest", () => {
             };
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("hd=domain.com&foo=bar");
@@ -207,7 +209,7 @@ describe("SigninRequest", () => {
             };
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.state.extraTokenParams).toEqual({
@@ -220,7 +222,7 @@ describe("SigninRequest", () => {
             settings.response_type = "code";
 
             // act
-            subject = new SigninRequest(settings);
+            subject = new SigninRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("code_challenge=");

--- a/src/SigninRequest.ts
+++ b/src/SigninRequest.ts
@@ -3,6 +3,7 @@
 
 import { Logger } from "./utils";
 import { SigninState } from "./SigninState";
+import type { ClockService } from "./ClockService";
 
 /**
  * @public
@@ -56,7 +57,7 @@ export class SigninRequest {
         extraQueryParams,
         extraTokenParams,
         ...optionalParams
-    }: SigninRequestArgs) {
+    }: SigninRequestArgs, clockService: ClockService) {
         if (!url) {
             this._logger.error("ctor: No url passed");
             throw new Error("url");
@@ -90,7 +91,7 @@ export class SigninRequest {
             response_mode,
             client_secret, scope, extraTokenParams,
             skipUserInfo,
-        });
+        }, clockService);
 
         const parsedUrl = new URL(url);
         parsedUrl.searchParams.append("client_id", client_id);

--- a/src/SigninResponse.test.ts
+++ b/src/SigninResponse.test.ts
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { SigninResponse } from "./SigninResponse";
-import { Timer } from "./utils";
+import { ClockService } from "./ClockService";
 
 describe("SigninResponse", () => {
     let now: number;
+    let clockService: ClockService;
 
     beforeEach(() => {
         now = 0;
-        jest.spyOn(Timer, "getEpochTime").mockImplementation(() => now);
+        clockService = new ClockService();
+        jest.spyOn(clockService, "getEpochTime").mockImplementation(() => now);
     });
 
     afterEach(() => {
@@ -19,7 +21,7 @@ describe("SigninResponse", () => {
     describe("constructor", () => {
         it("should read error", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams("error=foo"));
+            const subject = new SigninResponse(new URLSearchParams("error=foo"), clockService);
 
             // assert
             expect(subject.error).toEqual("foo");
@@ -27,7 +29,7 @@ describe("SigninResponse", () => {
 
         it("should read error_description", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams("error_description=foo"));
+            const subject = new SigninResponse(new URLSearchParams("error_description=foo"), clockService);
 
             // assert
             expect(subject.error_description).toEqual("foo");
@@ -35,7 +37,7 @@ describe("SigninResponse", () => {
 
         it("should read error_uri", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams("error_uri=foo"));
+            const subject = new SigninResponse(new URLSearchParams("error_uri=foo"), clockService);
 
             // assert
             expect(subject.error_uri).toEqual("foo");
@@ -43,7 +45,7 @@ describe("SigninResponse", () => {
 
         it("should read state", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams("state=foo"));
+            const subject = new SigninResponse(new URLSearchParams("state=foo"), clockService);
 
             // assert
             expect(subject.state).toEqual("foo");
@@ -51,7 +53,7 @@ describe("SigninResponse", () => {
 
         it("should read code", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams("code=foo"));
+            const subject = new SigninResponse(new URLSearchParams("code=foo"), clockService);
 
             // assert
             expect(subject.code).toEqual("foo");
@@ -59,7 +61,7 @@ describe("SigninResponse", () => {
 
         it("should read session_state", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams("session_state=foo"));
+            const subject = new SigninResponse(new URLSearchParams("session_state=foo"), clockService);
 
             // assert
             expect(subject.session_state).toEqual("foo");
@@ -67,11 +69,11 @@ describe("SigninResponse", () => {
 
         it("should calculate expires_at", () => {
             // act
-            const subject = new SigninResponse(new URLSearchParams());
+            const subject = new SigninResponse(new URLSearchParams(), clockService);
             Object.assign(subject, { expires_in: 10 });
 
             // assert
-            expect(subject.expires_at).toEqual(Timer.getEpochTime() + 10);
+            expect(subject.expires_at).toEqual(10);
         });
 
         it.each([
@@ -79,7 +81,7 @@ describe("SigninResponse", () => {
             [-10],
         ])("should not read invalid expires_in", (expires_in) => {
             // act
-            const subject = new SigninResponse(new URLSearchParams());
+            const subject = new SigninResponse(new URLSearchParams(), clockService);
             Object.assign(subject, { expires_in });
 
             // assert
@@ -90,7 +92,7 @@ describe("SigninResponse", () => {
 
     describe("expires_in", () => {
         it("should calculate how much time left", () => {
-            const subject = new SigninResponse(new URLSearchParams());
+            const subject = new SigninResponse(new URLSearchParams(), clockService);
             Object.assign(subject, { expires_in: 100 });
 
             // act
@@ -103,7 +105,7 @@ describe("SigninResponse", () => {
 
     describe("isOpenId", () => {
         it("should detect openid scope", () => {
-            const subject = new SigninResponse(new URLSearchParams());
+            const subject = new SigninResponse(new URLSearchParams(), clockService);
 
             // act
             Object.assign(subject, { scope: "foo openid bar" });
@@ -131,7 +133,7 @@ describe("SigninResponse", () => {
         });
 
         it("shoud detect id_token", () => {
-            const subject = new SigninResponse(new URLSearchParams());
+            const subject = new SigninResponse(new URLSearchParams(), clockService);
 
             // act
             Object.assign(subject, { id_token: undefined });

--- a/src/SigninResponse.ts
+++ b/src/SigninResponse.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Timer } from "./utils";
 import type { UserProfile } from "./User";
+import type { ClockService } from "./ClockService";
 
 const OidcScope = "openid";
 
@@ -46,7 +46,7 @@ export class SigninResponse {
     /** @see {@link User.profile} */
     public profile: UserProfile = {} as UserProfile;
 
-    public constructor(params: URLSearchParams) {
+    public constructor(params: URLSearchParams, private readonly _clockService: ClockService) {
         this.state = params.get("state");
         this.session_state = params.get("session_state");
 
@@ -61,13 +61,13 @@ export class SigninResponse {
         if (this.expires_at === undefined) {
             return undefined;
         }
-        return this.expires_at - Timer.getEpochTime();
+        return this.expires_at - this._clockService.getEpochTime();
     }
     public set expires_in(value: number | undefined) {
         // spec expects a number, but normalize here just in case
         if (typeof value === "string") value = Number(value);
         if (value !== undefined && value >= 0) {
-            this.expires_at = Math.floor(value) + Timer.getEpochTime();
+            this.expires_at = Math.floor(value) + this._clockService.getEpochTime();
         }
     }
 

--- a/src/SigninState.test.ts
+++ b/src/SigninState.test.ts
@@ -2,8 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { SigninState } from "./SigninState";
+import { ClockService } from "./ClockService";
 
 describe("SigninState", () => {
+    let clockService: ClockService;
+
+    beforeEach(() => {
+        clockService = new ClockService();
+    });
+
     describe("constructor", () => {
 
         it("should call base ctor", () => {
@@ -18,7 +25,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 request_type: "type",
                 scope: "scope",
-            });
+            }, clockService);
 
             // assert
             expect(subject.id).toEqual("5");
@@ -34,7 +41,7 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 redirect_uri: "http://cb",
-            });
+            }, clockService);
 
             // assert
             expect(subject.redirect_uri).toEqual("http://cb");
@@ -49,7 +56,7 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 code_verifier: "5",
-            });
+            }, clockService);
 
             // assert
             expect(subject.code_verifier).toEqual("5");
@@ -64,7 +71,7 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 code_verifier: true,
-            });
+            }, clockService);
 
             // assert
             expect(subject.code_verifier).toBeDefined();
@@ -81,7 +88,7 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 code_verifier: true,
-            });
+            }, clockService);
 
             // assert
             expect(subject.code_challenge).toBeDefined();
@@ -95,7 +102,7 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 client_id: "client",
-            });
+            }, clockService);
 
             // assert
             expect(subject.client_id).toEqual("client");
@@ -109,7 +116,7 @@ describe("SigninState", () => {
                 scope: "scope",
                 request_type: "type",
                 authority: "test",
-            });
+            }, clockService);
 
             // assert
             expect(subject.authority).toEqual("test");
@@ -123,7 +130,7 @@ describe("SigninState", () => {
                 redirect_uri: "http://cb",
                 scope: "scope",
                 request_type: "xoxo",
-            });
+            }, clockService);
 
             // assert
             expect(subject.request_type).toEqual("xoxo");
@@ -140,7 +147,7 @@ describe("SigninState", () => {
                 extraTokenParams: {
                     "resourceServer" : "abc",
                 },
-            });
+            }, clockService);
 
             // assert
             expect(subject.extraTokenParams).toEqual({ "resourceServer" : "abc" });
@@ -158,11 +165,11 @@ describe("SigninState", () => {
             redirect_uri: "http://cb",
             scope: "scope",
             request_type: "type",
-        });
+        }, clockService);
 
         // act
         const storage = subject1.toStorageString();
-        const subject2 = SigninState.fromStorageString(storage);
+        const subject2 = SigninState.fromStorageString(storage, clockService);
 
         // assert
         expect(subject2).toEqual(subject1);

--- a/src/SigninState.ts
+++ b/src/SigninState.ts
@@ -3,6 +3,7 @@
 
 import { Logger, CryptoUtils } from "./utils";
 import { State } from "./State";
+import type { ClockService } from "./ClockService";
 
 /**
  * @public
@@ -47,8 +48,8 @@ export class SigninState extends State {
         extraTokenParams?: Record<string, unknown>;
         response_mode?: "query" | "fragment";
         skipUserInfo?: boolean;
-    }) {
-        super(args);
+    }, clockService: ClockService) {
+        super(args, clockService);
 
         if (args.code_verifier === true) {
             this.code_verifier = CryptoUtils.generateCodeVerifier();
@@ -92,9 +93,9 @@ export class SigninState extends State {
         });
     }
 
-    public static fromStorageString(storageString: string): SigninState {
+    public static fromStorageString(storageString: string, clockService: ClockService): SigninState {
         Logger.createStatic("SigninState", "fromStorageString");
         const data = JSON.parse(storageString);
-        return new SigninState(data);
+        return new SigninState(data, clockService);
     }
 }

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { SignoutRequest, SignoutRequestArgs } from "./SignoutRequest";
+import { ClockService } from "./ClockService";
 
 describe("SignoutRequest", () => {
-
-    let subject: SignoutRequest;
     let settings: SignoutRequestArgs;
+    let clockService: ClockService;
+    let subject: SignoutRequest;
 
     beforeEach(() => {
         settings = {
@@ -15,7 +16,8 @@ describe("SignoutRequest", () => {
             post_logout_redirect_uri: "loggedout",
             state_data: { data: "test" },
         };
-        subject = new SignoutRequest(settings);
+        clockService = new ClockService();
+        subject = new SignoutRequest(settings, clockService);
     });
 
     describe("constructor", () => {
@@ -26,7 +28,7 @@ describe("SignoutRequest", () => {
 
             // act
             try {
-                new SignoutRequest(settings);
+                new SignoutRequest(settings, clockService);
                 fail("should not come here");
             }
             catch (err) {
@@ -58,7 +60,7 @@ describe("SignoutRequest", () => {
             delete settings.id_token_hint;
 
             // act
-            subject = new SignoutRequest(settings);
+            subject = new SignoutRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("post_logout_redirect_uri=loggedout");
@@ -75,7 +77,7 @@ describe("SignoutRequest", () => {
             delete settings.post_logout_redirect_uri;
 
             // act
-            subject = new SignoutRequest(settings);
+            subject = new SignoutRequest(settings, clockService);
 
             // assert
             expect(subject.url).not.toContain("state=");
@@ -99,7 +101,7 @@ describe("SignoutRequest", () => {
             };
 
             // act
-            subject = new SignoutRequest(settings);
+            subject = new SignoutRequest(settings, clockService);
 
             // assert
             expect(subject.url).toContain("TargetResource=logouturl.com&InErrorResource=errorurl.com");

--- a/src/SignoutRequest.ts
+++ b/src/SignoutRequest.ts
@@ -3,6 +3,7 @@
 
 import { Logger } from "./utils";
 import { State } from "./State";
+import type { ClockService } from "./ClockService";
 
 /**
  * @public
@@ -31,7 +32,7 @@ export class SignoutRequest {
     public constructor({
         url,
         state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
-    }: SignoutRequestArgs) {
+    }: SignoutRequestArgs, clockService: ClockService) {
         if (!url) {
             this._logger.error("ctor: No url passed");
             throw new Error("url");
@@ -46,7 +47,7 @@ export class SignoutRequest {
             parsedUrl.searchParams.append("post_logout_redirect_uri", post_logout_redirect_uri);
 
             if (state_data) {
-                this.state = new State({ data: state_data, request_type });
+                this.state = new State({ data: state_data, request_type }, clockService);
 
                 parsedUrl.searchParams.append("state", this.state.id);
             }

--- a/src/SilentRenewService.ts
+++ b/src/SilentRenewService.ts
@@ -12,9 +12,11 @@ import type { AccessTokenCallback } from "./AccessTokenEvents";
 export class SilentRenewService {
     protected _logger = new Logger("SilentRenewService");
     private _isStarted = false;
-    private readonly _retryTimer = new Timer("Retry Silent Renew");
+    private readonly _retryTimer: Timer;
 
-    public constructor(private _userManager: UserManager) {}
+    public constructor(private _userManager: UserManager) {
+        this._retryTimer = new Timer("Retry Silent Renew", _userManager.settings.clockService);
+    }
 
     public async start(): Promise<void> {
         const logger = this._logger.create("start");

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -5,15 +5,22 @@ import { State } from "./State";
 
 import { InMemoryWebStorage } from "./InMemoryWebStorage";
 import { WebStorageStateStore } from "./WebStorageStateStore";
+import { ClockService } from "./ClockService";
 
 describe("State", () => {
+    let clockService: ClockService;
+
+    beforeEach(() => {
+        clockService = new ClockService();
+    });
+
     describe("constructor", () => {
 
         it("should generate id", () => {
             // act
             const subject = new State({
                 request_type: "type",
-            });
+            }, clockService);
 
             // assert
             expect(subject.id).toBeDefined();
@@ -24,7 +31,7 @@ describe("State", () => {
             const subject = new State({
                 request_type: "type",
                 id: "5",
-            });
+            }, clockService);
 
             // assert
             expect(subject.id).toEqual("5");
@@ -35,7 +42,7 @@ describe("State", () => {
             const subject = new State({
                 request_type: "type",
                 data: "test",
-            });
+            }, clockService);
 
             // assert
             expect(subject.data).toEqual("test");
@@ -46,7 +53,7 @@ describe("State", () => {
             const subject = new State({
                 request_type: "type",
                 data: { foo: "test" },
-            });
+            }, clockService);
 
             // assert
             expect(subject.data).toEqual({ foo: "test" });
@@ -57,7 +64,7 @@ describe("State", () => {
             const subject = new State({
                 request_type: "type",
                 created: 1000,
-            });
+            }, clockService);
 
             // assert
             expect(subject.created).toEqual(1000);
@@ -73,7 +80,7 @@ describe("State", () => {
             // act
             const subject = new State({
                 request_type: "type",
-            });
+            }, clockService);
 
             // assert
             expect(subject.created).toEqual(123);
@@ -84,7 +91,7 @@ describe("State", () => {
             // act
             const subject = new State({
                 request_type: "xoxo",
-            });
+            }, clockService);
 
             // assert
             expect(subject.request_type).toEqual("xoxo");
@@ -95,11 +102,11 @@ describe("State", () => {
         // arrange
         const subject1 = new State({
             data: { foo: "test" }, created: 1000, request_type:"type",
-        });
+        }, clockService);
 
         // act
         const storage = subject1.toStorageString();
-        const subject2 = State.fromStorageString(storage);
+        const subject2 = State.fromStorageString(storage, clockService);
 
         // assert
         expect(subject2).toEqual(subject1);
@@ -118,11 +125,11 @@ describe("State", () => {
             const inMemStore = new InMemoryWebStorage();
             const store = new WebStorageStateStore({ prefix: prefix, store: inMemStore });
 
-            const s1 = new State({ id: "s1", created: 5, request_type:"type" });
-            const s2 = new State({ id: "s2", created: 99, request_type:"type" });
-            const s3 = new State({ id: "s3", created: 100, request_type:"type" });
-            const s4 = new State({ id: "s4", created: 101, request_type:"type" });
-            const s5 = new State({ id: "s5", created: 150, request_type:"type" });
+            const s1 = new State({ id: "s1", created: 5, request_type:"type" }, clockService);
+            const s2 = new State({ id: "s2", created: 99, request_type:"type" }, clockService);
+            const s3 = new State({ id: "s3", created: 100, request_type:"type" }, clockService);
+            const s4 = new State({ id: "s4", created: 101, request_type:"type" }, clockService);
+            const s5 = new State({ id: "s5", created: 150, request_type:"type" }, clockService);
 
             inMemStore.setItem("junk0", "junk");
             inMemStore.setItem(prefix + s1.id, s1.toStorageString());
@@ -137,7 +144,7 @@ describe("State", () => {
             inMemStore.setItem("junk5", "junk");
 
             // act
-            await State.clearStaleState(store, 100);
+            await State.clearStaleState(store, 100, clockService);
 
             // assert
             expect(inMemStore.length).toEqual(8);

--- a/src/State.ts
+++ b/src/State.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger, CryptoUtils, Timer } from "./utils";
+import { Logger, CryptoUtils } from "./utils";
 import type { StateStore } from "./StateStore";
+import type { ClockService } from "./ClockService";
 
 /**
  * @public
@@ -20,7 +21,7 @@ export class State {
         data?: unknown;
         created?: number;
         request_type?: string;
-    }) {
+    }, public readonly _clockService: ClockService) {
         this.id = args.id || CryptoUtils.generateUUIDv4();
         this.data = args.data;
 
@@ -28,7 +29,7 @@ export class State {
             this.created = args.created;
         }
         else {
-            this.created = Timer.getEpochTime();
+            this.created = this._clockService.getEpochTime();
         }
         this.request_type = args.request_type;
     }
@@ -43,14 +44,14 @@ export class State {
         });
     }
 
-    public static fromStorageString(storageString: string): State {
+    public static fromStorageString(storageString: string, clockService: ClockService): State {
         Logger.createStatic("State", "fromStorageString");
-        return new State(JSON.parse(storageString));
+        return new State(JSON.parse(storageString), clockService);
     }
 
-    public static async clearStaleState(storage: StateStore, age: number): Promise<void> {
+    public static async clearStaleState(storage: StateStore, age: number, clockService: ClockService): Promise<void> {
         const logger = Logger.createStatic("State", "clearStaleState");
-        const cutoff = Timer.getEpochTime() - age;
+        const cutoff = clockService.getEpochTime() - age;
 
         const keys = await storage.getAllKeys();
         logger.debug("got keys", keys);
@@ -62,7 +63,7 @@ export class State {
 
             if (item) {
                 try {
-                    const state = State.fromStorageString(item);
+                    const state = State.fromStorageString(item, clockService);
 
                     logger.debug("got item from key:", key, state.created);
                     if (state.created <= cutoff) {

--- a/src/User.test.ts
+++ b/src/User.test.ts
@@ -1,13 +1,14 @@
 import { User } from "./User";
-import { Timer } from "./utils";
+import { ClockService } from "./ClockService";
 
 describe("User", () => {
-
     let now: number;
+    let clockService: ClockService;
 
     beforeEach(() => {
         now = 0;
-        jest.spyOn(Timer, "getEpochTime").mockImplementation(() => now);
+        clockService = new ClockService();
+        jest.spyOn(clockService, "getEpochTime").mockImplementation(() => now);
     });
 
     afterEach(() => {
@@ -16,7 +17,7 @@ describe("User", () => {
 
     describe("expired", () => {
         it("should calculate how much time left", () => {
-            const subject = new User({ expires_at: 100 } as never);
+            const subject = new User({ expires_at: 100 } as never, clockService);
             expect(subject.expired).toEqual(false);
 
             // act
@@ -29,17 +30,17 @@ describe("User", () => {
 
     describe("scopes", () => {
         it("should return list of scopes", () => {
-            let subject = new User({ scope: "foo" } as never);
+            let subject = new User({ scope: "foo" } as never, clockService);
 
             // assert
             expect(subject.scopes).toEqual(["foo"]);
 
-            subject = new User({ scope: "foo bar" } as never);
+            subject = new User({ scope: "foo bar" } as never, clockService);
 
             // assert
             expect(subject.scopes).toEqual(["foo", "bar"]);
 
-            subject = new User({ scope: "foo bar baz" } as never);
+            subject = new User({ scope: "foo bar baz" } as never, clockService);
 
             // assert
             expect(subject.scopes).toEqual(["foo", "bar", "baz"]);

--- a/src/User.ts
+++ b/src/User.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Logger, Timer } from "./utils";
+import { Logger } from "./utils";
 import type { IdTokenClaims } from "./Claims";
+import type { ClockService } from "./ClockService";
 
 /**
  * Holds claims represented by a combination of the `id_token` and the user info endpoint.
@@ -61,7 +62,7 @@ export class User {
         profile: UserProfile;
         expires_at?: number;
         userState?: unknown;
-    }) {
+    }, private readonly _clockService: ClockService) {
         this.id_token = args.id_token;
         this.session_state = args.session_state ?? null;
         this.access_token = args.access_token;
@@ -79,12 +80,12 @@ export class User {
         if (this.expires_at === undefined) {
             return undefined;
         }
-        return this.expires_at - Timer.getEpochTime();
+        return this.expires_at - this._clockService.getEpochTime();
     }
 
     public set expires_in(value: number | undefined) {
         if (value !== undefined) {
-            this.expires_at = Math.floor(value) + Timer.getEpochTime();
+            this.expires_at = Math.floor(value) + this._clockService.getEpochTime();
         }
     }
 
@@ -116,8 +117,8 @@ export class User {
         });
     }
 
-    public static fromStorageString(storageString: string): User {
+    public static fromStorageString(storageString: string, clockService: ClockService): User {
         Logger.createStatic("User", "fromStorageString");
-        return new User(JSON.parse(storageString));
+        return new User(JSON.parse(storageString), clockService);
     }
 }

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -11,18 +11,20 @@ import type { UserProfile } from "./User";
 import { WebStorageStateStore } from "./WebStorageStateStore";
 import type { SigninState } from "./SigninState";
 import type { State } from "./State";
+import { ClockService } from "./ClockService";
 
 import { mocked } from "jest-mock";
 
 describe("UserManager", () => {
     let userStoreMock: WebStorageStateStore;
-
+    let clockService: ClockService;
     let subject: UserManager;
 
     beforeEach(() => {
         localStorage.clear();
 
         userStoreMock = new WebStorageStateStore();
+        clockService = new ClockService();
 
         subject = new UserManager({
             authority: "http://sts/oidc",
@@ -69,7 +71,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
             subject["_loadUser"] = jest.fn().mockReturnValue(user);
             const loadMock = jest.spyOn(subject["_events"], "load");
 
@@ -264,7 +266,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
             const handle = { } as PopupWindow;
             jest.spyOn(subject["_popupNavigator"], "prepare")
                 .mockImplementation(() => Promise.resolve(handle));
@@ -314,7 +316,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
 
             Object.assign(subject.settings, {
                 silentRequestTimeoutInSeconds: 123,
@@ -351,7 +353,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
             jest.spyOn(subject["_popupNavigator"], "prepare");
             subject["_signin"] = jest.fn().mockResolvedValue(user);
             const extraArgs: SigninSilentArgs = {
@@ -386,7 +388,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
             Object.assign(subject.settings, {
                 silent_redirect_uri: "http://client/silent_callback",
             });
@@ -406,7 +408,7 @@ describe("UserManager", () => {
                     sub: "sub",
                     nickname: "Nick",
                 } as UserProfile,
-            });
+            }, clockService);
 
             const useRefreshTokenSpy = jest.spyOn(subject["_client"], "useRefreshToken").mockResolvedValue({
                 access_token: "new_access_token",
@@ -450,7 +452,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
             const responseState = {
                 state: { request_type: "si:r" } as SigninState,
                 response: { } as SigninResponse,
@@ -586,7 +588,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
 
             // act
             await subject.storeUser(user);
@@ -602,7 +604,7 @@ describe("UserManager", () => {
                 access_token: "access_token",
                 token_type: "token_type",
                 profile: {} as UserProfile,
-            });
+            }, clockService);
             await subject.storeUser(user);
 
             // act

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -267,7 +267,7 @@ export class UserManager {
             state,
             timeoutInSeconds: this.settings.silentRequestTimeoutInSeconds,
         });
-        const user = new User({ ...state, ...response });
+        const user = new User({ ...state, ...response }, this.settings.clockService);
 
         await this.storeUser(user);
         this._events.load(user);
@@ -401,7 +401,7 @@ export class UserManager {
         const signinResponse = await this._client.processSigninResponse(url);
         logger.debug("got signin response");
 
-        const user = new User(signinResponse);
+        const user = new User(signinResponse, this.settings.clockService);
         if (verifySub) {
             if (verifySub !== user.profile.sub) {
                 logger.debug("current user does not match user returned from signin. sub from signin:", user.profile.sub);
@@ -584,7 +584,7 @@ export class UserManager {
         const storageString = await this.settings.userStore.get(this._userStoreKey);
         if (storageString) {
             logger.debug("user storageString loaded");
-            return User.fromStorageString(storageString);
+            return User.fromStorageString(storageString, this.settings.clockService);
         }
 
         logger.debug("no user storageString");

--- a/src/UserManagerEvents.ts
+++ b/src/UserManagerEvents.ts
@@ -45,7 +45,10 @@ export class UserManagerEvents extends AccessTokenEvents {
     private readonly _userSessionChanged = new Event<[]>("User session changed");
 
     public constructor(settings: UserManagerSettingsStore) {
-        super({ expiringNotificationTimeInSeconds: settings.accessTokenExpiringNotificationTimeInSeconds });
+        super({
+            expiringNotificationTimeInSeconds: settings.accessTokenExpiringNotificationTimeInSeconds,
+            clockService: settings.clockService,
+        });
     }
 
     public load(user: User, raiseEvent=true): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type { IFrameWindowParams, PopupWindowParams, RedirectParams } from "./na
 export { Log, Logger } from "./utils";
 export type { ILogger, PopupWindowFeatures } from "./utils";
 export type { OidcAddressClaim, OidcStandardClaims, IdTokenClaims, JwtClaims } from "./Claims";
-
+export type { ClockService } from "./ClockService";
 export { AccessTokenEvents } from "./AccessTokenEvents";
 export type { AccessTokenCallback } from "./AccessTokenEvents";
 export { CheckSessionIFrame } from "./CheckSessionIFrame";

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Timer } from "./Timer";
+import { ClockService } from "../ClockService";
 
 describe("Timer", () => {
-
+    let clockService: StubClockService;
     let subject: Timer;
-    let now = 1;
 
     beforeEach(() => {
-        subject = new Timer("test name");
-        jest.spyOn(Timer, "getEpochTime").mockImplementation(() => now);
+        clockService = new StubClockService();
+        subject = new Timer("test name", clockService);
         jest.useFakeTimers();
         jest.spyOn(globalThis, "clearInterval");
         jest.spyOn(globalThis, "setInterval");
@@ -66,7 +66,7 @@ describe("Timer", () => {
             expect(clearInterval).not.toHaveBeenCalled();
 
             // act
-            now += 1;
+            clockService.now += 1;
             subject.init(10);
 
             // assert
@@ -101,14 +101,14 @@ describe("Timer", () => {
             expect(setInterval).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
 
             // act
-            now += 9;
+            clockService.now += 9;
             jest.runOnlyPendingTimers();
 
             // assert
             expect(cb).toBeCalledTimes(0);
 
             // act
-            now += 1;
+            clockService.now += 1;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -125,13 +125,13 @@ describe("Timer", () => {
             // assert
             expect(setInterval).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
 
-            now += 9;
+            clockService.now += 9;
             jest.runOnlyPendingTimers();
 
             // assert
             expect(cb).toBeCalledTimes(0);
 
-            now += 2;
+            clockService.now += 2;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -145,7 +145,7 @@ describe("Timer", () => {
             // assert
             expect(setInterval).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
 
-            now += 10;
+            clockService.now += 10;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -187,7 +187,7 @@ describe("Timer", () => {
             // act
             subject.addHandler(cb);
             subject.init(10);
-            now += 10;
+            clockService.now += 10;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -204,7 +204,7 @@ describe("Timer", () => {
             subject.addHandler(cb);
             subject.addHandler(cb);
             subject.init(10);
-            now += 10;
+            clockService.now += 10;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -222,7 +222,7 @@ describe("Timer", () => {
 
             // act
             subject.removeHandler(cb);
-            now += 10;
+            clockService.now += 10;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -241,7 +241,7 @@ describe("Timer", () => {
             subject.init(10);
             subject.removeHandler(cb1);
             subject.removeHandler(cb1);
-            now += 10;
+            clockService.now += 10;
             jest.runOnlyPendingTimers();
 
             // assert
@@ -250,3 +250,10 @@ describe("Timer", () => {
         });
     });
 });
+
+class StubClockService extends ClockService {
+    public now = 1;
+    getEpochTime(): number {
+        return this.now;
+    }
+}


### PR DESCRIPTION
I dropped the clock service when migrating to Typescript. Thought it was only used because of unit-testing, which is not the case. This MR ports that functionality in the same way as the legacy library.
I make the `getEpochTime` in the `ClockService` return a none promise. As the `Timer` now uses `getEpochTime` from `ClockService`, but there are other modules which need an unchangeable  `getEpochTime` function too i have added a `DateUtils` class. 

Closes/fixes #414

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
