### PR TITLE
Add extra sign out query params

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -115,7 +115,7 @@ export class ErrorTimeout extends Error {
 export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state">;
 
 // @public (undocumented)
-export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;
+export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "extraSignoutQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;
 
 // Warning: (ae-forgotten-export) The symbol "Mandatory" needs to be exported by the entry point index.d.ts
 //
@@ -282,7 +282,7 @@ export class OidcClient {
     // (undocumented)
     createSigninRequest({ state, request, request_uri, request_type, id_token_hint, login_hint, skipUserInfo, nonce, response_type, scope, redirect_uri, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, extraQueryParams, extraTokenParams, }: CreateSigninRequestArgs): Promise<SigninRequest>;
     // (undocumented)
-    createSignoutRequest({ state, id_token_hint, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
+    createSignoutRequest({ state, id_token_hint, request_type, post_logout_redirect_uri, extraQueryParams, extraSignoutQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
     // (undocumented)
     protected readonly _logger: Logger;
     // (undocumented)
@@ -328,6 +328,7 @@ export interface OidcClientSettings {
     clockSkewInSeconds?: number;
     display?: string;
     extraQueryParams?: Record<string, string | number | boolean>;
+    extraSignoutQueryParams?: Record<string, string | number | boolean>;
     // (undocumented)
     extraTokenParams?: Record<string, unknown>;
     filterProtocolClaims?: boolean;
@@ -355,7 +356,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraSignoutQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -372,6 +373,8 @@ export class OidcClientSettingsStore {
     readonly display: string | undefined;
     // (undocumented)
     readonly extraQueryParams: Record<string, string | number | boolean>;
+    // (undocumented)
+    readonly extraSignoutQueryParams: Record<string, string | number | boolean>;
     // (undocumented)
     readonly extraTokenParams: Record<string, unknown>;
     // (undocumented)
@@ -732,7 +735,7 @@ export type SignoutRedirectArgs = RedirectParams & ExtraSignoutRequestArgs;
 
 // @public (undocumented)
 export class SignoutRequest {
-    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }: SignoutRequestArgs);
+    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, extraSignoutQueryParams, request_type, }: SignoutRequestArgs);
     // (undocumented)
     readonly state?: State;
     // (undocumented)
@@ -743,6 +746,8 @@ export class SignoutRequest {
 export interface SignoutRequestArgs {
     // (undocumented)
     extraQueryParams?: Record<string, string | number | boolean>;
+    // (undocumented)
+    extraSignoutQueryParams?: Record<string, string | number | boolean>;
     // (undocumented)
     id_token_hint?: string;
     // (undocumented)

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -186,6 +186,7 @@ export class OidcClient {
         request_type,
         post_logout_redirect_uri = this.settings.post_logout_redirect_uri,
         extraQueryParams = this.settings.extraQueryParams,
+        extraSignoutQueryParams = this.settings.extraSignoutQueryParams,
     }: CreateSignoutRequestArgs = {}): Promise<SignoutRequest> {
         const logger = this._logger.create("createSignoutRequest");
 
@@ -203,6 +204,7 @@ export class OidcClient {
             post_logout_redirect_uri,
             state_data: state,
             extraQueryParams,
+            extraSignoutQueryParams,
             request_type,
         });
 

--- a/src/OidcClientSettings.test.ts
+++ b/src/OidcClientSettings.test.ts
@@ -486,6 +486,36 @@ describe("OidcClientSettings", () => {
         });
     });
 
+    describe("extraSignoutQueryParams", () => {
+
+        it("should use default value", () => {
+            // act
+            const subject = new OidcClientSettingsStore({
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+            });
+
+            // assert
+            expect(subject.extraSignoutQueryParams).toEqual({});
+        });
+
+        it("should return value from initial settings", () => {
+            // act
+            const subject = new OidcClientSettingsStore({
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+                extraSignoutQueryParams: {
+                    "hd": "domain.com",
+                },
+            });
+
+            // assert
+            expect(subject.extraSignoutQueryParams).toEqual({ "hd": "domain.com" });
+        });
+    });
+
     describe("extraTokenParams", () => {
 
         it("should use default value", () => {

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -99,6 +99,12 @@ export interface OidcClientSettings {
      */
     extraQueryParams?: Record<string, string | number | boolean>;
 
+    /**
+     * An object containing additional query string parameters to be including in the signout authorization request.
+     * E.g, when using KeyCloak to redirect after logout you must pass an additional parameter `redirect_to`. extraSignoutQueryParams: `{redirect_to:"/signout-callback"}`
+     */
+    extraSignoutQueryParams?: Record<string, string | number | boolean>;
+
     extraTokenParams?: Record<string, unknown>;
 }
 
@@ -146,6 +152,7 @@ export class OidcClientSettingsStore {
 
     // extra
     public readonly extraQueryParams: Record<string, string | number | boolean>;
+    public readonly extraSignoutQueryParams: Record<string, string | number | boolean>;
     public readonly extraTokenParams: Record<string, unknown>;
 
     public constructor({
@@ -168,6 +175,7 @@ export class OidcClientSettingsStore {
         stateStore,
         // extra query params
         extraQueryParams = {},
+        extraSignoutQueryParams = {},
         extraTokenParams = {},
     }: OidcClientSettings) {
 
@@ -221,6 +229,7 @@ export class OidcClientSettingsStore {
         }
 
         this.extraQueryParams = extraQueryParams;
+        this.extraSignoutQueryParams = extraSignoutQueryParams;
         this.extraTokenParams = extraTokenParams;
     }
 }

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -105,5 +105,18 @@ describe("SignoutRequest", () => {
             expect(subject.url).toContain("TargetResource=logouturl.com&InErrorResource=errorurl.com");
         });
 
+        it("should include extra signout query params", () => {
+            // arrange
+            settings.extraSignoutQueryParams = {
+                "redirect_to": "logouturl.com",
+            };
+
+            // act
+            subject = new SignoutRequest(settings);
+
+            // assert
+            expect(subject.url).toContain("redirect_to=logouturl.com");
+        });
+
     });
 });

--- a/src/SignoutRequest.ts
+++ b/src/SignoutRequest.ts
@@ -16,6 +16,7 @@ export interface SignoutRequestArgs {
     id_token_hint?: string;
     post_logout_redirect_uri?: string;
     extraQueryParams?: Record<string, string | number | boolean>;
+    extraSignoutQueryParams?: Record<string, string | number | boolean>;
     request_type?: string;
 }
 
@@ -30,7 +31,7 @@ export class SignoutRequest {
 
     public constructor({
         url,
-        state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
+        state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, extraSignoutQueryParams, request_type,
     }: SignoutRequestArgs) {
         if (!url) {
             this._logger.error("ctor: No url passed");
@@ -52,7 +53,7 @@ export class SignoutRequest {
             }
         }
 
-        for (const [key, value] of Object.entries({ ...extraQueryParams })) {
+        for (const [key, value] of Object.entries({ ...extraQueryParams, ...extraSignoutQueryParams })) {
             if (value != null) {
                 parsedUrl.searchParams.append(key, value.toString());
             }

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -23,7 +23,7 @@ export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "ex
 /**
  * @public
  */
-export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;
+export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "extraSignoutQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;
 
 /**
  * @public


### PR DESCRIPTION
## Adds configuration for extra signout query params.

Currently this project only has extraQueryParams that are passed to both signin and signout requests but sometimes you just want to pass to one or another and this PR allows to pass query params only to signout.

### Example:
I want to logout of a keycloak server but keycloak does not recognize the post_logout_redirect_uri query param but recognizes the redirect_uri (implementation specific) so now someone can just pass this query param to the

### Links
- https://github.com/keycloak/keycloak/issues/10135
- https://github.com/keycloak/keycloak/discussions/9950 

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
