### PR TITLE
Define popup close within 100ms as blocked by the user and throw the relevant error.

### DIFF
--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -36,6 +36,12 @@ export class PopupWindow extends AbstractChildWindow {
     public async navigate(params: NavigateParams): Promise<NavigateResponse> {
         this._window?.focus();
 
+        setTimeout(() => {
+            if (!this._window || typeof this._window.closed !== "boolean" || this._window.closed) {
+                this._abort.raise(new Error("Popup blocked by user"));
+            }
+        }, 100);
+
         const popupClosedInterval = setInterval(() => {
             if (!this._window || this._window.closed) {
                 this._abort.raise(new Error("Popup closed by user"));


### PR DESCRIPTION
QoL feature to define the popup closing by a blocker (either as default by browser, or by an add-on/extension) if the popup was closed within 100ms of its creation time.

Currently, whether the popup is closed by a blocker or manually by the user, the same error—"Popup closed by user"—is thrown, making it difficult to decide if the client should fall back to the redirect method in such a case. With this added, the process should be as simple as comparing the thrown error and deciding accordingly.

I am not very familiar with jest, so I didn't know if or how I should write the relevant tests. Please tell me if I should do that. I have only confirmed its functionality via the Parcel sample.

### Checklist

- [x] This PR makes changes to the public API.
- [x] I have included links for closing relevant issue numbers
