### PR TITLE
clear stale states when creating new one

### DIFF
--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -90,7 +90,7 @@ export class OidcClient {
         id_token_hint,
         login_hint,
         skipUserInfo,
-        nonce, 
+        nonce,
         response_type = this.settings.response_type,
         scope = this.settings.scope,
         redirect_uri = this.settings.redirect_uri,
@@ -127,6 +127,9 @@ export class OidcClient {
             skipUserInfo,
             nonce,
         });
+
+        // house cleaning
+        await this.clearStaleState();
 
         const signinState = signinRequest.state;
         await this.settings.stateStore.set(signinState.id, signinState.toStorageString());
@@ -205,6 +208,9 @@ export class OidcClient {
             extraQueryParams,
             request_type,
         });
+
+        // house cleaning
+        await this.clearStaleState();
 
         const signoutState = request.state;
         if (signoutState) {


### PR DESCRIPTION
This fixes the case when `clearStaleState` is never called in user code. Sooner or later `window.localStorage` is full and adding an additional state results in a `QuoteExceededError`. 

Closes/fixes #466

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
