### PR TITLE
fix(UserManager): handle concurrent token refresh requests via leader election

### DIFF
--- a/src/LockManager.d.ts
+++ b/src/LockManager.d.ts
@@ -1,0 +1,49 @@
+// This is temporary until oidc-client-ts updates to a newer TypeScript version.
+// @see https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1291
+declare global {
+    interface Navigator {
+        locks : LockManager;
+    }
+
+    interface LockManager {
+        request<T>(
+            name : string,
+            callback : (lock? : Lock) => Promise<T> | T
+        ) : Promise<T>;
+
+        request<T>(
+            name : string,
+            options : LockOptions,
+            callback : (lock? : Lock) => Promise<T> | T
+        ) : Promise<T>;
+
+        query() : Promise<LockManagerSnapshot>;
+    }
+
+    type LockMode = "shared" | "exclusive";
+
+    interface LockOptions {
+        mode? : LockMode;
+        ifAvailable? : boolean;
+        steal? : boolean;
+        signal? : AbortSignal;
+    }
+
+    interface LockManagerSnapshot {
+        held : LockInfo[];
+        pending : LockInfo[];
+    }
+
+    interface LockInfo {
+        name : string;
+        mode : LockMode;
+        clientId : string;
+    }
+
+    interface Lock {
+        name : string;
+        mode : LockMode;
+    }
+}
+
+export {};

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -294,6 +294,7 @@ export class UserManager {
                     broadcastChannel.postMessage(user);
                 }
 
+                broadcastChannel.close();
                 await this.storeUser(user);
                 this._events.load(user);
                 return user;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,97 @@
 import { Log } from "../src";
 
-beforeAll(() => {
+// While NodeJs 15.4 has an experimental implementation, it is not API compatible with the browser version.
+class BroadcastChannelPolyfill {
+    public onmessage = null;
+    public onmessageerror = null;
+    private static _eventTargets: Record<string, EventTarget> = {};
+
+    public constructor(public readonly name: string) {
+        if (!(name in BroadcastChannelPolyfill._eventTargets)) {
+            BroadcastChannelPolyfill._eventTargets[name] = new EventTarget();
+        }
+    }
+
+    public close(): void {
+        // no-op
+    }
+
+    public dispatchEvent(): boolean {
+        return true;
+    }
+
+    public postMessage(message: unknown): void {
+        const messageEvent = new Event("message") as Event & { data : unknown };
+        messageEvent.data = message;
+        BroadcastChannelPolyfill._eventTargets[this.name].dispatchEvent(messageEvent);
+    }
+
+    public addEventListener<K extends keyof BroadcastChannelEventMap>(
+        type: K,
+        listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => unknown,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    public addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void {
+        BroadcastChannelPolyfill._eventTargets[this.name].addEventListener("message", listener, options);
+    }
+
+    public removeEventListener<K extends keyof BroadcastChannelEventMap>(
+        type: K,
+        listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => unknown,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    public removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void {
+        BroadcastChannelPolyfill._eventTargets[this.name].removeEventListener("message", listener, options);
+    }
+}
+
+globalThis.BroadcastChannel = BroadcastChannelPolyfill;
+
+class LockManagerPolyfill {
+    private _locks: Set<string> = new Set();
+
+    public async request<T>(
+        name: string,
+        options: LockOptions | ((lock?: Lock) => Promise<T> | T),
+        callback?: (lock?: Lock) => Promise<T> | T,
+    ): Promise<T> {
+        if (options instanceof Function) {
+            callback = options;
+            options = {};
+        }
+
+        while (this._locks.has(name)) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+        }
+
+        this._locks.add(name);
+
+        try {
+            return await callback!({ name, mode: options.mode ?? "exclusive" });
+        } finally {
+            this._locks.delete(name);
+        }
+    }
+
+    public async query(): Promise<LockManagerSnapshot> {
+        return await Promise.resolve({
+            held: [],
+            pending: [],
+        });
+    }
+}
+
+globalThis.navigator.locks = new LockManagerPolyfill();
+
+beforeAll(async () => {
     globalThis.fetch = jest.fn();
 
     const unload = () => window.dispatchEvent(new Event("unload"));

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,6 @@
     "emitDeclarationOnly": true,
     "tsBuildInfoFile": "tsconfig.build.tsbuildinfo"
   },
-  "files": ["src/index.ts"],
+  "files": ["src/index.ts", "src/LockManager.d.ts"],
   "include": []
 }


### PR DESCRIPTION
Introduces leader election for concurrent token refresh requests. This adds a new dependency (broadcast-channel) which takes care of the election process.

Closes #430