### PR TITLE
Fix default value documentation error

### DIFF
--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -75,7 +75,7 @@ export interface OidcClientSettings {
     filterProtocolClaims?: boolean;
     /** Flag to control if additional identity data is loaded from the user info endpoint in order to populate the user's profile (default: false) */
     loadUserInfo?: boolean;
-    /** Number (in seconds) indicating the age of state entries in storage for authorize requests that are considered abandoned and thus can be cleaned up (default: 300) */
+    /** Number (in seconds) indicating the age of state entries in storage for authorize requests that are considered abandoned and thus can be cleaned up (default: 900) */
     staleStateAgeInSeconds?: number;
 
     /** @deprecated Unused */


### PR DESCRIPTION
Fix an error in the documentation for the default value of `staleStateAgeInSeconds`.  
The actual default value is 60 * 15 = 900 and not 300.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers