### PR TITLE
Make it possible to include credentials on all requests.

### DIFF
--- a/dist/esm/package.json
+++ b/dist/esm/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/dist/esm/package.json
+++ b/dist/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -372,7 +372,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, fetchRequestCredentials, revokeTokenAdditionalContentTypes, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, refreshTokenCredentials, revokeTokenAdditionalContentTypes, fetchRequestCredentials, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -355,6 +355,7 @@ export interface OidcClientSettings {
     post_logout_redirect_uri?: string;
     prompt?: string;
     redirect_uri: string;
+    refreshTokenCredentials?: "same-origin" | "include" | "omit";
     resource?: string;
     response_mode?: "query" | "fragment";
     response_type?: string;

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -343,6 +343,7 @@ export interface OidcClientSettings {
     extraQueryParams?: Record<string, string | number | boolean>;
     // (undocumented)
     extraTokenParams?: Record<string, unknown>;
+    fetchRequestCredentials?: RequestCredentials;
     filterProtocolClaims?: boolean;
     loadUserInfo?: boolean;
     max_age?: number;
@@ -354,7 +355,6 @@ export interface OidcClientSettings {
     post_logout_redirect_uri?: string;
     prompt?: string;
     redirect_uri: string;
-    refreshTokenCredentials?: "same-origin" | "include" | "omit";
     resource?: string;
     response_mode?: "query" | "fragment";
     response_type?: string;
@@ -370,7 +370,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, refreshTokenCredentials, revokeTokenAdditionalContentTypes, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, fetchRequestCredentials, revokeTokenAdditionalContentTypes, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -389,6 +389,8 @@ export class OidcClientSettingsStore {
     readonly extraQueryParams: Record<string, string | number | boolean>;
     // (undocumented)
     readonly extraTokenParams: Record<string, unknown>;
+    // (undocumented)
+    readonly fetchRequestCredentials: RequestCredentials;
     // (undocumented)
     readonly filterProtocolClaims: boolean;
     // (undocumented)
@@ -409,8 +411,6 @@ export class OidcClientSettingsStore {
     readonly prompt: string | undefined;
     // (undocumented)
     readonly redirect_uri: string;
-    // (undocumented)
-    readonly refreshTokenCredentials: "same-origin" | "include" | "omit";
     // (undocumented)
     readonly resource: string | undefined;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -355,6 +355,7 @@ export interface OidcClientSettings {
     post_logout_redirect_uri?: string;
     prompt?: string;
     redirect_uri: string;
+    // @deprecated (undocumented)
     refreshTokenCredentials?: "same-origin" | "include" | "omit";
     resource?: string;
     response_mode?: "query" | "fragment";

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -14,6 +14,7 @@ export type JwtHandler = (text: string) => Promise<Record<string, unknown>>;
  */
 export interface GetJsonOpts {
     token?: string;
+    credentials?: RequestCredentials;
 }
 
 /**
@@ -73,6 +74,7 @@ export class JsonService {
 
     public async getJson(url: string, {
         token,
+        credentials,
     }: GetJsonOpts = {}): Promise<Record<string, unknown>> {
         const logger = this._logger.create("getJson");
         const headers: HeadersInit = {
@@ -86,7 +88,7 @@ export class JsonService {
         let response: Response;
         try {
             logger.debug("url:", url);
-            response = await this.fetchWithTimeout(url, { method: "GET", headers });
+            response = await this.fetchWithTimeout(url, { method: "GET", headers, credentials });
         }
         catch (err) {
             logger.error("Network Error");

--- a/src/MetadataService.test.ts
+++ b/src/MetadataService.test.ts
@@ -58,7 +58,7 @@ describe("MetadataService", () => {
             await subject.getMetadata();
 
             // assert
-            expect(getJsonMock).toBeCalledWith("authority/.well-known/openid-configuration");
+            expect(getJsonMock).toBeCalledWith("authority/.well-known/openid-configuration", { credentials: "same-origin" });
         });
 
         it("should fail when no authority or metadataUrl configured", async () => {
@@ -93,7 +93,7 @@ describe("MetadataService", () => {
             await subject.getMetadata();
 
             // assert
-            expect(getJsonMock).toBeCalledWith("http://sts/metadata");
+            expect(getJsonMock).toBeCalledWith("http://sts/metadata", { credentials: "same-origin" });
         });
 
         it("should return metadata from json call", async () => {
@@ -176,6 +176,27 @@ describe("MetadataService", () => {
             await expect(subject.getMetadata())
                 // assert
                 .rejects.toThrow(error);
+        });
+
+        it("should use getRequestCredentials to make json call when set", async () => {
+            // arrange
+            settings = {
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+                metadataUrl: "http://sts/metadata",
+                fetchRequestCredentials: "include",
+            };
+            subject = new MetadataService(new OidcClientSettingsStore(settings));
+            const jsonService = subject["_jsonService"]; // access private member
+            const getJsonMock = jest.spyOn(jsonService, "getJson")
+                .mockResolvedValue({ foo: "bar" });
+
+            // act
+            await subject.getMetadata();
+
+            // assert
+            expect(getJsonMock).toBeCalledWith("http://sts/metadata", { credentials: "include" });
         });
     });
 

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -17,6 +17,7 @@ export class MetadataService {
     private _metadataUrl: string;
     private _signingKeys: SigningKey[] | null = null;
     private _metadata: Partial<OidcMetadata> | null = null;
+    private fetchRequestCredentials: RequestCredentials | undefined;
 
     public constructor(private readonly _settings: OidcClientSettingsStore) {
         this._metadataUrl = this._settings.metadataUrl;
@@ -29,6 +30,11 @@ export class MetadataService {
         if (this._settings.metadata) {
             this._logger.debug("using metadata from settings");
             this._metadata = this._settings.metadata;
+        }
+
+        if (this._settings.fetchRequestCredentials) {
+            this._logger.debug("using fetchRequestCredentials from settings");
+            this.fetchRequestCredentials = this._settings.fetchRequestCredentials;
         }
     }
 
@@ -49,7 +55,7 @@ export class MetadataService {
         }
 
         logger.debug("getting metadata from", this._metadataUrl);
-        const metadata = await this._jsonService.getJson(this._metadataUrl);
+        const metadata = await this._jsonService.getJson(this._metadataUrl, { credentials: this.fetchRequestCredentials });
 
         logger.debug("merging remote JSON with seed metadata");
         this._metadata = Object.assign({}, this._settings.metadataSeed, metadata);

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -17,7 +17,7 @@ export class MetadataService {
     private _metadataUrl: string;
     private _signingKeys: SigningKey[] | null = null;
     private _metadata: Partial<OidcMetadata> | null = null;
-    private fetchRequestCredentials: RequestCredentials | undefined;
+    private _fetchRequestCredentials: RequestCredentials | undefined;
 
     public constructor(private readonly _settings: OidcClientSettingsStore) {
         this._metadataUrl = this._settings.metadataUrl;
@@ -34,7 +34,7 @@ export class MetadataService {
 
         if (this._settings.fetchRequestCredentials) {
             this._logger.debug("using fetchRequestCredentials from settings");
-            this.fetchRequestCredentials = this._settings.fetchRequestCredentials;
+            this._fetchRequestCredentials = this._settings.fetchRequestCredentials;
         }
     }
 
@@ -55,7 +55,7 @@ export class MetadataService {
         }
 
         logger.debug("getting metadata from", this._metadataUrl);
-        const metadata = await this._jsonService.getJson(this._metadataUrl, { credentials: this.fetchRequestCredentials });
+        const metadata = await this._jsonService.getJson(this._metadataUrl, { credentials: this._fetchRequestCredentials });
 
         logger.debug("merging remote JSON with seed metadata");
         this._metadata = Object.assign({}, this._settings.metadataSeed, metadata);

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -432,7 +432,6 @@ describe("OidcClient", () => {
                 refresh_token: "refresh_token",
                 scope: "openid",
                 timeoutInSeconds: undefined,
-                refreshTokenCredentials: "same-origin",
             });
             expect(response).toBeInstanceOf(SigninResponse);
             expect(response).toMatchObject(tokenResponse);

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -196,7 +196,6 @@ export class OidcClient {
             refresh_token: state.refresh_token,
             scope: state.scope,
             timeoutInSeconds,
-            refreshTokenCredentials: this.settings.refreshTokenCredentials,
         });
         const response = new SigninResponse(new URLSearchParams());
         Object.assign(response, result);

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -104,14 +104,15 @@ export interface OidcClientSettings {
     extraTokenParams?: Record<string, unknown>;
 
     /**
-     * Credentials used by fetch with the refresh request. (default: "same-origin")
-     */
-    refreshTokenCredentials?: "same-origin" | "include" | "omit";
-
-    /**
      * Will check the content type header of the response of the revocation endpoint to match these passed values (default: [])
      */
     revokeTokenAdditionalContentTypes?: string[];
+
+    /**
+     * Sets the credentials for fetch requests. (default: "same-origin")
+     * Use this if you need to send cookies to the OIDC/OAuth2 provider or if you are using a proxy that requires cookies
+     */
+    fetchRequestCredentials?: RequestCredentials;
 }
 
 /**
@@ -160,8 +161,8 @@ export class OidcClientSettingsStore {
     public readonly extraQueryParams: Record<string, string | number | boolean>;
     public readonly extraTokenParams: Record<string, unknown>;
 
-    public readonly refreshTokenCredentials: "same-origin" | "include" | "omit";
     public readonly revokeTokenAdditionalContentTypes?: string[];
+    public readonly fetchRequestCredentials: RequestCredentials;
 
     public constructor({
         // metadata related
@@ -181,7 +182,7 @@ export class OidcClientSettingsStore {
         mergeClaims = false,
         // other behavior
         stateStore,
-        refreshTokenCredentials = "same-origin",
+        fetchRequestCredentials = "same-origin",
         revokeTokenAdditionalContentTypes,
         // extra query params
         extraQueryParams = {},
@@ -229,8 +230,8 @@ export class OidcClientSettingsStore {
         this.userInfoJwtIssuer = userInfoJwtIssuer;
         this.mergeClaims = !!mergeClaims;
 
-        this.refreshTokenCredentials = refreshTokenCredentials;
         this.revokeTokenAdditionalContentTypes = revokeTokenAdditionalContentTypes;
+        this.fetchRequestCredentials = fetchRequestCredentials;
 
         if (stateStore) {
             this.stateStore = stateStore;

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -104,7 +104,7 @@ export interface OidcClientSettings {
     extraTokenParams?: Record<string, unknown>;
 
     /**
-     * Credentials used by fetch with the refresh request. (default: "same-origin")
+     * @deprecated since version 2.1.0. Use fetchRequestCredentials instead.
      */
     refreshTokenCredentials?: "same-origin" | "include" | "omit";
 

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -187,8 +187,9 @@ export class OidcClientSettingsStore {
         mergeClaims = false,
         // other behavior
         stateStore,
-        fetchRequestCredentials = "same-origin",
+        refreshTokenCredentials,
         revokeTokenAdditionalContentTypes,
+        fetchRequestCredentials,
         // extra query params
         extraQueryParams = {},
         extraTokenParams = {},
@@ -236,7 +237,12 @@ export class OidcClientSettingsStore {
         this.mergeClaims = !!mergeClaims;
 
         this.revokeTokenAdditionalContentTypes = revokeTokenAdditionalContentTypes;
-        this.fetchRequestCredentials = fetchRequestCredentials;
+
+        if (fetchRequestCredentials && refreshTokenCredentials) {
+            console.warn("Both fetchRequestCredentials and refreshTokenCredentials is set. Only fetchRequestCredentials will be used.");
+        }
+        this.fetchRequestCredentials = fetchRequestCredentials ? fetchRequestCredentials
+            : refreshTokenCredentials ? refreshTokenCredentials : "same-origin";
 
         if (stateStore) {
             this.stateStore = stateStore;

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -104,6 +104,11 @@ export interface OidcClientSettings {
     extraTokenParams?: Record<string, unknown>;
 
     /**
+     * Credentials used by fetch with the refresh request. (default: "same-origin")
+     */
+    refreshTokenCredentials?: "same-origin" | "include" | "omit";
+
+    /**
      * Will check the content type header of the response of the revocation endpoint to match these passed values (default: [])
      */
     revokeTokenAdditionalContentTypes?: string[];

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -45,7 +45,7 @@ const ProtocolClaims = [
  */
 export class ResponseValidator {
     protected readonly _logger = new Logger("ResponseValidator");
-    protected readonly _userInfoService = new UserInfoService(this._metadataService);
+    protected readonly _userInfoService = new UserInfoService(this._metadataService, this._settings);
     protected readonly _tokenClient = new TokenClient(this._settings, this._metadataService);
 
     public constructor(

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -45,7 +45,7 @@ const ProtocolClaims = [
  */
 export class ResponseValidator {
     protected readonly _logger = new Logger("ResponseValidator");
-    protected readonly _userInfoService = new UserInfoService(this._metadataService, this._settings);
+    protected readonly _userInfoService = new UserInfoService(this._settings, this._metadataService);
     protected readonly _tokenClient = new TokenClient(this._settings, this._metadataService);
 
     public constructor(

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -45,7 +45,6 @@ export interface ExchangeRefreshTokenArgs {
     scope?: string;
 
     timeoutInSeconds?: number;
-    refreshTokenCredentials?: "same-origin" | "include" | "omit";
 }
 
 /**
@@ -117,7 +116,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, { body: params, basicAuth });
+        const response = await this._jsonService.postForm(url, { body: params, basicAuth, initCredentials: this._settings.fetchRequestCredentials });
         logger.debug("got response");
 
         return response;
@@ -159,7 +158,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, { body: params, basicAuth });
+        const response = await this._jsonService.postForm(url, { body: params, basicAuth, initCredentials: this._settings.fetchRequestCredentials });
         logger.debug("got response");
 
         return response;
@@ -170,7 +169,6 @@ export class TokenClient {
         client_id = this._settings.client_id,
         client_secret = this._settings.client_secret,
         timeoutInSeconds,
-        refreshTokenCredentials,
         ...args
     }: ExchangeRefreshTokenArgs): Promise<Record<string, unknown>> {
         const logger = this._logger.create("exchangeRefreshToken");
@@ -207,7 +205,7 @@ export class TokenClient {
         const url = await this._metadataService.getTokenEndpoint(false);
         logger.debug("got token endpoint");
 
-        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, initCredentials: refreshTokenCredentials });
+        const response = await this._jsonService.postForm(url, { body: params, basicAuth, timeoutInSeconds, initCredentials: this._settings.fetchRequestCredentials });
         logger.debug("got response");
 
         return response;

--- a/src/UserInfoService.test.ts
+++ b/src/UserInfoService.test.ts
@@ -19,7 +19,7 @@ describe("UserInfoService", () => {
         });
         metadataService = new MetadataService(settings);
 
-        subject = new UserInfoService(metadataService);
+        subject = new UserInfoService(metadataService, settings);
 
         // access private members
         jsonService = subject["_jsonService"];

--- a/src/UserInfoService.test.ts
+++ b/src/UserInfoService.test.ts
@@ -16,10 +16,11 @@ describe("UserInfoService", () => {
             authority: "authority",
             client_id: "client",
             redirect_uri: "redirect",
+            fetchRequestCredentials: "include",
         });
         metadataService = new MetadataService(settings);
 
-        subject = new UserInfoService(metadataService, settings);
+        subject = new UserInfoService(settings, metadataService);
 
         // access private members
         jsonService = subject["_jsonService"];
@@ -100,6 +101,23 @@ describe("UserInfoService", () => {
 
             // assert
             expect(claims).toEqual(expectedClaims);
+        });
+
+        it("should use settings fetchRequestCredentials to set credentials on user info request", async () => {
+            // arrange
+            jest.spyOn(metadataService, "getUserInfoEndpoint").mockImplementation(() => Promise.resolve("http://sts/userinfo"));
+            const getJsonMock = jest.spyOn(jsonService, "getJson").mockImplementation(() => Promise.resolve({}));
+
+            // act
+            await subject.getClaims("token");
+
+            // assert
+            expect(getJsonMock).toBeCalledWith(
+                "http://sts/userinfo",
+                expect.objectContaining({
+                    credentials: "include",
+                }),
+            );
         });
     });
 });

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -5,6 +5,7 @@ import { Logger, JwtUtils } from "./utils";
 import { JsonService } from "./JsonService";
 import type { MetadataService } from "./MetadataService";
 import type { JwtClaims } from "./Claims";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
 
 /**
  * @internal
@@ -13,7 +14,8 @@ export class UserInfoService {
     protected readonly _logger = new Logger("UserInfoService");
     private readonly _jsonService: JsonService;
 
-    public constructor(private readonly _metadataService: MetadataService) {
+    public constructor(private readonly _metadataService: MetadataService,
+        private readonly _settings: OidcClientSettingsStore) {
         this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
     }
 
@@ -26,7 +28,7 @@ export class UserInfoService {
         const url = await this._metadataService.getUserInfoEndpoint();
         logger.debug("got userinfo url", url);
 
-        const claims = await this._jsonService.getJson(url, { token });
+        const claims = await this._jsonService.getJson(url, { token, credentials: this._settings.fetchRequestCredentials });
         logger.debug("got claims", claims);
 
         return claims;

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -14,8 +14,9 @@ export class UserInfoService {
     protected readonly _logger = new Logger("UserInfoService");
     private readonly _jsonService: JsonService;
 
-    public constructor(private readonly _metadataService: MetadataService,
-        private readonly _settings: OidcClientSettingsStore) {
+    public constructor(private readonly _settings: OidcClientSettingsStore,
+        private readonly _metadataService: MetadataService,
+    ) {
         this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
     }
 
@@ -28,7 +29,10 @@ export class UserInfoService {
         const url = await this._metadataService.getUserInfoEndpoint();
         logger.debug("got userinfo url", url);
 
-        const claims = await this._jsonService.getJson(url, { token, credentials: this._settings.fetchRequestCredentials });
+        const claims = await this._jsonService.getJson(url, {
+            token,
+            credentials: this._settings.fetchRequestCredentials,
+        });
         logger.debug("got claims", claims);
 
         return claims;
@@ -41,8 +45,7 @@ export class UserInfoService {
             logger.debug("JWT decoding successful");
 
             return payload;
-        }
-        catch (err) {
+        } catch (err) {
             logger.error("Error parsing JWT response");
             throw err;
         }


### PR DESCRIPTION
When using a proxy or cdn like AWS cloudfront you might need to pass cookies when doing http requests from your web application to your backend service. Ex if your infrastructure requires a token cookie to pass requests through to the backend endpoints.

Right now the oidc-client-ts library doesn't support using credentials on all fetch calls. Because of this the library doesn't support the above use case.

I looked at this pull request: [https://github.com/authts/oidc-client-ts/pull/659](https://github.com/authts/oidc-client-ts/pull/659) which adds support of credentials for the refreshToken fetch request. But it is only supports refreshToken.

In my pull request I changed this to be a fetchRequestCredentials which will put credentials on all fetch calls within the library because in the above use case credentials in needed in all fetch requests.

I could also add support credentials for each fetch request like the refreshToken so there would be settings like this:
- userInfoCredentials
- refreshTokenCredentials
- tokenCredentials
- openConfigurationCredentials
- etc

What is your feedback on this?

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
