### PR TITLE
Remove the event listener for unloading when navigating

### DIFF
--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -161,7 +161,14 @@ describe("UserManager", () => {
     describe("signinRedirect", () => {
         it("should redirect the browser to the authorize url", async () => {
             // act
-            await subject.signinRedirect();
+            const spy = jest.fn();
+            subject.signinRedirect().finally(spy);
+
+            // signinRedirect is a promise that will never resolve (since we
+            // want it to hold until the page has redirected), so we use a
+            // timeout to wait for the majority of the code to have been run
+            // before proceeding with the rest of the test.
+            await new Promise(resolve => setTimeout(resolve, 200));
 
             // assert
             expect(window.location.assign).toHaveBeenCalledWith(
@@ -171,6 +178,9 @@ describe("UserManager", () => {
             const state = new URL(location).searchParams.get("state");
             const item = await userStoreMock.get(state!);
             expect(JSON.parse(item!)).toHaveProperty("request_type", "si:r");
+
+            // We check to make sure the promise has not resolved
+            expect(spy).not.toHaveBeenCalled();
         });
 
         it("should pass navigator params to navigator", async () => {

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -165,10 +165,11 @@ describe("UserManager", () => {
             subject.signinRedirect().finally(spy);
 
             // signinRedirect is a promise that will never resolve (since we
-            // want it to hold until the page has redirected), so we use a
-            // timeout to wait for the majority of the code to have been run
-            // before proceeding with the rest of the test.
-            await new Promise(resolve => setTimeout(resolve, 200));
+            // want it to hold until the page has redirected), so we wait for
+            // the browser unload event before checking the test assertions.
+            await new Promise<void>(resolve => {
+                window.addEventListener("unload", () => resolve());
+            });
 
             // assert
             expect(window.location.assign).toHaveBeenCalledWith(

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+import { once } from "events";
 import type { PopupWindow } from "./navigators";
 import type { SigninResponse } from "./SigninResponse";
 import type { SignoutResponse } from "./SignoutResponse";
@@ -167,13 +168,7 @@ describe("UserManager", () => {
             // signinRedirect is a promise that will never resolve (since we
             // want it to hold until the page has redirected), so we wait for
             // the browser unload event before checking the test assertions.
-            await new Promise<void>(resolve => {
-                const listener = () => {
-                    resolve();
-                    window.removeEventListener("unload", listener);
-                };
-                window.addEventListener("unload", listener);
-            });
+            await once(window, "unload");
 
             // assert
             expect(window.location.assign).toHaveBeenCalledWith(

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -168,7 +168,11 @@ describe("UserManager", () => {
             // want it to hold until the page has redirected), so we wait for
             // the browser unload event before checking the test assertions.
             await new Promise<void>(resolve => {
-                window.addEventListener("unload", () => resolve());
+                const listener = () => {
+                    resolve();
+                    window.removeEventListener("unload", listener);
+                };
+                window.addEventListener("unload", listener);
             });
 
             // assert

--- a/src/navigators/RedirectNavigator.test.ts
+++ b/src/navigators/RedirectNavigator.test.ts
@@ -1,4 +1,5 @@
 import { mocked } from "jest-mock";
+import { once } from "events";
 import type { UserManagerSettingsStore } from "../UserManagerSettings";
 import { RedirectNavigator } from "./RedirectNavigator";
 
@@ -26,13 +27,7 @@ describe("RedirectNavigator", () => {
 
         // We check that the promise does not resolve even after the window
         // unload event
-        await new Promise<void>(resolve => {
-            const listener = () => {
-                resolve();
-                window.removeEventListener("unload", listener);
-            };
-            window.addEventListener("unload", listener);
-        });
+        await once(window, "unload");
         expect(spy).not.toHaveBeenCalled();
     });
 

--- a/src/navigators/RedirectNavigator.test.ts
+++ b/src/navigators/RedirectNavigator.test.ts
@@ -24,9 +24,11 @@ describe("RedirectNavigator", () => {
 
         expect(window.location.replace).toHaveBeenCalledWith("http://sts/authorize");
 
-        // We check that the promise does not resolve within some reasonable
-        // amount of time
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        // We check that the promise does not resolve even after the window
+        // unload event
+        await new Promise<void>(resolve => {
+            window.addEventListener("unload", () => resolve());
+        });
         expect(spy).not.toHaveBeenCalled();
     });
 

--- a/src/navigators/RedirectNavigator.test.ts
+++ b/src/navigators/RedirectNavigator.test.ts
@@ -27,7 +27,11 @@ describe("RedirectNavigator", () => {
         // We check that the promise does not resolve even after the window
         // unload event
         await new Promise<void>(resolve => {
-            window.addEventListener("unload", () => resolve());
+            const listener = () => {
+                resolve();
+                window.removeEventListener("unload", listener);
+            };
+            window.addEventListener("unload", listener);
         });
         expect(spy).not.toHaveBeenCalled();
     });

--- a/src/navigators/RedirectNavigator.test.ts
+++ b/src/navigators/RedirectNavigator.test.ts
@@ -19,9 +19,15 @@ describe("RedirectNavigator", () => {
 
     it("should redirect to the authority server using a specific redirect method", async () => {
         const handle = await navigator.prepare({ redirectMethod: "replace" });
-        await handle.navigate({ url: "http://sts/authorize" });
+        const spy = jest.fn();
+        handle.navigate({ url: "http://sts/authorize" }).finally(spy);
 
         expect(window.location.replace).toHaveBeenCalledWith("http://sts/authorize");
+
+        // We check that the promise does not resolve within some reasonable
+        // amount of time
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        expect(spy).not.toHaveBeenCalled();
     });
 
     it("should reject when the navigation is stopped programmatically", async () => {

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -30,9 +30,9 @@ export class RedirectNavigator implements INavigator {
         return {
             navigate: async (params): Promise<never> => {
                 this._logger.create("navigate");
+                // We use a promise that never resolves to block the caller
                 const promise = new Promise((resolve, reject) => {
                     abort = reject;
-                    window.addEventListener("unload", () => resolve(null));
                 });
                 redirect(params.url);
                 return await (promise as Promise<never>);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,17 +3,23 @@ import { Log } from "../src";
 beforeAll(() => {
     globalThis.fetch = jest.fn();
 
-    const location = Object.defineProperties({}, {
-        ...Object.getOwnPropertyDescriptors(window.location),
-        assign: {
-            enumerable: true,
-            value: jest.fn(),
+    const unload = () =>
+        setTimeout(() => window.dispatchEvent(new Event("unload")), 200);
+
+    const location = Object.defineProperties(
+        {},
+        {
+            ...Object.getOwnPropertyDescriptors(window.location),
+            assign: {
+                enumerable: true,
+                value: jest.fn(unload),
+            },
+            replace: {
+                enumerable: true,
+                value: jest.fn(unload),
+            },
         },
-        replace: {
-            enumerable: true,
-            value: jest.fn(),
-        },
-    });
+    );
     Object.defineProperty(window, "location", {
         enumerable: true,
         get: () => location,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,17 +3,15 @@ import { Log } from "../src";
 beforeAll(() => {
     globalThis.fetch = jest.fn();
 
-    const unload = () => window.dispatchEvent(new Event("unload"));
-
     const location = Object.defineProperties({}, {
         ...Object.getOwnPropertyDescriptors(window.location),
         assign: {
             enumerable: true,
-            value: jest.fn(unload),
+            value: jest.fn(),
         },
         replace: {
             enumerable: true,
-            value: jest.fn(unload),
+            value: jest.fn(),
         },
     });
     Object.defineProperty(window, "location", {


### PR DESCRIPTION
I got a somewhat similar issue to what was reported with #329 and #330. When calling `signinRedirect`, on Chrome everything seems fine. With Firefox (at least on v99.0.1), what I see happening is that the page does redirect to the OIDC provider, but oddly an infinite barrage of API requests get made when they shouldn't - as if its trying to reload my website over and over. I can only guess this must be a bug in Firefox itself to do with making an event listener before navigating or something?

I tried listening to different events (e.g. `beforeunload`, `visibilitychange`, etc. instead of `unload`), performing the window event listening outside of the promise function (to see if ensuring that its done before navigate could help) but neither of these make a difference. The only thing that seems to fix this is actually removing the event listening and making the promise never resolve. 

The tests here end up suffering however; as the author of #329 pointed out, its not easy to write proper tests for a promise that never resolves. The only thing I could do here was wait a "significant enough amount of time" that things should have executed (definitely not that nice), unless there's a better idea of how to carry this out?

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
