### PR TITLE
Add support for chrome StorageArea API as a valid store

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="chrome" />
+
 // @public (undocumented)
 export type AccessTokenCallback = (...ev: unknown[]) => (Promise<void> | void);
 
@@ -32,6 +34,22 @@ export interface AsyncStorage {
     readonly length: Promise<number>;
     removeItem(key: string): Promise<void>;
     setItem(key: string, value: string): Promise<void>;
+}
+
+// @public (undocumented)
+export class BrowserStorageStateStore implements StateStore {
+    constructor({ prefix, store, }?: {
+        prefix?: string;
+        store?: chrome.storage.StorageArea;
+    });
+    // (undocumented)
+    get(key: string): Promise<string | null>;
+    // (undocumented)
+    getAllKeys(): Promise<string[]>;
+    // (undocumented)
+    remove(key: string): Promise<string | null>;
+    // (undocumented)
+    set(key: string, value: string): Promise<void>;
 }
 
 // @internal (undocumented)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@microsoft/api-extractor": "^7.35.0",
         "@testing-library/jest-dom": "^6.0.0",
+        "@types/chrome": "^0.0.246",
         "@types/crypto-js": "^4.0.2",
         "@types/jest": "^29.2.3",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
@@ -1816,6 +1817,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.246",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.246.tgz",
+      "integrity": "sha512-MxGxEomGxsJiL9xe/7ZwVgwdn8XVKWbPvxpVQl3nWOjrS0Ce63JsfzxUc4aU3GvRcUPYsfufHmJ17BFyKxeA4g==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -1860,6 +1871,21 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.33.tgz",
+      "integrity": "sha512-2KedRPzwu2K528vFkoXnnWdsG0MtUwPjuA7pRy4vKxlxHEe8qUDZibYHXJKZZr2Cl/ELdCWYqyb/MKwsUuzBWw==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.30.tgz",
+      "integrity": "sha512-lB98tui0uxc7erbj0serZfJlHKLNJHwBltPnbmO1WRpL5T325GOHRiQfr2E29V2q+S1brDO63Fpdt6vb3bES9Q==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1868,6 +1894,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.13.tgz",
+      "integrity": "sha512-PwBsCBD3lDODn4xpje3Y1di0aDJp4Ww7aSfMRVw6ysnxD4I7Wmq2mBkSKaDtN403hqH5sp6c9xQUvFYY3+lkBg==",
+      "dev": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.8",
@@ -8538,6 +8570,16 @@
         "@types/node": "*"
       }
     },
+    "@types/chrome": {
+      "version": "0.0.246",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.246.tgz",
+      "integrity": "sha512-MxGxEomGxsJiL9xe/7ZwVgwdn8XVKWbPvxpVQl3nWOjrS0Ce63JsfzxUc4aU3GvRcUPYsfufHmJ17BFyKxeA4g==",
+      "dev": true,
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -8582,6 +8624,21 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/filesystem": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.33.tgz",
+      "integrity": "sha512-2KedRPzwu2K528vFkoXnnWdsG0MtUwPjuA7pRy4vKxlxHEe8qUDZibYHXJKZZr2Cl/ELdCWYqyb/MKwsUuzBWw==",
+      "dev": true,
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.30.tgz",
+      "integrity": "sha512-lB98tui0uxc7erbj0serZfJlHKLNJHwBltPnbmO1WRpL5T325GOHRiQfr2E29V2q+S1brDO63Fpdt6vb3bES9Q==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -8590,6 +8647,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/har-format": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.13.tgz",
+      "integrity": "sha512-PwBsCBD3lDODn4xpje3Y1di0aDJp4Ww7aSfMRVw6ysnxD4I7Wmq2mBkSKaDtN403hqH5sp6c9xQUvFYY3+lkBg==",
+      "dev": true
     },
     "@types/http-proxy": {
       "version": "1.17.8",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.35.0",
     "@testing-library/jest-dom": "^6.0.0",
+    "@types/chrome": "^0.0.246",
     "@types/crypto-js": "^4.0.2",
     "@types/jest": "^29.2.3",
     "@typescript-eslint/eslint-plugin": "^6.4.1",

--- a/src/BrowserStorageStateStore.ts
+++ b/src/BrowserStorageStateStore.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+import { Logger } from "./utils";
+import type { StateStore } from "./StateStore";
+
+/**
+ * @public
+ */
+export class BrowserStorageStateStore implements StateStore {
+    private readonly _logger = new Logger("BrowserStorageStateStore");
+    private readonly _store: chrome.storage.StorageArea;
+    private readonly _prefix: string;
+
+    public constructor({
+        prefix = "oidc.",
+        store = chrome.storage.local,
+    }: { prefix?: string; store?: chrome.storage.StorageArea } = {}) {
+        this._store = store;
+        this._prefix = prefix;
+    }
+
+    public async set(key: string, value: string): Promise<void> {
+        this._logger.create(`set('${key}')`);
+
+        key = this._prefix + key;
+        await this._store.set({ [key]: value });
+    }
+
+    public async get(key: string): Promise<string | null> {
+        this._logger.create(`get('${key}')`);
+
+        key = this._prefix + key;
+        const itemQuery = await this._store.get(key);
+        const item = String(itemQuery[key]) ?? null;
+        return item;
+    }
+
+    public async remove(key: string): Promise<string | null> {
+        this._logger.create(`remove('${key}')`);
+
+        key = this._prefix + key;
+        const itemQuery = await this._store.get(key);
+        await this._store.remove(key);
+        const item = String(itemQuery[key]) ?? null;
+        return item;
+    }
+
+    public async getAllKeys(): Promise<string[]> {
+        this._logger.create("getAllKeys");
+
+        const itemQuery = await this._store.get();
+        const keys = Object.keys(itemQuery).filter((key) => key.indexOf(this._prefix) === 0);
+        return keys.map((key) => key.substring(this._prefix.length));
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,3 +43,4 @@ export { UserManagerSettingsStore } from "./UserManagerSettings";
 export type { UserManagerSettings } from "./UserManagerSettings";
 export { Version } from "./Version";
 export { WebStorageStateStore } from "./WebStorageStateStore";
+export { BrowserStorageStateStore } from "./BrowserStorageStateStore";


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #1180.

The functionality seems to work great on my extension, I still have to add tests (I'm going to have to implement a modified copy of `InMemoryBrowserStorage.ts` to adjust for the differences in the methods). 

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
