### PR TITLE
Fix samples

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -265,7 +265,7 @@ export class OidcClient {
     // (undocumented)
     createSigninRequest({ state, request, request_uri, request_type, id_token_hint, login_hint, skipUserInfo, nonce, response_type, scope, redirect_uri, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, extraQueryParams, extraTokenParams, }: CreateSigninRequestArgs): Promise<SigninRequest>;
     // (undocumented)
-    createSignoutRequest({ state, id_token_hint, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
+    createSignoutRequest({ state, id_token_hint, client_id, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
     // (undocumented)
     protected readonly _logger: Logger;
     // (undocumented)
@@ -720,7 +720,7 @@ export type SignoutRedirectArgs = RedirectParams & ExtraSignoutRequestArgs;
 
 // @public (undocumented)
 export class SignoutRequest {
-    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, }: SignoutRequestArgs);
+    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, client_id, }: SignoutRequestArgs);
     // (undocumented)
     readonly state?: State;
     // (undocumented)
@@ -729,6 +729,8 @@ export class SignoutRequest {
 
 // @public (undocumented)
 export interface SignoutRequestArgs {
+    // (undocumented)
+    client_id?: string;
     // (undocumented)
     extraQueryParams?: Record<string, string | number | boolean>;
     // (undocumented)

--- a/samples/Parcel/src/oidc-client/sample.js
+++ b/samples/Parcel/src/oidc-client/sample.js
@@ -48,8 +48,8 @@ function signin() {
 }
 
 var signinResponse;
-function processSigninResponse(url) {
-    client.processSigninResponse(url).then(function(response) {
+function processSigninResponse() {
+    client.processSigninResponse(window.location.href).then(function(response) {
         signinResponse = response;
         log("signin response", signinResponse);
     }).catch(function(err) {
@@ -67,8 +67,8 @@ function signout() {
     });
 }
 
-function processSignoutResponse(url) {
-    client.processSignoutResponse(url).then(function(response) {
+function processSignoutResponse() {
+    client.processSignoutResponse(window.location.href).then(function(response) {
         signinResponse = null;
         log("signout response", response);
     }).catch(function(err) {
@@ -99,10 +99,10 @@ document.getElementById("processSignout").style.display = display;
 
 if (followLinks()) {
     if (window.location.href.indexOf("#") >= 0) {
-        processSigninResponse(window.location.href);
+        processSigninResponse();
     }
     else if (window.location.href.indexOf("?") >= 0) {
-        processSignoutResponse(window.location.href);
+        processSignoutResponse();
     }
 }
 

--- a/samples/Parcel/src/oidc-client/sample.js
+++ b/samples/Parcel/src/oidc-client/sample.js
@@ -48,8 +48,8 @@ function signin() {
 }
 
 var signinResponse;
-function processSigninResponse() {
-    client.processSigninResponse().then(function(response) {
+function processSigninResponse(url) {
+    client.processSigninResponse(url).then(function(response) {
         signinResponse = response;
         log("signin response", signinResponse);
     }).catch(function(err) {
@@ -59,7 +59,7 @@ function processSigninResponse() {
 }
 
 function signout() {
-    client.createSignoutRequest({ state: { foo: 5 } }).then(function(req) {
+    client.createSignoutRequest({ state: { foo: 5 }, client_id: settings.client_id }).then(function(req) {
         log("signout request", req, "<a href='" + req.url + "'>go signout</a>");
         if (followLinks()) {
             window.location = req.url;
@@ -67,8 +67,8 @@ function signout() {
     });
 }
 
-function processSignoutResponse() {
-    client.processSignoutResponse().then(function(response) {
+function processSignoutResponse(url) {
+    client.processSignoutResponse(url).then(function(response) {
         signinResponse = null;
         log("signout response", response);
     }).catch(function(err) {
@@ -99,10 +99,10 @@ document.getElementById("processSignout").style.display = display;
 
 if (followLinks()) {
     if (window.location.href.indexOf("#") >= 0) {
-        processSigninResponse();
+        processSigninResponse(window.location.href);
     }
     else if (window.location.href.indexOf("?") >= 0) {
-        processSignoutResponse();
+        processSignoutResponse(window.location.href);
     }
 }
 

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -558,9 +558,51 @@ describe("OidcClient", () => {
             expect(request.state).toBeDefined();
             expect(request.state?.data).toEqual("foo");
             const url = request.url;
+            console.log("url", url);
             expect(url).toContain("http://sts/signout");
             expect(url).toContain("post_logout_redirect_uri=bar");
             expect(url).toContain("id_token_hint=baz");
+        });
+
+        it("should pass params to SignoutRequest w/o id_token_hint and client_id", async () => {
+            // arrange
+            jest.spyOn(subject.metadataService, "getEndSessionEndpoint").mockImplementation(() => Promise.resolve("http://sts/signout"));
+
+            // act
+            const request = await subject.createSignoutRequest({
+                state: "foo",
+                post_logout_redirect_uri: "bar",
+            });
+
+            // assert
+            expect(request.state).toBeDefined();
+            expect(request.state?.data).toEqual("foo");
+            const url = request.url;
+            console.log("url", url);
+            expect(url).toContain("http://sts/signout");
+            expect(url).toContain("post_logout_redirect_uri=bar");
+            expect(url).toContain("client_id=client");
+        });
+
+        it("should pass params to SignoutRequest with client_id", async () => {
+            // arrange
+            jest.spyOn(subject.metadataService, "getEndSessionEndpoint").mockImplementation(() => Promise.resolve("http://sts/signout"));
+
+            // act
+            const request = await subject.createSignoutRequest({
+                state: "foo",
+                post_logout_redirect_uri: "bar",
+                client_id: "baz",
+            });
+
+            // assert
+            expect(request.state).toBeDefined();
+            expect(request.state?.data).toEqual("foo");
+            const url = request.url;
+            console.log("url", url);
+            expect(url).toContain("http://sts/signout");
+            expect(url).toContain("post_logout_redirect_uri=bar");
+            expect(url).toContain("client_id=baz");
         });
 
         it("should fail if metadata fails", async () => {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -233,6 +233,11 @@ export class OidcClient {
 
         logger.debug("Received end session endpoint", url);
 
+        // specify the client identifier when post_logout_redirect_uri is used but id_token_hint is not
+        if (!client_id && post_logout_redirect_uri && !id_token_hint) {
+            client_id = this.settings.client_id;
+        }
+
         const request = new SignoutRequest({
             url,
             id_token_hint,

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -218,6 +218,7 @@ export class OidcClient {
     public async createSignoutRequest({
         state,
         id_token_hint,
+        client_id,
         request_type,
         post_logout_redirect_uri = this.settings.post_logout_redirect_uri,
         extraQueryParams = this.settings.extraQueryParams,
@@ -235,6 +236,7 @@ export class OidcClient {
         const request = new SignoutRequest({
             url,
             id_token_hint,
+            client_id,
             post_logout_redirect_uri,
             state_data: state,
             extraQueryParams,

--- a/src/SignoutRequest.ts
+++ b/src/SignoutRequest.ts
@@ -14,6 +14,7 @@ export interface SignoutRequestArgs {
 
     // optional
     id_token_hint?: string;
+    client_id?: string;
     post_logout_redirect_uri?: string;
     extraQueryParams?: Record<string, string | number | boolean>;
 
@@ -34,7 +35,7 @@ export class SignoutRequest {
 
     public constructor({
         url,
-        state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type,
+        state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, client_id,
     }: SignoutRequestArgs) {
         if (!url) {
             this._logger.error("ctor: No url passed");
@@ -44,6 +45,9 @@ export class SignoutRequest {
         const parsedUrl = new URL(url);
         if (id_token_hint) {
             parsedUrl.searchParams.append("id_token_hint", id_token_hint);
+        }
+        if (client_id) {
+            parsedUrl.searchParams.append("client_id", client_id);
         }
 
         if (post_logout_redirect_uri) {


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes --

- Pass callback URLs to login/logout requests to prevent fatal errors
- Add `client_id` to logout request to prevent fatal errors (tested against Keycloak - either "`id_token_hint`" (already available) or "`client_id`" (missing till now) are required when using `post_logout_redirect_uri`)

### Checklist

- [x] This PR makes changes to the public API
  - [x] Update API report (docs/oidc-client-ts.api.md)
- [x] I have included links for closing relevant issue numbers
