### PR TITLE
Return of UserManager.createSigninRequest

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -858,6 +858,7 @@ export class UserManager {
     clearStaleState(): Promise<void>;
     // (undocumented)
     protected readonly _client: OidcClient;
+    createSigninRequest(args: CreateSigninRequestArgs): Promise<SigninRequest>;
     get events(): UserManagerEvents;
     // (undocumented)
     protected readonly _events: UserManagerEvents;

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -11,6 +11,7 @@ import type { UserProfile } from "./User";
 import { WebStorageStateStore } from "./WebStorageStateStore";
 import type { SigninState } from "./SigninState";
 import type { State } from "./State";
+import type { SigninRequest, SigninRequestArgs } from "./SigninRequest";
 
 import { mocked } from "jest-mock";
 
@@ -155,6 +156,24 @@ describe("UserManager", () => {
             await expect(subject.revokeTokens())
                 // assert
                 .resolves.toBe(undefined);
+        });
+    });
+
+    describe("createSigninRequest", () => {
+        it("should relay to _client.createSigninRequest", async () => {
+            // arrange
+            const args = {} as SigninRequestArgs;
+            const resultMock = {} as SigninRequest;
+            const spy = jest.spyOn(subject["_client"], "createSigninRequest")
+                .mockResolvedValue(resultMock);
+
+            // act
+            const signinRequest = await subject.createSigninRequest(args);
+
+            // assert
+            expect(spy).toBeCalledTimes(1);
+            expect(spy).toBeCalledWith(args);
+            expect(signinRequest).toBe(resultMock);
         });
     });
 

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -14,6 +14,7 @@ import { SessionMonitor } from "./SessionMonitor";
 import type { SessionStatus } from "./SessionStatus";
 import type { SignoutResponse } from "./SignoutResponse";
 import type { MetadataService } from "./MetadataService";
+import type { SigninRequest } from "./SigninRequest";
 import { RefreshState } from "./RefreshState";
 
 /**
@@ -137,6 +138,15 @@ export class UserManager {
         await this.storeUser(null);
         logger.info("user removed from storage");
         this._events.unload();
+    }
+
+    /**
+     * Returns a promise with the sign-in request information for the given request arguments
+     * @param args The sign-in request args
+     * @returns The sign-in request
+     */
+    public createSigninRequest(args: CreateSigninRequestArgs): Promise<SigninRequest> {
+        return this._client.createSigninRequest(args);
     }
 
     /**


### PR DESCRIPTION
_[x] This PR does not change, only augments public APIs with one new method._

Today I attempted to migrate from `oidc-client` to `oidc-client-ts` in our LOB products, and I ended up with only _one unresolvable issue_.

It looks like the method `UserManager.createSigninRequest(args: SigninRequestArgs): Promise<SigninRequest>` was "lost in translation" somewhere after you forked `oidc-client` and converted to TypeScript, or you may have decided that it should be changed to an internal feature.

Our applications actually depend on this method since we sometimes provide a "login" hyperlink in the UI. 
We get the URL for the login hyperlink using `(await userManager.createSigninRequest({...})).url`.
This functionality is unfortunately not available anymore.
 
In this PR I have added the method back for feature parity with the legacy client, and to solve the issue in our apps.
The added method simply relays to `_client.createSigninRequest(args: SigninRequestArgs): Promise<SigninRequest>` .

PS! I have added unit tests that covers the new code.
Hoping for approval and a quick package patch release! 👍
