### PR TITLE
Add static or dynamic custom header for each client calls.

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -95,6 +95,9 @@ export type CreateSignoutRequestArgs = Omit<SignoutRequestArgs, "url" | "state_d
     state?: unknown;
 };
 
+// @public (undocumented)
+export type CustomHeader = string | (() => string);
+
 // @public
 export class ErrorResponse extends Error {
     constructor(args: {
@@ -339,6 +342,7 @@ export interface OidcClientSettings {
     client_secret?: string;
     // @deprecated (undocumented)
     clockSkewInSeconds?: number;
+    customHeaders?: Record<string, CustomHeader>;
     disablePKCE?: boolean;
     display?: string;
     extraQueryParams?: Record<string, string | number | boolean>;
@@ -374,7 +378,7 @@ export interface OidcClientSettings {
 
 // @public
 export class OidcClientSettingsStore {
-    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, disablePKCE, stateStore, refreshTokenCredentials, revokeTokenAdditionalContentTypes, fetchRequestCredentials, refreshTokenAllowedScope, extraQueryParams, extraTokenParams, }: OidcClientSettings);
+    constructor({ authority, metadataUrl, metadata, signingKeys, metadataSeed, client_id, client_secret, response_type, scope, redirect_uri, post_logout_redirect_uri, client_authentication, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, filterProtocolClaims, loadUserInfo, staleStateAgeInSeconds, clockSkewInSeconds, userInfoJwtIssuer, mergeClaims, disablePKCE, stateStore, refreshTokenCredentials, revokeTokenAdditionalContentTypes, fetchRequestCredentials, refreshTokenAllowedScope, extraQueryParams, extraTokenParams, customHeaders, }: OidcClientSettings);
     // (undocumented)
     readonly acr_values: string | undefined;
     // (undocumented)
@@ -387,6 +391,8 @@ export class OidcClientSettingsStore {
     readonly client_secret: string | undefined;
     // (undocumented)
     readonly clockSkewInSeconds: number;
+    // (undocumented)
+    readonly customHeaders: Record<string, CustomHeader>;
     // (undocumented)
     readonly disablePKCE: boolean;
     // (undocumented)

--- a/src/JsonService.test.ts
+++ b/src/JsonService.test.ts
@@ -8,9 +8,30 @@ import { mocked } from "jest-mock";
 
 describe("JsonService", () => {
     let subject: JsonService;
+    let customStaticHeaderSubject: JsonService;
+    let customDynamicHeaderSubject: JsonService;
+
+    const staticCustomHeaders = {
+        "Custom-Header-1": "this-is-header-1",
+        "Custom-Header-2": "this-is-header-2",
+        "acCept" : "application/fake",
+        "AuthoriZation" : "not good",
+        "Content-Type": "application/fail",
+    };
+    const dynamicCustomHeaders = {
+        "Custom-Header-1": () => "my-name-is-header-1",
+        "Custom-Header-2": () => {
+            return "my-name-is-header-2";
+        },
+        "acCept" : () => "nothing",
+        "AuthoriZation" : () => "not good",
+        "Content-Type": "application/fail",
+    };
 
     beforeEach(() =>{
         subject = new JsonService();
+        customStaticHeaderSubject = new JsonService(undefined, null, staticCustomHeaders);
+        customDynamicHeaderSubject = new JsonService(undefined, null, dynamicCustomHeaders);
     });
 
     describe("getJson", () => {
@@ -28,6 +49,42 @@ describe("JsonService", () => {
             );
         });
 
+        it("should make GET request to url with static custom headers", async () => {
+            // act
+            await expect(customStaticHeaderSubject.getJson("http://test")).rejects.toThrow();
+
+            // assert
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: { 
+                        Accept: "application/json",
+                        "Custom-Header-1": "this-is-header-1",
+                        "Custom-Header-2": "this-is-header-2",
+                    },
+                    method: "GET",
+                }),
+            );
+        });
+
+        it("should make GET request to url with dynamic custom headers", async () => {
+            // act
+            await expect(customDynamicHeaderSubject.getJson("http://test")).rejects.toThrow();
+
+            // assert
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: { 
+                        Accept: "application/json",
+                        "Custom-Header-1": "my-name-is-header-1",
+                        "Custom-Header-2": "my-name-is-header-2",
+                    },
+                    method: "GET",
+                }),
+            );
+        });
+
         it("should set token as authorization header", async () => {
             // act
             await expect(subject.getJson("http://test", { token: "token" })).rejects.toThrow();
@@ -37,6 +94,44 @@ describe("JsonService", () => {
                 "http://test",
                 expect.objectContaining({
                     headers: { Accept: "application/json", Authorization: "Bearer token" },
+                    method: "GET",
+                }),
+            );
+        });
+
+        it("should set token as authorization header with static custom headers", async () => {
+            // act
+            await expect(customStaticHeaderSubject.getJson("http://test", { token: "token" })).rejects.toThrow();
+
+            // assert
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: { 
+                        Accept: "application/json",
+                        Authorization: "Bearer token",
+                        "Custom-Header-1": "this-is-header-1",
+                        "Custom-Header-2": "this-is-header-2",
+                    },
+                    method: "GET",
+                }),
+            );
+        });
+
+        it("should set token as authorization header with dynamic custom headers", async () => {
+            // act
+            await expect(customDynamicHeaderSubject.getJson("http://test", { token: "token" })).rejects.toThrow();
+
+            // assert
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: { 
+                        Accept: "application/json", 
+                        Authorization: "Bearer token",
+                        "Custom-Header-1": "my-name-is-header-1",
+                        "Custom-Header-2": "my-name-is-header-2",
+                    },
                     method: "GET",
                 }),
             );
