### PR TITLE
refresh userinfo data on demand

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -287,12 +287,18 @@ export interface OidcAddressClaim {
 // @public
 export class OidcClient {
     constructor(settings: OidcClientSettings);
+    // Warning: (ae-forgotten-export) The symbol "ClaimsService" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected readonly _claimsService: ClaimsService;
     // (undocumented)
     clearStaleState(): Promise<void>;
     // (undocumented)
     createSigninRequest({ state, request, request_uri, request_type, id_token_hint, login_hint, skipUserInfo, nonce, response_type, scope, redirect_uri, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, extraQueryParams, extraTokenParams, }: CreateSigninRequestArgs): Promise<SigninRequest>;
     // (undocumented)
     createSignoutRequest({ state, id_token_hint, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
+    // (undocumented)
+    getUserInfo(token: string, profile: IdTokenClaims): Promise<IdTokenClaims>;
     // (undocumented)
     protected readonly _logger: Logger;
     // (undocumented)
@@ -323,6 +329,10 @@ export class OidcClient {
     protected readonly _tokenClient: TokenClient;
     // (undocumented)
     useRefreshToken({ state, timeoutInSeconds, }: UseRefreshTokenArgs): Promise<SigninResponse>;
+    // Warning: (ae-forgotten-export) The symbol "UserInfoService" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected readonly _userInfoService: UserInfoService;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -903,7 +913,7 @@ export class UserManager {
     get events(): UserManagerEvents;
     // (undocumented)
     protected readonly _events: UserManagerEvents;
-    getUser(): Promise<User | null>;
+    getUser(refreshUserInfo?: boolean): Promise<User | null>;
     // Warning: (ae-forgotten-export) The symbol "IFrameNavigator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -355,6 +355,7 @@ export interface OidcClientSettings {
     extraTokenParams?: Record<string, unknown>;
     fetchRequestCredentials?: RequestCredentials;
     filterProtocolClaims?: boolean | string[];
+    legacyMergeClaimsBehavior?: boolean;
     loadUserInfo?: boolean;
     max_age?: number;
     mergeClaims?: boolean;
@@ -383,7 +384,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, stateStore, refreshTokenCredentials, revokeTokenAdditionalContentTypes, fetchRequestCredentials, refreshTokenAllowedScope, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, legacyMergeClaimsBehavior, stateStore, refreshTokenCredentials, revokeTokenAdditionalContentTypes, fetchRequestCredentials, refreshTokenAllowedScope, extraQueryParams, extraTokenParams, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -406,6 +407,7 @@ export class OidcClientSettingsStore {
     readonly fetchRequestCredentials: RequestCredentials;
     // (undocumented)
     readonly filterProtocolClaims: boolean | string[];
+    readonly legacyMergeClaimsBehavior: boolean;
     // (undocumented)
     readonly loadUserInfo: boolean;
     // (undocumented)

--- a/src/ClaimsService.test.ts
+++ b/src/ClaimsService.test.ts
@@ -179,8 +179,10 @@ describe("ClaimsService", () => {
             expect(result).toEqual({ a: "apple", c: "carrot", b: "banana" });
         });
 
-        it("should not merge claims when claim types are objects", () => {
+        it("should not merge (but append) claims when claim types are objects, if using legacy merge behavior", () => {
             // arrange
+            Object.assign(settings, { legacyMergeClaimsBehavior: true });
+
             const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
             const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
 
@@ -189,6 +191,32 @@ describe("ClaimsService", () => {
 
             // assert
             expect(result).toEqual({ custom: [{ "apple": "foo", "pear": "bar" }, { "apple": "foo", "orange": "peel" }], b: "banana" });
+        });
+
+        it("should overwrite claims when claim types are objects", () => {
+            // arrange
+            const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
+            const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ custom: { "apple": "foo", "orange": "peel" }, b: "banana" });
+        });
+
+        it("should merge claims when claim types are objects when mergeClaims settings is true, if using legacy merge behavior", () => {
+            // arrange
+            Object.assign(settings, { mergeClaims: true, legacyMergeClaimsBehavior: true });
+
+            const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
+            const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ custom: { "apple": "foo", "pear": "bar", "orange": "peel" }, b: "banana" });
         });
 
         it("should merge claims when claim types are objects when mergeClaims settings is true", () => {
@@ -205,8 +233,10 @@ describe("ClaimsService", () => {
             expect(result).toEqual({ custom: { "apple": "foo", "pear": "bar", "orange": "peel" }, b: "banana" });
         });
 
-        it("should merge same claim types into array", () => {
+        it("should merge same claim types into array, if using legacy merge behavior", () => {
             // arrange
+            Object.assign(settings, { legacyMergeClaimsBehavior: true });
+
             const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
             const c2 = { a: "carrot" };
 
@@ -217,8 +247,22 @@ describe("ClaimsService", () => {
             expect(result).toEqual({ a: ["apple", "carrot"], b: "banana" });
         });
 
-        it("should merge arrays of same claim types into array", () => {
+        it("should overwrite same claim", () => {
             // arrange
+            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
+            const c2 = { a: "carrot" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: "carrot", b: "banana" });
+        });
+
+        it("should merge arrays of same claim types into array, if using legacy merge behavior", () => {
+            // arrange
+            Object.assign(settings, { legacyMergeClaimsBehavior: true });
+
             const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
             const c2 = { a: ["carrot", "durian"] };
 
@@ -249,8 +293,10 @@ describe("ClaimsService", () => {
             expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
         });
 
-        it("should remove duplicates when producing arrays", () => {
+        it("should remove duplicates when producing arrays, if using legacy merge behavior", () => {
             // arrange
+            Object.assign(settings, { legacyMergeClaimsBehavior: true });
+
             const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
             const c2 = { a: ["apple", "durian"] };
 
@@ -261,8 +307,10 @@ describe("ClaimsService", () => {
             expect(result).toEqual({ a: ["apple", "durian"], b: "banana" });
         });
 
-        it("should not add if already present in array", () => {
+        it("should not add if already present in array, if using legacy merge behavior", () => {
             // arrange
+            Object.assign(settings, { legacyMergeClaimsBehavior: true });
+
             const c1 = { a: ["apple", "durian"], b: "banana" } as unknown as UserProfile;
             const c2 = { a: "apple" };
 
@@ -272,5 +320,18 @@ describe("ClaimsService", () => {
             // assert
             expect(result).toEqual({ a: ["apple", "durian"], b: "banana" });
         });
+
+        it("should override array", () => {
+            // arrange
+            const c1 = { a: ["apple", "banana"], b: "banana" } as unknown as UserProfile;
+            const c2 = { a: ["orange", "durian"] };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: ["orange", "durian"], b: "banana" });
+        });
+
     });
 });

--- a/src/ClaimsService.test.ts
+++ b/src/ClaimsService.test.ts
@@ -1,0 +1,276 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+import { ClaimsService } from "./ClaimsService";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { UserProfile } from "./User";
+
+describe("ClaimsService", () => {
+    let settings: OidcClientSettingsStore;
+    let subject: ClaimsService;
+
+    beforeEach(() => {
+        settings = {
+            authority: "op",
+            client_id: "client",
+            loadUserInfo: true,
+        } as OidcClientSettingsStore;
+
+        subject = new ClaimsService(settings);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("filterProtocolClaims", () => {
+        it("should filter protocol claims if enabled on settings", () => {
+            // arrange
+            Object.assign(settings, { filterProtocolClaims: true });
+            const claims = {
+                foo: 1, bar: "test",
+                aud: "some_aud", iss: "issuer",
+                sub: "123", email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                iat: 5, exp: 20,
+                nbf: 10, at_hash: "athash",
+            };
+
+            // act
+            const result = subject["filterProtocolClaims"](claims);
+
+            // assert
+            expect(result).toEqual({
+                foo: 1, bar: "test",
+                aud: "some_aud", iss: "issuer",
+                sub: "123", email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                iat: 5, exp: 20,
+            });
+        });
+
+        it("should not filter protocol claims if not enabled on settings", () => {
+            // arrange
+            Object.assign(settings, { filterProtocolClaims: false });
+            const claims = {
+                foo: 1, bar: "test",
+                aud: "some_aud", iss: "issuer",
+                sub: "123", email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                at_hash: "athash",
+                iat: 5, nbf: 10, exp: 20,
+            };
+
+            // act
+            const result = subject["filterProtocolClaims"](claims);
+
+            // assert
+            expect(result).toEqual({
+                foo: 1, bar: "test",
+                aud: "some_aud", iss: "issuer",
+                sub: "123", email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                at_hash: "athash",
+                iat: 5, nbf: 10, exp: 20,
+            });
+        });
+
+        it("should filter protocol claims if specified in settings", () => {
+            // arrange
+            Object.assign(settings, { filterProtocolClaims: ["foo", "bar", "role", "nbf", "email"] });
+            const claims = {
+                foo: 1, bar: "test",
+                aud: "some_aud", iss: "issuer",
+                sub: "123", email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                iat: 5, exp: 20,
+                nbf: 10, at_hash: "athash",
+            };
+
+            // act
+            const result = subject["filterProtocolClaims"](claims);
+
+            // assert
+            expect(result).toEqual({
+                aud: "some_aud", iss: "issuer",
+                sub: "123",
+                iat: 5, exp: 20,
+                at_hash: "athash",
+            });
+        });
+
+        it("should filter only protocol claims defined by default by the library", () => {
+            // arrange
+            Object.assign(settings, { filterProtocolClaims: true });
+            const defaultProtocolClaims = {
+                nbf: 3, jti: "jti",
+                auth_time: 123,
+                nonce: "nonce",
+                acr: "acr",
+                amr: "amr",
+                azp: "azp",
+                at_hash: "athash",
+            };
+            const claims = {
+                foo: 1, bar: "test",
+                aud: "some_aud", iss: "issuer",
+                sub: "123", email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                iat: 5, exp: 20,
+            };
+
+            // act
+            const result = subject["filterProtocolClaims"]({ ...defaultProtocolClaims, ...claims });
+
+            // assert
+            expect(result).toEqual(claims);
+        });
+
+        it("should not filter protocol claims that are required by the library", () => {
+            // arrange
+            Object.assign(settings, { filterProtocolClaims: true });
+            const internalRequiredProtocolClaims = {
+                sub: "sub",
+                iss: "issuer",
+                aud: "some_aud",
+                exp: 20,
+                iat: 5,
+            };
+            const claims = {
+                foo: 1, bar: "test",
+                email: "foo@gmail.com",
+                role: ["admin", "dev"],
+                nbf: 10,
+            };
+
+            // act
+            let items = { ...internalRequiredProtocolClaims, ...claims };
+            let result = subject["filterProtocolClaims"](items);
+
+            // assert
+            // nbf is part of the claims that should be filtered by the library by default, so we need to remove it
+            delete (items as Partial<typeof items>).nbf;
+            expect(result).toEqual(items);
+
+            // ... even if specified in settings
+
+            // arrange
+            Object.assign(settings, { filterProtocolClaims: ["sub", "iss", "aud", "exp", "iat"] });
+
+            // act
+            items = { ...internalRequiredProtocolClaims, ...claims };
+            result = subject["filterProtocolClaims"](items);
+
+            // assert
+            expect(result).toEqual(items);
+        });
+    });
+
+    describe("mergeClaims", () => {
+        it("should merge claims", () => {
+            // arrange
+            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
+            const c2 = { c: "carrot" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: "apple", c: "carrot", b: "banana" });
+        });
+
+        it("should not merge claims when claim types are objects", () => {
+            // arrange
+            const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
+            const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ custom: [{ "apple": "foo", "pear": "bar" }, { "apple": "foo", "orange": "peel" }], b: "banana" });
+        });
+
+        it("should merge claims when claim types are objects when mergeClaims settings is true", () => {
+            // arrange
+            Object.assign(settings, { mergeClaims: true });
+
+            const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
+            const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ custom: { "apple": "foo", "pear": "bar", "orange": "peel" }, b: "banana" });
+        });
+
+        it("should merge same claim types into array", () => {
+            // arrange
+            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
+            const c2 = { a: "carrot" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: ["apple", "carrot"], b: "banana" });
+        });
+
+        it("should merge arrays of same claim types into array", () => {
+            // arrange
+            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
+            const c2 = { a: ["carrot", "durian"] };
+
+            // act
+            let result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
+
+            // arrange
+            const d1 = { a: ["apple", "carrot"], b: "banana" } as unknown as UserProfile;
+            const d2 = { a: ["durian"] };
+
+            // act
+            result = subject["mergeClaims"](d1, d2);
+
+            // assert
+            expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
+
+            // arrange
+            const e1 = { a: ["apple", "carrot"], b: "banana" } as unknown as UserProfile;
+            const e2 = { a: "durian" };
+
+            // act
+            result = subject["mergeClaims"](e1, e2);
+
+            // assert
+            expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
+        });
+
+        it("should remove duplicates when producing arrays", () => {
+            // arrange
+            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
+            const c2 = { a: ["apple", "durian"] };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: ["apple", "durian"], b: "banana" });
+        });
+
+        it("should not add if already present in array", () => {
+            // arrange
+            const c1 = { a: ["apple", "durian"], b: "banana" } as unknown as UserProfile;
+            const c2 = { a: "apple" };
+
+            // act
+            const result = subject["mergeClaims"](c1, c2);
+
+            // assert
+            expect(result).toEqual({ a: ["apple", "durian"], b: "banana" });
+        });
+    });
+});

--- a/src/ClaimsService.ts
+++ b/src/ClaimsService.ts
@@ -4,7 +4,7 @@
 import type { JwtClaims } from "./Claims";
 import type { OidcClientSettingsStore } from "./OidcClientSettings";
 import type { UserProfile } from "./User";
-import type { Logger } from "./utils";
+import { Logger } from "./utils";
 
 /**
  * Protocol claims that could be removed by default from profile.
@@ -38,9 +38,9 @@ const InternalRequiredProtocolClaims = ["sub", "iss", "aud", "exp", "iat"];
  * @internal
  */
 export class ClaimsService {
+    protected readonly _logger = new Logger("ClaimsService");
     public constructor(
         protected readonly _settings: OidcClientSettingsStore,
-        protected readonly _logger: Logger,
     ) {}
 
     public filterProtocolClaims(claims: UserProfile): UserProfile {

--- a/src/ClaimsService.ts
+++ b/src/ClaimsService.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+import type { JwtClaims } from "./Claims";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { UserProfile } from "./User";
+import type { Logger } from "./utils";
+
+/**
+ * Protocol claims that could be removed by default from profile.
+ * Derived from the following sets of claims:
+ * - {@link https://datatracker.ietf.org/doc/html/rfc7519.html#section-4.1}
+ * - {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken}
+ * - {@link https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken}
+ *
+ * @internal
+ */
+const DefaultProtocolClaims = [
+    "nbf",
+    "jti",
+    "auth_time",
+    "nonce",
+    "acr",
+    "amr",
+    "azp",
+    "at_hash", // https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
+] as const;
+
+/**
+ * Protocol claims that should never be removed from profile.
+ * "sub" is needed internally and others should remain required as per the OIDC specs.
+ *
+ * @internal
+ */
+const InternalRequiredProtocolClaims = ["sub", "iss", "aud", "exp", "iat"];
+
+/**
+ * @internal
+ */
+export class ClaimsService {
+    public constructor(
+        protected readonly _settings: OidcClientSettingsStore,
+        protected readonly _logger: Logger,
+    ) {}
+
+    public filterProtocolClaims(claims: UserProfile): UserProfile {
+        const result = { ...claims };
+
+        if (this._settings.filterProtocolClaims) {
+            let protocolClaims;
+            if (Array.isArray(this._settings.filterProtocolClaims)) {
+                protocolClaims = this._settings.filterProtocolClaims;
+            } else {
+                protocolClaims = DefaultProtocolClaims;
+            }
+
+            for (const claim of protocolClaims) {
+                if (!InternalRequiredProtocolClaims.includes(claim)) {
+                    delete result[claim];
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public mergeClaims(claims1: UserProfile, claims2: JwtClaims): UserProfile {
+        const result = { ...claims1 };
+
+        for (const [claim, values] of Object.entries(claims2)) {
+            for (const value of Array.isArray(values) ? values : [values]) {
+                const previousValue = result[claim];
+                if (!previousValue) {
+                    result[claim] = value;
+                }
+                else if (Array.isArray(previousValue)) {
+                    if (!previousValue.includes(value)) {
+                        previousValue.push(value);
+                    }
+                }
+                else if (result[claim] !== value) {
+                    if (typeof value === "object" && this._settings.mergeClaims) {
+                        result[claim] = this.mergeClaims(previousValue as UserProfile, value);
+                    }
+                    else {
+                        result[claim] = [previousValue, value];
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/ClaimsService.ts
+++ b/src/ClaimsService.ts
@@ -91,18 +91,23 @@ export class ClaimsService {
         return result;
     }
 
-    public mergeClaims(claims1: UserProfile, claims2: JwtClaims): UserProfile {
+    public mergeClaims(claims1: UserProfile, claims2: JwtClaims): UserProfile;
+    public mergeClaims(claims1: JwtClaims, claims2: JwtClaims): JwtClaims;
+    public mergeClaims(claims1: JwtClaims | UserProfile, claims2: JwtClaims): JwtClaims | UserProfile {
         // TODO: remove on next major version
         if (this._settings.legacyMergeClaimsBehavior) {
-            return this.legacyMergeClaims(claims1, claims2);
+            return this.legacyMergeClaims(claims1 as UserProfile, claims2);
         }
 
         const result = { ...claims1 };
 
         for (const [claim, value] of Object.entries(claims2)) {
             if (result[claim] !== value) {
-                if (typeof value === "object" && this._settings.mergeClaims) {
-                    result[claim] = this.mergeClaims(result[claim] as UserProfile, value as JwtClaims);
+                if (typeof result[claim] === "object"
+                    && typeof value === "object"
+                    && this._settings.mergeClaims
+                ) {
+                    result[claim] = this.mergeClaims(result[claim] as JwtClaims, value as JwtClaims);
                 } else {
                     result[claim] = value;
                 }

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -814,4 +814,36 @@ describe("OidcClient", () => {
             });
         });
     });
+
+    describe("getUserInfo", () => {
+        it("gets user info", async () => {
+            // arrange
+            const claims = {
+                aud: "aud",
+                exp: 0,
+                iat: 0,
+                iss: "iss",
+                sub: "sub",
+            };
+
+            const getClaimsSpy = jest.spyOn(subject["_userInfoService"], "getClaims").mockResolvedValue({
+                aud: "aud",
+                exp: 0,
+                iat: 0,
+                iss: "iss",
+                sub: "sub",
+                a: "apple",
+            });
+
+            // act
+            await subject.getUserInfo("access_token", claims);
+
+            // assert
+            expect(getClaimsSpy).toHaveBeenCalledWith(
+                "access_token",
+                claims,
+                true,
+            );
+        });
+    });
 });

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -14,6 +14,9 @@ import { SignoutResponse } from "./SignoutResponse";
 import { SigninState } from "./SigninState";
 import { State } from "./State";
 import { TokenClient } from "./TokenClient";
+import { UserInfoService } from "./UserInfoService";
+import { ClaimsService } from "./ClaimsService";
+import type { IdTokenClaims } from "./Claims";
 
 /**
  * @public
@@ -83,12 +86,16 @@ export class OidcClient {
     public readonly metadataService: MetadataService;
     protected readonly _validator: ResponseValidator;
     protected readonly _tokenClient: TokenClient;
+    protected readonly  _userInfoService: UserInfoService;
+    protected readonly _claimsService: ClaimsService;
 
     public constructor(settings: OidcClientSettings) {
         this.settings = new OidcClientSettingsStore(settings);
 
         this.metadataService = new MetadataService(this.settings);
-        this._validator = new ResponseValidator(this.settings, this.metadataService);
+        this._claimsService = new ClaimsService(this.settings, this. _logger);
+        this._userInfoService = new UserInfoService(this.settings, this.metadataService, this._claimsService);
+        this._validator = new ResponseValidator(this.settings, this.metadataService, this._claimsService, this._userInfoService);
         this._tokenClient = new TokenClient(this.settings, this.metadataService);
     }
 

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -323,6 +323,6 @@ export class OidcClient {
     }
 
     public getUserInfo(token: string, profile: IdTokenClaims): Promise<IdTokenClaims> {
-        return this._userInfoService.getClaims(token, profile);
+        return this._userInfoService.getClaims(token, profile, true);
     }
 }

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -86,14 +86,14 @@ export class OidcClient {
     public readonly metadataService: MetadataService;
     protected readonly _validator: ResponseValidator;
     protected readonly _tokenClient: TokenClient;
-    protected readonly  _userInfoService: UserInfoService;
+    protected readonly _userInfoService: UserInfoService;
     protected readonly _claimsService: ClaimsService;
 
     public constructor(settings: OidcClientSettings) {
         this.settings = new OidcClientSettingsStore(settings);
 
         this.metadataService = new MetadataService(this.settings);
-        this._claimsService = new ClaimsService(this.settings, this. _logger);
+        this._claimsService = new ClaimsService(this.settings);
         this._userInfoService = new UserInfoService(this.settings, this.metadataService, this._claimsService);
         this._validator = new ResponseValidator(this.settings, this.metadataService, this._claimsService, this._userInfoService);
         this._tokenClient = new TokenClient(this.settings, this.metadataService);
@@ -320,5 +320,9 @@ export class OidcClient {
             token,
             token_type_hint: type,
         });
+    }
+
+    public getUserInfo(token: string, profile: IdTokenClaims): Promise<IdTokenClaims> {
+        return this._userInfoService.getClaims(token, profile);
     }
 }

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -94,6 +94,12 @@ export interface OidcClientSettings {
     mergeClaims?: boolean;
 
     /**
+     * Indicates if the library should use the legacy merge behavior, which mutates string claims into arrays whenever the data is updated on the remote.
+     * This behavior is enabled by default on v2 and will be removed on v3, since it's not a deterministic way of handling claims.
+     */
+    legacyMergeClaimsBehavior?: boolean;
+
+    /**
      * Storage object used to persist interaction state (default: window.localStorage, InMemoryWebStorage iff no window).
      * E.g. `stateStore: new WebStorageStateStore({ store: window.localStorage })`
      */
@@ -168,6 +174,10 @@ export class OidcClientSettingsStore {
     public readonly clockSkewInSeconds: number;
     public readonly userInfoJwtIssuer: "ANY" | "OP" | string;
     public readonly mergeClaims: boolean;
+    /**
+     * TODO: remove me on v3
+     */
+    public readonly legacyMergeClaimsBehavior: boolean;
 
     public readonly stateStore: StateStore;
 
@@ -195,6 +205,7 @@ export class OidcClientSettingsStore {
         clockSkewInSeconds = DefaultClockSkewInSeconds,
         userInfoJwtIssuer = "OP",
         mergeClaims = false,
+        legacyMergeClaimsBehavior = true,
         // other behavior
         stateStore,
         refreshTokenCredentials,
@@ -246,6 +257,7 @@ export class OidcClientSettingsStore {
         this.clockSkewInSeconds = clockSkewInSeconds;
         this.userInfoJwtIssuer = userInfoJwtIssuer;
         this.mergeClaims = !!mergeClaims;
+        this.legacyMergeClaimsBehavior = !!legacyMergeClaimsBehavior;
 
         this.revokeTokenAdditionalContentTypes = revokeTokenAdditionalContentTypes;
 

--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -8,15 +8,18 @@ import { MetadataService } from "./MetadataService";
 import type { SigninState } from "./SigninState";
 import type { SigninResponse } from "./SigninResponse";
 import type { SignoutResponse } from "./SignoutResponse";
-import type { UserProfile } from "./User";
 import type { OidcClientSettingsStore } from "./OidcClientSettings";
 import { mocked } from "jest-mock";
+import { ClaimsService } from "./ClaimsService";
+import { UserInfoService } from "./UserInfoService";
 
 describe("ResponseValidator", () => {
     let stubState: SigninState;
     let stubResponse: SigninResponse & SignoutResponse;
     let settings: OidcClientSettingsStore;
     let metadataService: MetadataService;
+    let claimsService: ClaimsService;
+    let userInfoService: UserInfoService;
     let subject: ResponseValidator;
 
     beforeEach(() => {
@@ -37,8 +40,11 @@ describe("ResponseValidator", () => {
             loadUserInfo: true,
         } as OidcClientSettingsStore;
         metadataService = new MetadataService(settings);
+        claimsService = new ClaimsService(settings);
+        userInfoService = new UserInfoService(settings, metadataService, claimsService);
 
-        subject = new ResponseValidator(settings, metadataService);
+        subject = new ResponseValidator(settings, metadataService, claimsService, userInfoService);
+
         jest.spyOn(subject["_tokenClient"], "exchangeCode").mockResolvedValue({});
         jest.spyOn(subject["_userInfoService"], "getClaims").mockResolvedValue({ nickname: "Nick" });
     });
@@ -600,256 +606,5 @@ describe("ResponseValidator", () => {
             expect(stubResponse).toHaveProperty("profile", { sub: "subsub", nickname: "Nick" });
         });
 
-    });
-
-    describe("_mergeClaims", () => {
-        it("should merge claims", () => {
-            // arrange
-            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
-            const c2 = { c: "carrot" };
-
-            // act
-            const result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ a: "apple", c: "carrot", b: "banana" });
-        });
-
-        it("should not merge claims when claim types are objects", () => {
-            // arrange
-            const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
-            const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
-
-            // act
-            const result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ custom: [{ "apple": "foo", "pear": "bar" }, { "apple": "foo", "orange": "peel" }], b: "banana" });
-        });
-
-        it("should merge claims when claim types are objects when mergeClaims settings is true", () => {
-            // arrange
-            Object.assign(settings, { mergeClaims: true });
-
-            const c1 = { custom: { "apple": "foo", "pear": "bar" } } as unknown as UserProfile;
-            const c2 = { custom: { "apple": "foo", "orange": "peel" }, b: "banana" };
-
-            // act
-            const result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ custom: { "apple": "foo", "pear": "bar", "orange": "peel" }, b: "banana" });
-        });
-
-        it("should merge same claim types into array", () => {
-            // arrange
-            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
-            const c2 = { a: "carrot" };
-
-            // act
-            const result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ a: ["apple", "carrot"], b: "banana" });
-        });
-
-        it("should merge arrays of same claim types into array", () => {
-            // arrange
-            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
-            const c2 = { a: ["carrot", "durian"] };
-
-            // act
-            let result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
-
-            // arrange
-            const d1 = { a: ["apple", "carrot"], b: "banana" } as unknown as UserProfile;
-            const d2 = { a: ["durian"] };
-
-            // act
-            result = subject["_mergeClaims"](d1, d2);
-
-            // assert
-            expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
-
-            // arrange
-            const e1 = { a: ["apple", "carrot"], b: "banana" } as unknown as UserProfile;
-            const e2 = { a: "durian" };
-
-            // act
-            result = subject["_mergeClaims"](e1, e2);
-
-            // assert
-            expect(result).toEqual({ a: ["apple", "carrot", "durian"], b: "banana" });
-        });
-
-        it("should remove duplicates when producing arrays", () => {
-            // arrange
-            const c1 = { a: "apple", b: "banana" } as unknown as UserProfile;
-            const c2 = { a: ["apple", "durian"] };
-
-            // act
-            const result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ a: ["apple", "durian"], b: "banana" });
-        });
-
-        it("should not add if already present in array", () => {
-            // arrange
-            const c1 = { a: ["apple", "durian"], b: "banana" } as unknown as UserProfile;
-            const c2 = { a: "apple" };
-
-            // act
-            const result = subject["_mergeClaims"](c1, c2);
-
-            // assert
-            expect(result).toEqual({ a: ["apple", "durian"], b: "banana" });
-        });
-    });
-
-    describe("_filterProtocolClaims", () => {
-        it("should filter protocol claims if enabled on settings", () => {
-            // arrange
-            Object.assign(settings, { filterProtocolClaims: true });
-            const claims = {
-                foo: 1, bar: "test",
-                aud: "some_aud", iss: "issuer",
-                sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                iat: 5, exp: 20,
-                nbf: 10, at_hash: "athash",
-            };
-
-            // act
-            const result = subject["_filterProtocolClaims"](claims);
-
-            // assert
-            expect(result).toEqual({
-                foo: 1, bar: "test",
-                aud: "some_aud", iss: "issuer",
-                sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                iat: 5, exp: 20,
-            });
-        });
-
-        it("should not filter protocol claims if not enabled on settings", () => {
-            // arrange
-            Object.assign(settings, { filterProtocolClaims: false });
-            const claims = {
-                foo: 1, bar: "test",
-                aud: "some_aud", iss: "issuer",
-                sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                at_hash: "athash",
-                iat: 5, nbf: 10, exp: 20,
-            };
-
-            // act
-            const result = subject["_filterProtocolClaims"](claims);
-
-            // assert
-            expect(result).toEqual({
-                foo: 1, bar: "test",
-                aud: "some_aud", iss: "issuer",
-                sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                at_hash: "athash",
-                iat: 5, nbf: 10, exp: 20,
-            });
-        });
-
-        it("should filter protocol claims if specified in settings", () => {
-            // arrange
-            Object.assign(settings, { filterProtocolClaims: ["foo", "bar", "role", "nbf", "email"] });
-            const claims = {
-                foo: 1, bar: "test",
-                aud: "some_aud", iss: "issuer",
-                sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                iat: 5, exp: 20,
-                nbf: 10, at_hash: "athash",
-            };
-
-            // act
-            const result = subject["_filterProtocolClaims"](claims);
-
-            // assert
-            expect(result).toEqual({
-                aud: "some_aud", iss: "issuer",
-                sub: "123",
-                iat: 5, exp: 20,
-                at_hash: "athash",
-            });
-        });
-
-        it("should filter only protocol claims defined by default by the library", () => {
-            // arrange
-            Object.assign(settings, { filterProtocolClaims: true });
-            const defaultProtocolClaims = {
-                nbf: 3, jti: "jti",
-                auth_time: 123,
-                nonce: "nonce",
-                acr: "acr",
-                amr: "amr",
-                azp: "azp",
-                at_hash: "athash",
-            };
-            const claims = {
-                foo: 1, bar: "test",
-                aud: "some_aud", iss: "issuer",
-                sub: "123", email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                iat: 5, exp: 20,
-            };
-
-            // act
-            const result = subject["_filterProtocolClaims"]({ ...defaultProtocolClaims, ...claims });
-
-            // assert
-            expect(result).toEqual(claims);
-        });
-
-        it("should not filter protocol claims that are required by the library", () => {
-            // arrange
-            Object.assign(settings, { filterProtocolClaims: true });
-            const internalRequiredProtocolClaims = {
-                sub: "sub",
-                iss: "issuer",
-                aud: "some_aud",
-                exp: 20,
-                iat: 5,
-            };
-            const claims = {
-                foo: 1, bar: "test",
-                email: "foo@gmail.com",
-                role: ["admin", "dev"],
-                nbf: 10,
-            };
-
-            // act
-            let items = { ...internalRequiredProtocolClaims, ...claims };
-            let result = subject["_filterProtocolClaims"](items);
-
-            // assert
-            // nbf is part of the claims that should be filtered by the library by default, so we need to remove it
-            delete (items as Partial<typeof items>).nbf;
-            expect(result).toEqual(items);
-
-            // ... even if specified in settings
-
-            // arrange
-            Object.assign(settings, { filterProtocolClaims: ["sub", "iss", "aud", "exp", "iat"] });
-
-            // act
-            items = { ...internalRequiredProtocolClaims, ...claims };
-            result = subject["_filterProtocolClaims"](items);
-
-            // assert
-            expect(result).toEqual(items);
-        });
     });
 });

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -149,7 +149,7 @@ export class ResponseValidator {
         }
     }
 
-    protected async _processClaims(response: SigninResponse, skipUserInfo = false, validateSub = true): Promise<void> {
+    protected async _processClaims(response: SigninResponse, skipUserInfo = false, validateSub?: boolean): Promise<void> {
         const logger = this._logger.create("_processClaims");
         response.profile = this._claimsService.filterProtocolClaims(response.profile);
 

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -13,35 +13,7 @@ import type { State } from "./State";
 import type { SignoutResponse } from "./SignoutResponse";
 import type { UserProfile } from "./User";
 import type { RefreshState } from "./RefreshState";
-import type { JwtClaims, IdTokenClaims } from "./Claims";
-
-/**
- * Protocol claims that could be removed by default from profile.
- * Derived from the following sets of claims:
- * - {@link https://datatracker.ietf.org/doc/html/rfc7519.html#section-4.1}
- * - {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken}
- * - {@link https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken}
- *
- * @internal
- */
-const DefaultProtocolClaims = [
-    "nbf",
-    "jti",
-    "auth_time",
-    "nonce",
-    "acr",
-    "amr",
-    "azp",
-    "at_hash", // https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
-] as const;
-
-/**
- * Protocol claims that should never be removed from profile.
- * "sub" is needed internally and others should remain required as per the OIDC specs.
- *
- * @internal
- */
-const InternalRequiredProtocolClaims = ["sub", "iss", "aud", "exp", "iat"];
+import type { ClaimsService } from "./ClaimsService";
 
 /**
  * @internal
@@ -54,6 +26,7 @@ export class ResponseValidator {
     public constructor(
         protected readonly _settings: OidcClientSettingsStore,
         protected readonly _metadataService: MetadataService,
+        protected readonly _claimsService: ClaimsService,
     ) {}
 
     public async validateSigninResponse(response: SigninResponse, state: SigninState): Promise<void> {
@@ -178,7 +151,7 @@ export class ResponseValidator {
 
     protected async _processClaims(response: SigninResponse, skipUserInfo = false, validateSub = true): Promise<void> {
         const logger = this._logger.create("_processClaims");
-        response.profile = this._filterProtocolClaims(response.profile);
+        response.profile = this._claimsService.filterProtocolClaims(response.profile);
 
         if (skipUserInfo || !this._settings.loadUserInfo || !response.access_token) {
             logger.debug("not loading user info");
@@ -193,57 +166,8 @@ export class ResponseValidator {
             logger.throw(new Error("subject from UserInfo response does not match subject in ID Token"));
         }
 
-        response.profile = this._mergeClaims(response.profile, this._filterProtocolClaims(claims as IdTokenClaims));
+        response.profile = this._claimsService.mergeClaims(response.profile, this._claimsService.filterProtocolClaims(claims));
         logger.debug("user info claims received, updated profile:", response.profile);
-    }
-
-    protected _mergeClaims(claims1: UserProfile, claims2: JwtClaims): UserProfile {
-        const result = { ...claims1 };
-
-        for (const [claim, values] of Object.entries(claims2)) {
-            for (const value of Array.isArray(values) ? values : [values]) {
-                const previousValue = result[claim];
-                if (!previousValue) {
-                    result[claim] = value;
-                }
-                else if (Array.isArray(previousValue)) {
-                    if (!previousValue.includes(value)) {
-                        previousValue.push(value);
-                    }
-                }
-                else if (result[claim] !== value) {
-                    if (typeof value === "object" && this._settings.mergeClaims) {
-                        result[claim] = this._mergeClaims(previousValue as UserProfile, value);
-                    }
-                    else {
-                        result[claim] = [previousValue, value];
-                    }
-                }
-            }
-        }
-
-        return result;
-    }
-
-    protected _filterProtocolClaims(claims: UserProfile): UserProfile {
-        const result = { ...claims };
-
-        if (this._settings.filterProtocolClaims) {
-            let protocolClaims;
-            if (Array.isArray(this._settings.filterProtocolClaims)) {
-                protocolClaims = this._settings.filterProtocolClaims;
-            } else {
-                protocolClaims = DefaultProtocolClaims;
-            }
-
-            for (const claim of protocolClaims) {
-                if (!InternalRequiredProtocolClaims.includes(claim)) {
-                    delete result[claim];
-                }
-            }
-        }
-
-        return result;
     }
 
     protected async _processCode(response: SigninResponse, state: SigninState): Promise<void> {

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -22,10 +22,10 @@ export class UserInfoService {
         this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
     }
 
-    public async getClaims(token: string, profile?: IdTokenClaims, validateSub = true): Promise<IdTokenClaims> {
+    public async getClaims(token: string, profile: IdTokenClaims, validateSub = true): Promise<IdTokenClaims> {
         const logger = this._logger.create("getClaims");
         if (!token) {
-            this._logger.throw(new Error("No token passed"));
+            logger.throw(new Error("No token passed"));
         }
 
         const url = await this._metadataService.getUserInfoEndpoint();
@@ -43,11 +43,7 @@ export class UserInfoService {
 
         const filteredClaims = this._claimsService.filterProtocolClaims(claims as IdTokenClaims);
 
-        if (profile) {
-            return this._claimsService.mergeClaims(profile, filteredClaims);
-        }
-
-        return filteredClaims;
+        return this._claimsService.mergeClaims(profile, filteredClaims);
     }
 
     protected _getClaimsFromJwt = async (responseText: string): Promise<JwtClaims> => {

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -4,8 +4,9 @@
 import { Logger, JwtUtils } from "./utils";
 import { JsonService } from "./JsonService";
 import type { MetadataService } from "./MetadataService";
-import type { JwtClaims } from "./Claims";
+import type { IdTokenClaims, JwtClaims } from "./Claims";
 import type { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { ClaimsService } from "./ClaimsService";
 
 /**
  * @internal
@@ -16,11 +17,12 @@ export class UserInfoService {
 
     public constructor(private readonly _settings: OidcClientSettingsStore,
         private readonly _metadataService: MetadataService,
+        private readonly _claimsService: ClaimsService,
     ) {
         this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
     }
 
-    public async getClaims(token: string): Promise<JwtClaims> {
+    public async getClaims(token: string, profile?: IdTokenClaims, validateSub = true): Promise<IdTokenClaims> {
         const logger = this._logger.create("getClaims");
         if (!token) {
             this._logger.throw(new Error("No token passed"));
@@ -33,9 +35,19 @@ export class UserInfoService {
             token,
             credentials: this._settings.fetchRequestCredentials,
         });
-        logger.debug("got claims", claims);
+        logger.debug("user info claims received from user info endpoint");
 
-        return claims;
+        if (validateSub && profile && claims.sub !== profile.sub) {
+            logger.throw(new Error("subject from UserInfo response does not match subject in ID Token"));
+        }
+
+        const filteredClaims = this._claimsService.filterProtocolClaims(claims as IdTokenClaims);
+
+        if (profile) {
+            return this._claimsService.mergeClaims(profile, filteredClaims);
+        }
+
+        return filteredClaims;
     }
 
     protected _getClaimsFromJwt = async (responseText: string): Promise<JwtClaims> => {

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -109,6 +109,139 @@ describe("UserManager", () => {
             expect(result).toBeNull();
             expect(loadMock).not.toBeCalled();
         });
+
+        it("should refresh the userinfo", async () => {
+            Object.assign(subject.settings, {
+                loadUserInfo: true,
+            });
+            // arrange
+            const user = new User({
+                access_token: "access_token",
+                token_type: "token_type",
+                profile: {
+                    sub: "my sub",
+                    iss: "issuer",
+                    aud: "audience",
+                    a: "apple",
+                    exp: 123,
+                    iat: 543,
+                } as UserProfile,
+            });
+            subject["_loadUser"] = jest.fn().mockReturnValue(user);
+            const updateUserInfo = jest.spyOn(subject["_client"], "getUserInfo").mockResolvedValue({
+                sub: "my sub",
+                iss: "issuer",
+                aud: "audience",
+                a: "orange",
+                b: "banana",
+                exp: 456,
+                iat: 789,
+            });
+            const loadMock = jest.spyOn(subject["_events"], "load");
+
+            // act
+            const result = await subject.getUser(true);
+
+            // assert
+            expect(result).toEqual(user);
+            expect(result?.profile).toHaveProperty("a", "orange");
+            expect(result?.profile).toHaveProperty("b", "banana");
+            expect(updateUserInfo).toHaveBeenCalled();
+            expect(loadMock).toBeCalledWith(user, false);
+        });
+
+        it("while refreshing userinfo, should refresh token if expired", async () => {
+            Object.assign(subject.settings, {
+                loadUserInfo: true,
+            });
+            // arrange
+            const user = new User({
+                access_token: "access_token",
+                token_type: "token_type",
+                expires_at: 100,
+                refresh_token: "refresh_token",
+                profile: {
+                    sub: "my sub",
+                    iss: "issuer",
+                    aud: "audience",
+                    a: "apple",
+                    exp: 123,
+                    iat: 543,
+                } as UserProfile,
+            });
+            subject["_loadUser"] = jest.fn().mockReturnValue(user);
+            const updateUserInfo = jest.spyOn(subject["_client"], "getUserInfo").mockResolvedValue({
+                sub: "my sub",
+                iss: "issuer",
+                aud: "audience",
+                a: "orange",
+                b: "banana",
+                exp: 456,
+                iat: 789,
+            });
+
+            const useRefreshMock = jest.spyOn(subject["_client"], "useRefreshToken").mockResolvedValue({
+                access_token: "new_access_token",
+                profile: {
+                    sub: "sub",
+                    nickname: "Nicholas",
+                },
+            } as unknown as SigninResponse);
+
+            const loadMock = jest.spyOn(subject["_events"], "load");
+
+            // act
+            const result = await subject.getUser(true);
+
+            // assert
+            expect(result).toEqual(user);
+            expect(result?.profile).toHaveProperty("a", "orange");
+            expect(result?.profile).toHaveProperty("b", "banana");
+            expect(updateUserInfo).toHaveBeenCalled();
+            expect(useRefreshMock).toHaveBeenCalled();
+            expect(loadMock).toBeCalledWith(user, false);
+        });
+        it("should retrieve updated userinfo and persist it", async () => {
+            Object.assign(subject.settings, {
+                loadUserInfo: true,
+            });
+            // arrange
+            const user = new User({
+                access_token: "access_token",
+                token_type: "token_type",
+                profile: {
+                    sub: "my sub",
+                    iss: "issuer",
+                    aud: "audience",
+                    a: "apple",
+                    exp: 123,
+                    iat: 543,
+                } as UserProfile,
+            });
+            subject["_loadUser"] = jest.fn().mockReturnValue(user);
+            const updateUserInfo = jest.spyOn(subject["_client"], "getUserInfo").mockResolvedValue({
+                sub: "my sub",
+                iss: "issuer",
+                aud: "audience",
+                a: "orange",
+                exp: 456,
+                iat: 789,
+            });
+            const loadMock = jest.spyOn(subject["_events"], "load");
+
+            // act
+            const result = await subject.getUser(true);
+            const result2 = await subject.getUser();
+
+            // assert
+            expect(result).toEqual(user);
+            expect(result?.profile).toHaveProperty("a", "orange");
+            expect(updateUserInfo).toHaveBeenCalledTimes(1);
+            expect(loadMock).toBeCalledWith(user, false);
+
+            expect(result2?.profile).toHaveProperty("a", "orange");
+            expect(result2?.profile).toEqual(result?.profile);
+        });
     });
 
     describe("removeUser", () => {

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -169,37 +169,29 @@ describe("UserManager", () => {
                     iat: 543,
                 } as UserProfile,
             });
+
             subject["_loadUser"] = jest.fn().mockReturnValue(user);
-            const updateUserInfo = jest.spyOn(subject["_client"], "getUserInfo").mockResolvedValue({
-                sub: "my sub",
-                iss: "issuer",
-                aud: "audience",
-                a: "orange",
-                b: "banana",
-                exp: 456,
-                iat: 789,
-            });
 
             const useRefreshMock = jest.spyOn(subject["_client"], "useRefreshToken").mockResolvedValue({
                 access_token: "new_access_token",
                 profile: {
-                    sub: "sub",
-                    nickname: "Nicholas",
+                    sub: "my sub",
+                    iss: "issuer",
+                    aud: "audience",
+                    exp: 123,
+                    iat: 543,
+
+                    a: "orange",
                 },
             } as unknown as SigninResponse);
-
-            const loadMock = jest.spyOn(subject["_events"], "load");
 
             // act
             const result = await subject.getUser(true);
 
             // assert
-            expect(result).toEqual(user);
             expect(result?.profile).toHaveProperty("a", "orange");
-            expect(result?.profile).toHaveProperty("b", "banana");
-            expect(updateUserInfo).toHaveBeenCalled();
+            expect(result?.profile).not.toHaveProperty("b");
             expect(useRefreshMock).toHaveBeenCalled();
-            expect(loadMock).toBeCalledWith(user, false);
         });
         it("should retrieve updated userinfo and persist it", async () => {
             Object.assign(subject.settings, {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -132,12 +132,17 @@ export class UserManager {
         const logger = this._logger.create("getUser");
         const user = await this._loadUser();
         if (user) {
-            if (refreshUserInfo) {
-                // TODO: refresh token
+            if (this.settings.loadUserInfo && refreshUserInfo) {
+                // Refresh
+                if (user.expired) {
+                    await this.signinSilent();
+                }
 
                 logger.debug("refreshing user info");
                 user.profile = await this._client.getUserInfo(user.access_token, user.profile);
                 logger.debug("user info refreshed");
+                await this.storeUser(user);
+                logger.debug("user updated in storage");
             }
 
             logger.info("user loaded");

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -126,11 +126,20 @@ export class UserManager {
 
     /**
      * Returns promise to load the `User` object for the currently authenticated user.
+     * Can optionally refresh userInfo data
      */
-    public async getUser(): Promise<User | null> {
+    public async getUser(refreshUserInfo?: boolean): Promise<User | null> {
         const logger = this._logger.create("getUser");
         const user = await this._loadUser();
         if (user) {
+            if (refreshUserInfo) {
+                // TODO: refresh token
+
+                logger.debug("refreshing user info");
+                user.profile = await this._client.getUserInfo(user.access_token, user.profile);
+                logger.debug("user info refreshed");
+            }
+
             logger.info("user loaded");
             this._events.load(user, false);
             return user;


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Fixes #846 #852

### Checklist

- [X] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [X] I have included links for closing relevant issue numbers

This PR adds a new parameter "refreshUserInfo" to "loadUser", so that it's possible to refresh (and store) updated userinfo claims for the logged user. `loadUser` will refresh the token, if expired, otherwise it will simply reload userinfo. 
In order for this to be enabled, `loadUserInfo` should be enabled in the settings.

NOTE: if the token is refreshed during the procedure, old claims that "disappeared" will be removed. Otherwise, they will be kept.

It also:
- Adds a new configuration property "legacyMergeClaimsBehavior" (defaulted to `true` for backwards compatibility) that, if disabled, overwrites claims instead of transforming types.
- Exposes a new `getUserInfo` method in OidcClient to perform the raw userinfo data retrieval.

LMKWYT