### PR TITLE
fix: Exception when id_token not set.

### DIFF
--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -578,6 +578,27 @@ describe("ResponseValidator", () => {
             expect(stubResponse).not.toHaveProperty("profile");
         });
 
+        it("should process an openid signin response without an id_token as a non-openid signin response", async () => {
+            // this is aimed at Authorization servers that don't support the OIDC spec and don't return an id_token if the
+            // openid scope is set in the request scope.
+            // arrange
+            Object.assign(stubResponse, {
+                isOpenId: true,
+            });
+            jest.spyOn(JwtUtils, "decode").mockReturnValue({ sub: "subsub" });
+
+            // act
+            await subject.validateCredentialsResponse(stubResponse, true);
+
+            // assert
+            expect(JwtUtils.decode).not.toHaveBeenCalledWith("id_token");
+            expect(
+                subject["_userInfoService"].getClaims,
+            ).not.toHaveBeenCalledWith();
+            expect(stubResponse).toHaveProperty("profile", {});
+
+        });
+
         it("should process a valid non-openid signin response skipping userInfo", async () => {
             // arrange
             Object.assign(stubResponse, {

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -51,7 +51,7 @@ export class ResponseValidator {
     public async validateCredentialsResponse(response: SigninResponse, skipUserInfo: boolean): Promise<void> {
         const logger = this._logger.create("validateCredentialsResponse");
 
-        if (response.isOpenId) {
+        if (response.isOpenId && !!response.id_token) {
             this._validateIdTokenAttributes(response);
         }
         logger.debug("tokens validated");


### PR DESCRIPTION
django-oauth-toolkit does not support openid for the resource owner credentials flow. The response will still have openid in the scopes property, but there is not id_token This leads to an exception.

This change makes the client a little more tolerant of auth servers by not trying to parse the id_token in this scenario.

fixes  #1206


### Checklist

- [N/A] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [*] I have included links for closing relevant issue numbers