@@ -178,6 +273,46 @@ describe("JsonService", () => {
                     headers: {
                         Accept: "application/json",
                         "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    method: "POST",
+                    body: new URLSearchParams(),
+                }),
+            );
+        });
+
+        it("should make POST request to url with custom static headers", async () => {
+            // act
+            await expect(customStaticHeaderSubject.postForm("http://test", { body: new URLSearchParams("a=b") })).rejects.toThrow();
+
+            // assert
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: {
+                        Accept: "application/json",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Custom-Header-1": "this-is-header-1",
+                        "Custom-Header-2": "this-is-header-2",
+                    },
+                    method: "POST",
+                    body: new URLSearchParams(),
+                }),
+            );
+        });
+
+        it("should make POST request to url with custom dynamic headers", async () => {
+            // act
+            await expect(customDynamicHeaderSubject.postForm("http://test", { body: new URLSearchParams("a=b") })).rejects.toThrow();
+
+            // assert
+            expect(fetch).toBeCalledWith(
+                "http://test",
+                expect.objectContaining({
+                    headers: {
+                        Accept: "application/json",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Custom-Header-1": "my-name-is-header-1",
+                        "Custom-Header-2": "my-name-is-header-2",
                     },
                     method: "POST",
                     body: new URLSearchParams(),

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -11,7 +11,7 @@ import type { OidcMetadata } from "./OidcMetadata";
  */
 export class MetadataService {
     private readonly _logger = new Logger("MetadataService");
-    private readonly _jsonService = new JsonService(["application/jwk-set+json"]);
+    private readonly _jsonService;
 
     // cache
     private _metadataUrl: string;
@@ -21,7 +21,11 @@ export class MetadataService {
 
     public constructor(private readonly _settings: OidcClientSettingsStore) {
         this._metadataUrl = this._settings.metadataUrl;
-
+        this._jsonService = new JsonService(
+            ["application/jwk-set+json"],
+            null,
+            this._settings.customHeaders,
+        );
         if (this._settings.signingKeys) {
             this._logger.debug("using signingKeys from settings");
             this._signingKeys = this._settings.signingKeys;

--- a/src/OidcClientSettings.test.ts
+++ b/src/OidcClientSettings.test.ts
@@ -526,4 +526,36 @@ describe("OidcClientSettings", () => {
             expect(subject.extraTokenParams).toEqual({ "resourceServer": "abc" });
         });
     });
+
+    describe("customHeaders", () => {
+
+        it("should use default value", () => {
+            // act
+            const subject = new OidcClientSettingsStore({
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+            });
+
+            // assert
+            expect(subject.customHeaders).toEqual({});
+        });
+
+        it("should return value from initial settings", () => {
+            // act
+            const customHeaders = {
+                "Header-1": "this-is-a-test",
+                "Header-3": () => "dynamic header",
+            };
+            const subject = new OidcClientSettingsStore({
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+                customHeaders: customHeaders,
+            });
+
+            // assert
+            expect(subject.customHeaders).toEqual(customHeaders);
+        });
+    });
 });

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -5,6 +5,7 @@ import { WebStorageStateStore } from "./WebStorageStateStore";
 import type { OidcMetadata } from "./OidcMetadata";
 import type { StateStore } from "./StateStore";
 import { InMemoryWebStorage } from "./InMemoryWebStorage";
+import type { CustomHeader } from "./JsonService";
 
 const DefaultResponseType = "code";
 const DefaultScope = "openid";
@@ -130,6 +131,11 @@ export interface OidcClientSettings {
      * Only scopes in this list will be passed in the token refresh request.
      */
     refreshTokenAllowedScope?: string | undefined;
+
+    /**
+     * Set additional custom headers to be passed to the client
+     */
+    customHeaders?: Record<string, CustomHeader>;
 }
 
 /**
@@ -182,6 +188,9 @@ export class OidcClientSettingsStore {
     public readonly fetchRequestCredentials: RequestCredentials;
     public readonly refreshTokenAllowedScope: string | undefined;
     public readonly disablePKCE: boolean;
+
+    // headers
+    public readonly customHeaders: Record<string, CustomHeader>;
     
     public constructor({
         // metadata related
@@ -209,6 +218,8 @@ export class OidcClientSettingsStore {
         // extra query params
         extraQueryParams = {},
         extraTokenParams = {},
+        // custom headers
+        customHeaders = {},
     }: OidcClientSettings) {
 
         this.authority = authority;
@@ -272,5 +283,6 @@ export class OidcClientSettingsStore {
 
         this.extraQueryParams = extraQueryParams;
         this.extraTokenParams = extraTokenParams;
+        this.customHeaders = customHeaders;
     }
 }

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -66,7 +66,11 @@ export class TokenClient {
         private readonly _settings: OidcClientSettingsStore,
         private readonly _metadataService: MetadataService,
     ) {
-        this._jsonService = new JsonService(this._settings.revokeTokenAdditionalContentTypes);
+        this._jsonService = new JsonService(
+            this._settings.revokeTokenAdditionalContentTypes,
+            null,
+            this._settings.customHeaders,
+        );
     }
 
     public async exchangeCode({

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -17,7 +17,11 @@ export class UserInfoService {
     public constructor(private readonly _settings: OidcClientSettingsStore,
         private readonly _metadataService: MetadataService,
     ) {
-        this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
+        this._jsonService = new JsonService(
+            undefined,
+            this._getClaimsFromJwt,
+            this._settings.customHeaders,
+        );
     }
 
     public async getClaims(token: string): Promise<JwtClaims> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { MetadataService } from "./MetadataService";
 export * from "./OidcClient";
 export { OidcClientSettingsStore } from "./OidcClientSettings";
 export type { OidcClientSettings, SigningKey } from "./OidcClientSettings";
+export type { CustomHeader } from "./JsonService";
 export type { OidcMetadata } from "./OidcMetadata";
 export { SessionMonitor } from "./SessionMonitor";
 export type { SessionStatus } from "./SessionStatus";


### PR DESCRIPTION
New feature

I've made this PR because I need to have custom headers for the client calls.
Our DevOps team need those custom headers to have better reading and filtering logs on low level network components.

I'm not sure if I've done code as your standards. I'm fully opened to share and discuss about it. 
Hope this feature could help other people and accepted by you.

### Changes

New optional setting `customHeaders` into `OidcClientSettings`.

`customHeaders` is an hash array with header name as a key. Values could be string or a function returning a string.

Some headers are protected:
 - Authorization
 - Accept
 - Content-Type


### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
