### PR TITLE
deprecated unused clockSkewInSeconds and userInfoJwtIssuer settings

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -325,6 +325,7 @@ export interface OidcClientSettings {
     client_id: string;
     // (undocumented)
     client_secret?: string;
+    // @deprecated (undocumented)
     clockSkewInSeconds?: number;
     display?: string;
     extraQueryParams?: Record<string, string | number | boolean>;
@@ -349,7 +350,7 @@ export interface OidcClientSettings {
     staleStateAgeInSeconds?: number;
     stateStore?: StateStore;
     ui_locales?: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     userInfoJwtIssuer?: "ANY" | "OP" | string;
 }
 

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -77,8 +77,10 @@ export interface OidcClientSettings {
     loadUserInfo?: boolean;
     /** Number (in seconds) indicating the age of state entries in storage for authorize requests that are considered abandoned and thus can be cleaned up (default: 300) */
     staleStateAgeInSeconds?: number;
-    /** The window of time (in seconds) to allow the current time to deviate when validating token's iat, nbf, and exp values (default: 300) */
+
+    /** @deprecated Unused */
     clockSkewInSeconds?: number;
+    /** @deprecated Unused */
     userInfoJwtIssuer?: "ANY" | "OP" | string;
 
     /**


### PR DESCRIPTION
First part for #552: As removing will cause a major version bump, we deprecate them first...
Both setting are unused. They were used for the implicit grant, which we dropped...

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
