### PR TITLE
Add extraTokenParams to ROPC Flow

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -298,7 +298,7 @@ export class OidcClient {
     // (undocumented)
     readonly metadataService: MetadataService;
     // (undocumented)
-    processResourceOwnerPasswordCredentials({ username, password, skipUserInfo, }: ProcessResourceOwnerPasswordCredentialsArgs): Promise<SigninResponse>;
+    processResourceOwnerPasswordCredentials({ username, password, skipUserInfo, extraTokenParams, }: ProcessResourceOwnerPasswordCredentialsArgs): Promise<SigninResponse>;
     // (undocumented)
     processSigninResponse(url: string): Promise<SigninResponse>;
     // (undocumented)
@@ -562,6 +562,7 @@ export type ProcessResourceOwnerPasswordCredentialsArgs = {
     username: string;
     password: string;
     skipUserInfo?: boolean;
+    extraTokenParams?: Record<string, unknown>;
 };
 
 // @public (undocumented)

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -65,6 +65,7 @@ export type ProcessResourceOwnerPasswordCredentialsArgs = {
     username: string;
     password: string;
     skipUserInfo?: boolean;
+    extraTokenParams?: Record<string, unknown>;
 };
 
 /**
@@ -178,8 +179,9 @@ export class OidcClient {
         username,
         password,
         skipUserInfo = false,
+        extraTokenParams = {},
     }: ProcessResourceOwnerPasswordCredentialsArgs): Promise<SigninResponse> {
-        const tokenResponse: Record<string, unknown> = await this._tokenClient.exchangeCredentials({ username, password });
+        const tokenResponse: Record<string, unknown> = await this._tokenClient.exchangeCredentials({ username, password, ...extraTokenParams });
         const signinResponse: SigninResponse = new SigninResponse(new URLSearchParams());
         Object.assign(signinResponse, tokenResponse);
         await this._validator.validateCredentialsResponse(signinResponse, skipUserInfo);

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -127,8 +127,7 @@ export class TokenClient {
         client_id = this._settings.client_id,
         client_secret = this._settings.client_secret,
         scope = this._settings.scope,
-        username,
-        password,
+        ...args
     }: ExchangeCredentialsArgs): Promise<Record<string, unknown>> {
         const logger = this._logger.create("exchangeCredentials");
 
@@ -136,7 +135,12 @@ export class TokenClient {
             logger.throw(new Error("A client_id is required"));
         }
 
-        const params = new URLSearchParams({ grant_type, username, password, scope });
+        const params = new URLSearchParams({ grant_type, scope });
+        for (const [key, value] of Object.entries(args)) {
+            if (value != null) {
+                params.set(key, value);
+            }
+        }
 
         let basicAuth: string | undefined;
         switch (this._settings.client_authentication) {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -194,7 +194,7 @@ export class UserManager {
     }: SigninResourceOwnerCredentialsArgs ) {
         const logger = this._logger.create("signinResourceOwnerCredential");
 
-        const signinResponse = await this._client.processResourceOwnerPasswordCredentials({ username, password, skipUserInfo });
+        const signinResponse = await this._client.processResourceOwnerPasswordCredentials({ username, password, skipUserInfo, extraTokenParams: this.settings.extraTokenParams });
         logger.debug("got signin response");
 
         const user = await this._buildUser(signinResponse);


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #820 

Add the extraTokenParameters to the Resource Owner Password Credential Flow request to the `/token` endpoint.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [X ] I have included links for closing relevant issue numbers
