### PR TITLE
Allow auth_time to be undefined on token refresh

### DIFF
--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -186,28 +186,28 @@ export class ResponseValidator {
         }
     }
 
-    protected _validateIdTokenAttributes(response: SigninResponse, currentToken?: string): void {
+    protected _validateIdTokenAttributes(response: SigninResponse, existingToken?: string): void {
         const logger = this._logger.create("_validateIdTokenAttributes");
 
         logger.debug("decoding ID Token JWT");
-        const profile = JwtUtils.decode(response.id_token ?? "");
+        const incoming = JwtUtils.decode(response.id_token ?? "");
 
-        if (!profile.sub) {
+        if (!incoming.sub) {
             logger.throw(new Error("ID Token is missing a subject claim"));
         }
 
-        if (currentToken) {
-            const current = JwtUtils.decode(currentToken);
-            if (current.sub !== profile.sub) {
+        if (existingToken) {
+            const existing = JwtUtils.decode(existingToken);
+            if (incoming.sub !== existing.sub) {
                 logger.throw(new Error("sub in id_token does not match current sub"));
             }
-            if (profile.auth_time !== undefined && current.auth_time && current.auth_time !== profile.auth_time) {
+            if (incoming.auth_time && incoming.auth_time !== existing.auth_time) {
                 logger.throw(new Error("auth_time in id_token does not match original auth_time"));
             }
-            if (current.azp && current.azp !== profile.azp) {
+            if (incoming.azp && incoming.azp !== existing.azp) {
                 logger.throw(new Error("azp in id_token does not match original azp"));
             }
-            if (!current.azp && profile.azp) {
+            if (!incoming.azp && existing.azp) {
                 logger.throw(new Error("azp not in id_token, but present in original id_token"));
             }
         }

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -212,6 +212,6 @@ export class ResponseValidator {
             }
         }
 
-        response.profile = profile as UserProfile;
+        response.profile = incoming as UserProfile;
     }
 }

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -201,7 +201,7 @@ export class ResponseValidator {
             if (current.sub !== profile.sub) {
                 logger.throw(new Error("sub in id_token does not match current sub"));
             }
-            if (current.auth_time && current.auth_time !== profile.auth_time) {
+            if (profile.auth_time !== undefined && current.auth_time && current.auth_time !== profile.auth_time) {
                 logger.throw(new Error("auth_time in id_token does not match original auth_time"));
             }
             if (current.azp && current.azp !== profile.azp) {


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #772

Per [response spec](https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse), auth_time is conditional dependent on max_age being provided in the request. To fully implement the spec regarding auth_time we would also need access to the request max_age being provided to understand if auth_time is required.

Also renamed variables to assist with logic evaluation. It's likely parameters were being misused based on error messaging, although still valid.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers