### PR TITLE
fix(IFrameWindow): Remove sandbox attribute due to it beeing obsolete

### DIFF
--- a/src/navigators/IFrameWindow.test.ts
+++ b/src/navigators/IFrameWindow.test.ts
@@ -33,11 +33,6 @@ describe("IFrameWindow", () => {
             expect(width).toBe("0");
             expect(height).toBe("0");
         });
-
-        it("should set correct sandbox attribute", () => {
-            const sandboxAttr = frameWindow["_frame"]!.attributes.getNamedItem("sandbox");
-            expect(sandboxAttr?.value).toBe("allow-scripts allow-same-origin allow-forms");
-        });
     });
 
     describe("close", () => {

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -42,7 +42,6 @@ export class IFrameWindow extends AbstractChildWindow {
         iframe.style.top = "0";
         iframe.width = "0";
         iframe.height = "0";
-        iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
 
         window.document.body.appendChild(iframe);
         return iframe;


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes #827

Remove obsolete sandbox attribute due to it not being used by Auth0.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers