### PR TITLE
Add `redirect_uri` to `ExtraSigninRequestArgs`

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -112,7 +112,7 @@ export class ErrorTimeout extends Error {
 }
 
 // @public (undocumented)
-export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state">;
+export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state" | "redirect_uri">;
 
 // @public (undocumented)
 export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -197,6 +197,7 @@ describe("UserManager", () => {
                 extraTokenParams: { t: "t" },
                 state: "state",
                 nonce: "random_nonce",
+                redirect_uri: "http://app/extra_callback",
             };
 
             // act
@@ -275,6 +276,7 @@ describe("UserManager", () => {
                 extraTokenParams: { t: "t" },
                 state: "state",
                 nonce: "random_nonce",
+                redirect_uri: "http://app/extra_callback",
             };
 
             // act
@@ -284,7 +286,6 @@ describe("UserManager", () => {
             expect(subject["_signin"]).toBeCalledWith(
                 {
                     request_type: "si:p",
-                    redirect_uri: subject.settings.redirect_uri,
                     display: "popup",
                     ...extraArgs,
                 },
@@ -361,6 +362,7 @@ describe("UserManager", () => {
                 extraTokenParams: { t: "t" },
                 state: "state",
                 nonce: "random_nonce",
+                redirect_uri: "http://app/extra_callback",
             };
 
             // act
@@ -370,7 +372,6 @@ describe("UserManager", () => {
             expect(subject["_signin"]).toBeCalledWith(
                 {
                     request_type: "si:s",
-                    redirect_uri: subject.settings.redirect_uri,
                     prompt: "none",
                     id_token_hint: undefined,
                     ...extraArgs,

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -19,7 +19,7 @@ import { RefreshState } from "./RefreshState";
 /**
  * @public
  */
-export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state">;
+export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state" | "redirect_uri">;
 /**
  * @public
  */


### PR DESCRIPTION
This allows apps to redirect users back to the exact same place they came from. Somehow had the exact same thought at the same time as mentioned in #468 (only found the issue after trying the same thing myself!). I've tried this in my own project and do seem to end up at the right place (even when instantiating `UserManager` with a different `redirect_uri`).

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #468 

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
