### PR TITLE
new option refreshWithCredentials sends cookies with token refresh

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -342,7 +342,7 @@ export interface OidcClientSettings {
     post_logout_redirect_uri?: string;
     prompt?: string;
     redirect_uri: string;
-    refreshWithCredentials?: boolean;
+    refreshTokenCredentials?: "same-origin" | "include" | "omit";
     resource?: string;
     response_mode?: "query" | "fragment";
     response_type?: string;
@@ -357,7 +357,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, refreshWithCredentials, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, refreshTokenCredentials, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -397,7 +397,7 @@ export class OidcClientSettingsStore {
     // (undocumented)
     readonly redirect_uri: string;
     // (undocumented)
-    readonly refreshWithCredentials: boolean;
+    readonly refreshTokenCredentials: "same-origin" | "include" | "omit" | undefined;
     // (undocumented)
     readonly resource: string | undefined;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -397,7 +397,7 @@ export class OidcClientSettingsStore {
     // (undocumented)
     readonly redirect_uri: string;
     // (undocumented)
-    readonly refreshTokenCredentials: "same-origin" | "include" | "omit" | undefined;
+    readonly refreshTokenCredentials: "same-origin" | "include" | "omit";
     // (undocumented)
     readonly resource: string | undefined;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -342,6 +342,7 @@ export interface OidcClientSettings {
     post_logout_redirect_uri?: string;
     prompt?: string;
     redirect_uri: string;
+    refreshWithCredentials?: boolean;
     resource?: string;
     response_mode?: "query" | "fragment";
     response_type?: string;
@@ -356,7 +357,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, refreshWithCredentials, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -395,6 +396,8 @@ export class OidcClientSettingsStore {
     readonly prompt: string | undefined;
     // (undocumented)
     readonly redirect_uri: string;
+    // (undocumented)
+    readonly refreshWithCredentials: boolean;
     // (undocumented)
     readonly resource: string | undefined;
     // (undocumented)

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -23,6 +23,7 @@ export interface PostFormOpts {
     body: URLSearchParams;
     basicAuth?: string;
     timeoutInSeconds?: number;
+    withCredentials?: boolean;
 }
 
 /**
@@ -123,6 +124,7 @@ export class JsonService {
         body,
         basicAuth,
         timeoutInSeconds,
+        withCredentials,
     }: PostFormOpts): Promise<Record<string, unknown>> {
         const logger = this._logger.create("postForm");
         const headers: HeadersInit = {
@@ -132,11 +134,15 @@ export class JsonService {
         if (basicAuth !== undefined) {
             headers["Authorization"] = "Basic " + basicAuth;
         }
+        let initCredentials = {};
+        if (withCredentials) {
+            initCredentials = { "credentials": "include" };
+        }
 
         let response: Response;
         try {
             logger.debug("url:", url);
-            response = await this.fetchWithTimeout(url, { method: "POST", headers, body, timeoutInSeconds });
+            response = await this.fetchWithTimeout(url, { method: "POST", headers, body, timeoutInSeconds, ...initCredentials });
         }
         catch (err) {
             logger.error("Network error");

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -23,7 +23,7 @@ export interface PostFormOpts {
     body: URLSearchParams;
     basicAuth?: string;
     timeoutInSeconds?: number;
-    corsCredentials?: "same-origin" | "include" | "omit";
+    initCredentials?: "same-origin" | "include" | "omit";
 }
 
 /**
@@ -124,7 +124,7 @@ export class JsonService {
         body,
         basicAuth,
         timeoutInSeconds,
-        corsCredentials,
+        initCredentials,
     }: PostFormOpts): Promise<Record<string, unknown>> {
         const logger = this._logger.create("postForm");
         const headers: HeadersInit = {
@@ -138,7 +138,7 @@ export class JsonService {
         let response: Response;
         try {
             logger.debug("url:", url);
-            response = await this.fetchWithTimeout(url, { method: "POST", headers, body, timeoutInSeconds, credentials: corsCredentials });
+            response = await this.fetchWithTimeout(url, { method: "POST", headers, body, timeoutInSeconds, credentials: initCredentials });
         }
         catch (err) {
             logger.error("Network error");

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -134,15 +134,11 @@ export class JsonService {
         if (basicAuth !== undefined) {
             headers["Authorization"] = "Basic " + basicAuth;
         }
-        let initCredentials = {};
-        if (corsCredentials) {
-            initCredentials = { "credentials": corsCredentials };
-        }
 
         let response: Response;
         try {
             logger.debug("url:", url);
-            response = await this.fetchWithTimeout(url, { method: "POST", headers, body, timeoutInSeconds, ...initCredentials });
+            response = await this.fetchWithTimeout(url, { method: "POST", headers, body, timeoutInSeconds, credentials: corsCredentials });
         }
         catch (err) {
             logger.error("Network error");

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -23,7 +23,7 @@ export interface PostFormOpts {
     body: URLSearchParams;
     basicAuth?: string;
     timeoutInSeconds?: number;
-    withCredentials?: boolean;
+    corsCredentials?: "same-origin" | "include" | "omit";
 }
 
 /**
@@ -124,7 +124,7 @@ export class JsonService {
         body,
         basicAuth,
         timeoutInSeconds,
-        withCredentials,
+        corsCredentials,
     }: PostFormOpts): Promise<Record<string, unknown>> {
         const logger = this._logger.create("postForm");
         const headers: HeadersInit = {
@@ -135,8 +135,8 @@ export class JsonService {
             headers["Authorization"] = "Basic " + basicAuth;
         }
         let initCredentials = {};
-        if (withCredentials) {
-            initCredentials = { "credentials": "include" };
+        if (corsCredentials) {
+            initCredentials = { "credentials": corsCredentials };
         }
 
         let response: Response;

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -380,6 +380,8 @@ describe("OidcClient", () => {
             expect(exchangeRefreshTokenMock).toHaveBeenCalledWith( {
                 refresh_token: "refresh_token",
                 scope: "openid",
+                timeoutInSeconds: undefined,
+                refreshWithCredentials: false,
             });
             expect(response).toBeInstanceOf(SigninResponse);
             expect(response).toMatchObject(tokenResponse);

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -381,7 +381,7 @@ describe("OidcClient", () => {
                 refresh_token: "refresh_token",
                 scope: "openid",
                 timeoutInSeconds: undefined,
-                refreshWithCredentials: false,
+                refreshTokenCredentials: undefined,
             });
             expect(response).toBeInstanceOf(SigninResponse);
             expect(response).toMatchObject(tokenResponse);

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -381,7 +381,7 @@ describe("OidcClient", () => {
                 refresh_token: "refresh_token",
                 scope: "openid",
                 timeoutInSeconds: undefined,
-                refreshTokenCredentials: undefined,
+                refreshTokenCredentials: "same-origin",
             });
             expect(response).toBeInstanceOf(SigninResponse);
             expect(response).toMatchObject(tokenResponse);

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -175,6 +175,7 @@ export class OidcClient {
             refresh_token: state.refresh_token,
             scope: state.scope,
             timeoutInSeconds,
+            refreshWithCredentials: this.settings.refreshWithCredentials,
         });
         const response = new SigninResponse(new URLSearchParams());
         Object.assign(response, result);

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -175,7 +175,7 @@ export class OidcClient {
             refresh_token: state.refresh_token,
             scope: state.scope,
             timeoutInSeconds,
-            refreshWithCredentials: this.settings.refreshWithCredentials,
+            refreshTokenCredentials: this.settings.refreshTokenCredentials,
         });
         const response = new SigninResponse(new URLSearchParams());
         Object.assign(response, result);

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -102,6 +102,11 @@ export interface OidcClientSettings {
     extraQueryParams?: Record<string, string | number | boolean>;
 
     extraTokenParams?: Record<string, unknown>;
+
+    /**
+     * Whether credentials should be sent with the refresh request.
+     */
+    refreshWithCredentials?: boolean;
 }
 
 /**
@@ -150,6 +155,8 @@ export class OidcClientSettingsStore {
     public readonly extraQueryParams: Record<string, string | number | boolean>;
     public readonly extraTokenParams: Record<string, unknown>;
 
+    public readonly refreshWithCredentials: boolean;
+
     public constructor({
         // metadata related
         authority, metadataUrl, metadata, signingKeys, metadataSeed,
@@ -168,6 +175,7 @@ export class OidcClientSettingsStore {
         mergeClaims = false,
         // other behavior
         stateStore,
+        refreshWithCredentials = false,
         // extra query params
         extraQueryParams = {},
         extraTokenParams = {},
@@ -213,6 +221,8 @@ export class OidcClientSettingsStore {
         this.clockSkewInSeconds = clockSkewInSeconds;
         this.userInfoJwtIssuer = userInfoJwtIssuer;
         this.mergeClaims = !!mergeClaims;
+
+        this.refreshWithCredentials = refreshWithCredentials;
 
         if (stateStore) {
             this.stateStore = stateStore;

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -104,7 +104,7 @@ export interface OidcClientSettings {
     extraTokenParams?: Record<string, unknown>;
 
     /**
-     * CORS settings for credentials sent with the refresh request.
+     * Credentials used by fetch with the refresh request. (default: "same-origin")
      */
     refreshTokenCredentials?: "same-origin" | "include" | "omit";
 }
@@ -155,7 +155,7 @@ export class OidcClientSettingsStore {
     public readonly extraQueryParams: Record<string, string | number | boolean>;
     public readonly extraTokenParams: Record<string, unknown>;
 
-    public readonly refreshTokenCredentials: "same-origin" | "include" | "omit" | undefined;
+    public readonly refreshTokenCredentials: "same-origin" | "include" | "omit";
 
     public constructor({
         // metadata related
@@ -175,7 +175,7 @@ export class OidcClientSettingsStore {
         mergeClaims = false,
         // other behavior
         stateStore,
-        refreshTokenCredentials,
+        refreshTokenCredentials = "same-origin",
         // extra query params
         extraQueryParams = {},
         extraTokenParams = {},

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -104,9 +104,9 @@ export interface OidcClientSettings {
     extraTokenParams?: Record<string, unknown>;
 
     /**
-     * Whether credentials should be sent with the refresh request.
+     * CORS settings for credentials sent with the refresh request.
      */
-    refreshWithCredentials?: boolean;
+    refreshTokenCredentials?: "same-origin" | "include" | "omit";
 }
 
 /**
@@ -155,7 +155,7 @@ export class OidcClientSettingsStore {
     public readonly extraQueryParams: Record<string, string | number | boolean>;
     public readonly extraTokenParams: Record<string, unknown>;
 
-    public readonly refreshWithCredentials: boolean;
+    public readonly refreshTokenCredentials: "same-origin" | "include" | "omit" | undefined;
 
     public constructor({
         // metadata related
@@ -175,7 +175,7 @@ export class OidcClientSettingsStore {
         mergeClaims = false,
         // other behavior
         stateStore,
-        refreshWithCredentials = false,
+        refreshTokenCredentials,
         // extra query params
         extraQueryParams = {},
         extraTokenParams = {},
@@ -222,7 +222,7 @@ export class OidcClientSettingsStore {
         this.userInfoJwtIssuer = userInfoJwtIssuer;
         this.mergeClaims = !!mergeClaims;
 
-        this.refreshWithCredentials = refreshWithCredentials;
+        this.refreshTokenCredentials = refreshTokenCredentials;
 
         if (stateStore) {
             this.stateStore = stateStore;

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -31,6 +31,8 @@ export interface ExchangeRefreshTokenArgs {
     scope?: string;
 
     timeoutInSeconds?: number;
+
+    refreshWithCredentials?: boolean;
 }
 
 /**
@@ -111,6 +113,7 @@ export class TokenClient {
         client_id = this._settings.client_id,
         client_secret = this._settings.client_secret,
         timeoutInSeconds,
+        refreshWithCredentials,
         ...args
     }: ExchangeRefreshTokenArgs): Promise<Record<string, unknown>> {
         const logger = this._logger.create("exchangeRefreshToken");
@@ -147,7 +150,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds });
+        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, withCredentials: refreshWithCredentials });
         logger.debug("got response");
 
         return response;

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -31,7 +31,6 @@ export interface ExchangeRefreshTokenArgs {
     scope?: string;
 
     timeoutInSeconds?: number;
-
     refreshTokenCredentials?: "same-origin" | "include" | "omit";
 }
 

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -149,7 +149,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, corsCredentials: refreshTokenCredentials });
+        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, initCredentials: refreshTokenCredentials });
         logger.debug("got response");
 
         return response;

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -32,7 +32,7 @@ export interface ExchangeRefreshTokenArgs {
 
     timeoutInSeconds?: number;
 
-    refreshWithCredentials?: boolean;
+    refreshTokenCredentials?: "same-origin" | "include" | "omit";
 }
 
 /**
@@ -113,7 +113,7 @@ export class TokenClient {
         client_id = this._settings.client_id,
         client_secret = this._settings.client_secret,
         timeoutInSeconds,
-        refreshWithCredentials,
+        refreshTokenCredentials,
         ...args
     }: ExchangeRefreshTokenArgs): Promise<Record<string, unknown>> {
         const logger = this._logger.create("exchangeRefreshToken");
@@ -150,7 +150,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, withCredentials: refreshWithCredentials });
+        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, corsCredentials: refreshTokenCredentials });
         logger.debug("got response");
 
         return response;


### PR DESCRIPTION
fixes https://github.com/authts/oidc-client-ts/issues/607

PR could be improved by allowing more `credentials` settings besides include.

the PR is very helpful in the case that the openid server sets cookies which can be updated by refresh so that silent signin works longer.

### Checklist

- [x ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ x] I have included links for closing relevant issue numbers
