### PR TITLE
Fixing a bug in merging token id and user info data. 0 is being omitted.

### DIFF
--- a/src/ClaimsService.ts
+++ b/src/ClaimsService.ts
@@ -70,7 +70,7 @@ export class ClaimsService {
         for (const [claim, values] of Object.entries(claims2)) {
             for (const value of Array.isArray(values) ? values : [values]) {
                 const previousValue = result[claim];
-                if (!previousValue) {
+                if (previousValue === undefined) {
                     result[claim] = value;
                 }
                 else if (Array.isArray(previousValue)) {


### PR DESCRIPTION
This solution is created based on a bug in merging two claim services.
In more details, the first implementation, whenever a user have a user attribute in the first claim and the second claim, if this attribute has a value of 0, it will be omitted: "!previousValue" line 73 in src/ClaimService.ts, however the expected output should contain that 0. In the solution provided, this previous value is being checked if it is undefined.

### Checklist

- [ No need to update the api report] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ No issue number to be included] I have included links for closing relevant issue numbers
