### PR TITLE
Allow using `OidcClient` without `window` object

### DIFF
--- a/src/utils/UrlUtils.ts
+++ b/src/utils/UrlUtils.ts
@@ -7,7 +7,8 @@
 export class UrlUtils {
     public static readParams(url: string, responseMode: "query" | "fragment" = "query"): URLSearchParams {
         if (!url) throw new TypeError("Invalid URL");
-        const parsedUrl = new URL(url, window.location.origin);
+        // the base URL is irrelevant, it's just here to support relative url arguments
+        const parsedUrl = new URL(url, "http://127.0.0.1");
         const params = parsedUrl[responseMode === "fragment" ? "hash" : "search"];
         return new URLSearchParams(params.slice(1));
     }


### PR DESCRIPTION
This allows using the `OidcClient` class in environments where `window` is undefined.

