### PR TITLE
feat: add ability to specify iframe script origin and iframe notify parent for silent auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 .DS_Store
 .vscode/
 temp/
+.history/

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -968,6 +968,9 @@ export interface UserManagerSettings extends OidcClientSettings {
     accessTokenExpiringNotificationTimeInSeconds?: number;
     automaticSilentRenew?: boolean;
     checkSessionIntervalInSeconds?: number;
+    iframeNotifyParentOrigin?: string;
+    // (undocumented)
+    iframeScriptOrigin?: string;
     includeIdTokenInSilentRenew?: boolean;
     // (undocumented)
     monitorAnonymousSession?: boolean;
@@ -999,6 +1002,10 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     readonly automaticSilentRenew: boolean;
     // (undocumented)
     readonly checkSessionIntervalInSeconds: number;
+    // (undocumented)
+    readonly iframeNotifyParentOrigin: string | undefined;
+    // (undocumented)
+    readonly iframeScriptOrigin: string | undefined;
     // (undocumented)
     readonly includeIdTokenInSilentRenew: boolean;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -969,7 +969,6 @@ export interface UserManagerSettings extends OidcClientSettings {
     automaticSilentRenew?: boolean;
     checkSessionIntervalInSeconds?: number;
     iframeNotifyParentOrigin?: string;
-    // (undocumented)
     iframeScriptOrigin?: string;
     includeIdTokenInSilentRenew?: boolean;
     // (undocumented)

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -43,6 +43,21 @@ describe("UserManager", () => {
             // act
             expect(subject.settings.client_id).toEqual("client");
         });
+
+        it.each([
+            { monitorSession: true, message: "should" },
+            { monitorSession: false, message: "should not" },
+        ])("when monitorSession is $monitorSession $message init sessionMonitor", (args) => {
+            const settings = { ...subject.settings, monitorSession: args.monitorSession };
+
+            const userManager = new UserManager(settings);
+            const sessionMonitor = userManager["_sessionMonitor"];
+            if (args.monitorSession) {
+                expect(sessionMonitor).toBeDefined();
+            } else {
+                expect(sessionMonitor).toBeNull();
+            }
+        });
     });
 
     describe("settings", () => {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -388,6 +388,7 @@ export class UserManager {
                 url: signinRequest.url,
                 state: signinRequest.state.id,
                 response_mode: signinRequest.state.response_mode,
+                scriptOrigin: this.settings.iframeScriptOrigin,
             });
         }
         catch (err) {

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -36,6 +36,10 @@ export interface UserManagerSettings extends OidcClientSettings {
     /** The methods window.location method used to redirect (default: "assign") */
     redirectMethod?: "replace" | "assign";
 
+    /** The target to pass while calling postMessage inside iframe for callback */
+    iframeNotifyParentOrigin?: string;
+    iframeScriptOrigin?: string;
+
     /** The URL for the page containing the code handling the silent renew */
     silent_redirect_uri?: string;
     /** Number of seconds to wait for the silent renew to return before assuming it has failed or timed out (default: 10) */
@@ -86,6 +90,9 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     public readonly popupWindowTarget: string;
     public readonly redirectMethod: "replace" | "assign";
 
+    public readonly iframeNotifyParentOrigin: string | undefined;
+    public readonly iframeScriptOrigin: string | undefined;
+
     public readonly silent_redirect_uri: string;
     public readonly silentRequestTimeoutInSeconds: number;
     public readonly automaticSilentRenew: boolean;
@@ -111,6 +118,9 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
             popupWindowFeatures = DefaultPopupWindowFeatures,
             popupWindowTarget = DefaultPopupTarget,
             redirectMethod = "assign",
+
+            iframeNotifyParentOrigin = args.iframeNotifyParentOrigin,
+            iframeScriptOrigin = args.iframeScriptOrigin,
 
             silent_redirect_uri = args.redirect_uri,
             silentRequestTimeoutInSeconds = DefaultSilentRequestTimeoutInSeconds,
@@ -138,6 +148,9 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
         this.popupWindowFeatures = popupWindowFeatures;
         this.popupWindowTarget = popupWindowTarget;
         this.redirectMethod = redirectMethod;
+
+        this.iframeNotifyParentOrigin = iframeNotifyParentOrigin;
+        this.iframeScriptOrigin = iframeScriptOrigin;
 
         this.silent_redirect_uri = silent_redirect_uri;
         this.silentRequestTimeoutInSeconds = silentRequestTimeoutInSeconds;

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -36,8 +36,10 @@ export interface UserManagerSettings extends OidcClientSettings {
     /** The methods window.location method used to redirect (default: "assign") */
     redirectMethod?: "replace" | "assign";
 
-    /** The target to pass while calling postMessage inside iframe for callback */
+    /** The target to pass while calling postMessage inside iframe for callback (default: window.location.origin) */
     iframeNotifyParentOrigin?: string;
+
+    /** The script origin to check during 'message' callback execution while performing silent auth via iframe (default: window.location.origin) */
     iframeScriptOrigin?: string;
 
     /** The URL for the page containing the code handling the silent renew */

--- a/src/navigators/AbstractChildWindow.ts
+++ b/src/navigators/AbstractChildWindow.ts
@@ -37,7 +37,8 @@ export abstract class AbstractChildWindow implements IWindow {
         const { url, keepOpen } = await new Promise<MessageData>((resolve, reject) => {
             const listener = (e: MessageEvent) => {
                 const data: MessageData | undefined = e.data;
-                if (e.origin !== window.location.origin || data?.source !== messageSource) {
+                const origin = params.scriptOrigin ?? window.location.origin;
+                if (e.origin !== origin || data?.source !== messageSource) {
                     // silently discard events not intended for us
                     return;
                 }
@@ -86,11 +87,11 @@ export abstract class AbstractChildWindow implements IWindow {
         this._disposeHandlers.clear();
     }
 
-    protected static _notifyParent(parent: Window, url: string, keepOpen = false): void {
+    protected static _notifyParent(parent: Window, url: string, keepOpen = false, targetOrigin = window.location.origin): void {
         parent.postMessage({
             source: messageSource,
             url,
             keepOpen,
-        } as MessageData, window.location.origin);
+        } as MessageData, targetOrigin);
     }
 }

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -22,6 +22,6 @@ export class IFrameNavigator implements INavigator {
 
     public async callback(url: string): Promise<void> {
         this._logger.create("callback");
-        IFrameWindow.notifyParent(url);
+        IFrameWindow.notifyParent(url, this._settings.iframeNotifyParentOrigin);
     }
 }

--- a/src/navigators/IFrameWindow.test.ts
+++ b/src/navigators/IFrameWindow.test.ts
@@ -1,0 +1,118 @@
+import { IFrameWindow } from "./IFrameWindow";
+import type { NavigateParams } from "./IWindow";
+
+describe("IFrameWindow", () => {
+    const postMessageMock = jest.fn();
+    const fakeWindowOrigin = "https://fake-origin.com";
+    const fakeUrl = "https://fakeurl.com";
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("hidden frame", () => {
+        let frameWindow: IFrameWindow;
+
+        beforeAll(() => {
+            frameWindow = new IFrameWindow({ });
+        });
+
+        it("should have appropriate styles for hidden presentation", () => {
+            const { visibility, position, left, top } = frameWindow["_frame"]!.style;
+
+            expect(visibility).toBe("hidden");
+            expect(position).toBe("fixed");
+            expect(left).toBe("-1000px");
+            expect(top).toBe("0px");
+        });
+
+        it("should have 0 width and height", () => {
+            const { width, height } = frameWindow["_frame"]!;
+            expect(width).toBe("0");
+            expect(height).toBe("0");
+        });
+
+        it("should set correct sandbox attribute", () => {
+            const sandboxAttr = frameWindow["_frame"]!.attributes.getNamedItem("sandbox");
+            expect(sandboxAttr?.value).toBe("allow-scripts allow-same-origin allow-forms");
+        });
+    });
+
+    describe("close", () => {
+        let subject: IFrameWindow;
+        const parentRemoveChild = jest.fn();
+        beforeEach(() => {
+            subject = new IFrameWindow({});
+            jest.spyOn(subject["_frame"]!, "parentNode", "get").mockReturnValue({
+                removeChild: parentRemoveChild,
+            } as unknown as ParentNode);
+        });
+
+        it("should reset window to null", () => {
+            subject.close();
+            expect(subject["_window"]).toBeNull();
+        });
+
+        describe("if frame defined", () => {
+            it("should set blank url for contentWindow", () => {
+                const replaceMock = jest.fn();
+                jest.spyOn(subject["_frame"]!, "contentWindow", "get")
+                    .mockReturnValue({ location: { replace: replaceMock } } as unknown as WindowProxy);
+
+                subject.close();
+                expect(replaceMock).toBeCalledWith("about:blank");
+            });
+
+            it("should reset frame to null", () => {
+                subject.close();
+                expect(subject["_frame"]).toBeNull();
+            });
+        });
+    });
+
+    describe("navigate", () => {
+        const contentWindowMock = jest.fn();
+
+        beforeAll(() => {
+            jest.spyOn(window, "parent", "get").mockReturnValue({
+                postMessage: postMessageMock,
+            } as unknown as WindowProxy);
+            Object.defineProperty(window, "location", {
+                enumerable: true,
+                value: { origin: fakeWindowOrigin },
+            });
+
+            contentWindowMock.mockReturnValue(null);
+            jest.spyOn(window.document.body, "appendChild").mockImplementation();
+            jest.spyOn(window.document, "createElement").mockReturnValue(({
+                contentWindow: contentWindowMock(),
+                style: {},
+                setAttribute: jest.fn(),
+            } as unknown as HTMLIFrameElement),
+            );
+        });
+
+        it("when frame.contentWindow is not defined should throw error", async() => {
+            const frameWindow = new IFrameWindow({});
+            await expect(frameWindow.navigate({} as NavigateParams))
+                .rejects
+                .toMatchObject({ message: "Attempted to navigate on a disposed window" });
+        });
+    });
+
+    describe("notifyParent", () => {
+        const messageData = {
+            source: "oidc-client",
+            url: fakeUrl,
+            keepOpen: false,
+        };
+
+        it.each([
+            ["https://parent-domain.com", "https://parent-domain.com"],
+            [undefined, fakeWindowOrigin],
+        ])("should call postMessage with appropriate parameters", (targetOrigin, expectedOrigin) => {
+            IFrameWindow.notifyParent(messageData.url, targetOrigin);
+            expect(postMessageMock).toBeCalledWith(messageData, expectedOrigin);
+        });
+    });
+});

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -71,7 +71,7 @@ export class IFrameWindow extends AbstractChildWindow {
         this._window = null;
     }
 
-    public static notifyParent(url: string): void {
-        return super._notifyParent(window.parent, url);
+    public static notifyParent(url: string, targetOrigin?: string): void {
+        return super._notifyParent(window.parent, url, false, targetOrigin);
     }
 }

--- a/src/navigators/IWindow.ts
+++ b/src/navigators/IWindow.ts
@@ -10,6 +10,7 @@ export interface NavigateParams {
     /** The request "state" parameter. For sign out requests, this parameter is optional. */
     state?: string;
     response_mode?: "query" | "fragment";
+    scriptOrigin?: string;
 }
 
 /**


### PR DESCRIPTION
**The problem**
Both - oidc-client-js & oidc-client-ts - support silent flow only within the same domain. However in my case - apps are hosted on different domains. It's possible to address it by specifying 2 new settings which will allow to overcome issue and make all things work even with different domains.

**What for**
I'm working on micro frontends implementation currently. 
- Architecture is based on webpack module federation and web components
- There is a shell hosted on on https://app-a.test.com
- And there is micro frontend app loaded through the shell, hosted as https://app-b.test.com
- Shell and each micro app - are separate relying parties which have their own client id, redirect urls etc.  Users can also access them directly.

The main goal is to avoid explicit login flow for getting micro app access token (user does not need to enter credentials once again)
Though, both apps are separate relying parties, token is issued by the same authority.

So the main idea:
- User logs in to shell: https://app-a.test.com and token is saved into session storage
- User clicks the link to load micro app - code is loaded using module federation, which includes oidc-client load dependency as well
- Silent auth flow happens to get token for micro app. And in result - it's also saved in session storage 

BTW, I'll add unit tests soon to cover updated scenarios
### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
