### PR TITLE
fix(CheckSessionIFrame): normalize iframe origin before comparing to the MessageEvent origin

### DIFF
--- a/src/CheckSessionIFrame.ts
+++ b/src/CheckSessionIFrame.ts
@@ -20,8 +20,8 @@ export class CheckSessionIFrame {
         private _intervalInSeconds: number,
         private _stopOnError: boolean,
     ) {
-        const idx = url.indexOf("/", url.indexOf("//") + 2);
-        this._frame_origin = url.substr(0, idx);
+        const parsedUrl = new URL(url);
+        this._frame_origin = parsedUrl.origin;
 
         this._frame = window.document.createElement("iframe");
 
@@ -32,7 +32,7 @@ export class CheckSessionIFrame {
         this._frame.style.top = "0";
         this._frame.width = "0";
         this._frame.height = "0";
-        this._frame.src = url;
+        this._frame.src = parsedUrl.href;
     }
 
     public load(): Promise<void> {


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #465

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers

This normalizes the stored iframe origin with `new URL` which fixes the comparison to the origin in the `MessageEvent` handler later.

The existing `CheckSessionIFrame` implementation is still a bit messy. I'd like to clean up its API a bit before adding unit tests for it.