### PR TITLE
build(esm): dynamically generate package.json for ESM build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 
 **/dist/*
 /dist/esm/*
-!/dist/esm/package.json
 
 # caches
 .eslintcache

--- a/dist/esm/package.json
+++ b/dist/esm/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 const { buildSync } = require("esbuild");
 const { join } = require("path");
+const fs = require("fs");
 
-const { dependencies, peerDependencies } = require("../package.json");
+const { dependencies, peerDependencies, version } = require("../package.json");
 
 const opts = {
     entryPoints: ["src/index.ts"],
@@ -21,6 +22,10 @@ try {
         outfile: "dist/esm/oidc-client-ts.js",
         external,
     });
+    // generate package.json for esm
+    const distPackageJson = { type: "module" , version };
+    fs.writeFileSync("dist/esm/package.json", JSON.stringify(distPackageJson, null, 2) + "\n");
+
     // node
     buildSync({
         ...opts,


### PR DESCRIPTION
## Description
This pull request addresses a warning emitted by Webpack that occurs when building the project. The warning indicates the absence of a version specification in the `package.json` of the `dist/esm` directory. To rectify this, I have implemented a solution to automatically copy the version from the main `package.json` to the `dist/esm/package.json` upon each successful build. This resolves the warning and ensures the version information is consistently propagated to the built package.

## Changes Made

- Implemented an automatic version copying script from `package.json` to `dist/esm/package.json` after every build.
- Modified the existing build script to incorporate the new version copying functionality.
- Removed unnecessary static package.json

## How to Test

1. Run the build process using the provided build script.
2. Verify that the version in `package.json` matches the version in `dist/esm/package.json`.
3. Confirm that the webpack warning related to the missing version is no longer present.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
