### PR TITLE
allow to optionally pass redirect_uri into exchangeRefreshToken

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -333,7 +333,7 @@ export class OidcClient {
     // (undocumented)
     protected readonly _tokenClient: TokenClient;
     // (undocumented)
-    useRefreshToken({ state, resource, timeoutInSeconds, extraTokenParams, }: UseRefreshTokenArgs): Promise<SigninResponse>;
+    useRefreshToken({ state, redirect_uri, resource, timeoutInSeconds, extraTokenParams, }: UseRefreshTokenArgs): Promise<SigninResponse>;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -926,6 +926,8 @@ export class User {
 export interface UseRefreshTokenArgs {
     // (undocumented)
     extraTokenParams?: Record<string, unknown>;
+    // (undocumented)
+    redirect_uri?: string;
     // (undocumented)
     resource?: string | string[];
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -333,7 +333,7 @@ export class OidcClient {
     // (undocumented)
     protected readonly _tokenClient: TokenClient;
     // (undocumented)
-    useRefreshToken({ state, timeoutInSeconds, extraTokenParams, }: UseRefreshTokenArgs): Promise<SigninResponse>;
+    useRefreshToken({ state, resource, timeoutInSeconds, extraTokenParams, }: UseRefreshTokenArgs): Promise<SigninResponse>;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -570,7 +570,7 @@ export class RefreshState {
         scope?: string;
         profile: UserProfile;
         state?: unknown;
-    }, resource?: string | string[]);
+    });
     readonly data?: unknown;
     // (undocumented)
     readonly id_token?: string;
@@ -578,8 +578,6 @@ export class RefreshState {
     readonly profile: UserProfile;
     // (undocumented)
     readonly refresh_token: string;
-    // (undocumented)
-    readonly resource?: string | string[];
     // (undocumented)
     readonly scope?: string;
     // (undocumented)
@@ -928,6 +926,8 @@ export class User {
 export interface UseRefreshTokenArgs {
     // (undocumented)
     extraTokenParams?: Record<string, unknown>;
+    // (undocumented)
+    resource?: string | string[];
     // (undocumented)
     state: RefreshState;
     // (undocumented)

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -426,10 +426,10 @@ describe("OidcClient", () => {
                 session_state: "session_state",
                 scope: "openid",
                 profile: {} as UserProfile,
-            }, "resource");
+            });
 
             // act
-            const response = await subject.useRefreshToken({ state });
+            const response = await subject.useRefreshToken({ state, resource: "resource" });
 
             // assert
             expect(exchangeRefreshTokenMock).toHaveBeenCalledWith( {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -33,9 +33,11 @@ export interface CreateSigninRequestArgs
  * @public
  */
 export interface UseRefreshTokenArgs {
-    state: RefreshState;
-    timeoutInSeconds?: number;
+    resource?: string | string[];
     extraTokenParams?: Record<string, unknown>;
+    timeoutInSeconds?: number;
+
+    state: RefreshState;
 }
 
 /**
@@ -185,6 +187,7 @@ export class OidcClient {
 
     public async useRefreshToken({
         state,
+        resource,
         timeoutInSeconds,
         extraTokenParams,
     }: UseRefreshTokenArgs): Promise<SigninResponse> {
@@ -205,9 +208,9 @@ export class OidcClient {
 
         const result = await this._tokenClient.exchangeRefreshToken({
             refresh_token: state.refresh_token,
-            resource: state.resource,
             // provide the (possible filtered) scope list
             scope,
+            resource,
             timeoutInSeconds,
             ...extraTokenParams,
         });
@@ -216,7 +219,7 @@ export class OidcClient {
         logger.debug("validating response", response);
         await this._validator.validateRefreshResponse(response, {
             ...state,
-            // overide the scope in the state handed over to the validator
+            // override the scope in the state handed over to the validator
             // so it can set the granted scope to the requested scope in case none is included in the response
             scope,
         });

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -33,6 +33,7 @@ export interface CreateSigninRequestArgs
  * @public
  */
 export interface UseRefreshTokenArgs {
+    redirect_uri?: string;
     resource?: string | string[];
     extraTokenParams?: Record<string, unknown>;
     timeoutInSeconds?: number;
@@ -187,6 +188,7 @@ export class OidcClient {
 
     public async useRefreshToken({
         state,
+        redirect_uri,
         resource,
         timeoutInSeconds,
         extraTokenParams,
@@ -210,6 +212,7 @@ export class OidcClient {
             refresh_token: state.refresh_token,
             // provide the (possible filtered) scope list
             scope,
+            redirect_uri,
             resource,
             timeoutInSeconds,
             ...extraTokenParams,

--- a/src/RefreshState.ts
+++ b/src/RefreshState.ts
@@ -17,7 +17,6 @@ export class RefreshState {
     public readonly session_state: string | null;
     public readonly scope?: string;
     public readonly profile: UserProfile;
-    public readonly resource?: string | string[];
 
     constructor(args: {
         refresh_token: string;
@@ -27,13 +26,12 @@ export class RefreshState {
         profile: UserProfile;
 
         state?: unknown;
-    }, resource?: string | string[]) {
+    }) {
         this.refresh_token = args.refresh_token;
         this.id_token = args.id_token;
         this.session_state = args.session_state;
         this.scope = args.scope;
         this.profile = args.profile;
-        this.resource = resource;
 
         this.data = args.state;
 

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -39,6 +39,7 @@ export interface ExchangeCredentialsArgs {
 export interface ExchangeRefreshTokenArgs {
     client_id?: string;
     client_secret?: string;
+    redirect_uri?: string;
 
     grant_type?: string;
     refresh_token: string;

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -552,11 +552,11 @@ describe("UserManager", () => {
             expect(useRefreshTokenSpy).toBeCalledWith(
                 expect.objectContaining({
                     state: {
-                        resource: "resource",
                         refresh_token: user.refresh_token,
                         session_state: null,
                         "profile": { "nickname": "Nick", "sub": "sub" },
                     },
+                    resource: "resource",
                 }),
             );
         });

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -282,15 +282,18 @@ export class UserManager {
         const logger = this._logger.create("signinSilent");
         const {
             silentRequestTimeoutInSeconds,
-            resource,
             ...requestArgs
         } = args;
         // first determine if we have a refresh token, or need to use iframe
         let user = await this._loadUser();
         if (user?.refresh_token) {
             logger.debug("using refresh token");
-            const state = new RefreshState(user as Required<User>, resource);
-            return await this._useRefreshToken({ state, extraTokenParams: requestArgs.extraTokenParams });
+            const state = new RefreshState(user as Required<User>);
+            return await this._useRefreshToken({
+                state,
+                resource: requestArgs.resource,
+                extraTokenParams: requestArgs.extraTokenParams,
+            });
         }
 
         const url = this.settings.silent_redirect_uri;

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -294,6 +294,7 @@ export class UserManager {
                 redirect_uri: requestArgs.redirect_uri,
                 resource: requestArgs.resource,
                 extraTokenParams: requestArgs.extraTokenParams,
+                timeoutInSeconds: silentRequestTimeoutInSeconds,
             });
         }
 

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -291,6 +291,7 @@ export class UserManager {
             const state = new RefreshState(user as Required<User>);
             return await this._useRefreshToken({
                 state,
+                redirect_uri: requestArgs.redirect_uri,
                 resource: requestArgs.resource,
                 extraTokenParams: requestArgs.extraTokenParams,
             });


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #1175

Removes the `resource` prop from the state and adds it into the args to pass down to the `exchangeRefreshToken` function. Treat `resource`, `extraTokenParams` and `redirect_uri` and any future prop the same way.

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
