### PR TITLE
Fix 1379 revert 1341

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 
 # build artifacts
 *.tsbuildinfo

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,9 +2,7 @@
 
 The API is largely backwards-compatible.
 
-The "crypto-js" software library has been removed; the native crypto/crypto.subtle module built into the
-browser is instead used. All modern browsers are expected to support it.
-If you need to support older browsers stay with v2.4!
+The "crypto-js" software library has been removed; the native crypto/crypto.subtle module built into the browser is instead used. All modern browsers are expected to support it. If you need to support older browsers stay with v2.4!
 
 The behavior of merging claims  has been improved.
 
@@ -17,8 +15,6 @@ The behavior of merging claims  has been improved.
 - the `mergeClaims` has been replaced by `mergeClaimsStrategy`
   - if the previous behavior is required `mergeClaimsStrategy: { array: "merge" }` comes close to it
 - default of `response_mode` changed from `query` &rarr; `undefined`
-- when using `signoutRedirect` a working callback is required to remove the user and raise an event. As usual
-  either call `signoutCallback` or `signoutRedirectCallback` in this situation.
 
 
 ## oidc-client v1.11.5 &rarr; oidc-client-ts v2.0.0

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -2,13 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { once } from "events";
-import {
-    RedirectNavigator,
-    type PopupWindow,
-    PopupNavigator,
-    IFrameNavigator,
-    type NavigateResponse,
-} from "./navigators";
+import { RedirectNavigator, type PopupWindow, PopupNavigator, IFrameNavigator } from "./navigators";
 import type { SigninResponse } from "./SigninResponse";
 import type { SignoutResponse } from "./SignoutResponse";
 import { UserManager, type SigninPopupArgs, type SigninRedirectArgs, type SigninSilentArgs, type SignoutSilentArgs } from "./UserManager";
@@ -39,7 +33,6 @@ describe("UserManager", () => {
             userStore: userStoreMock,
             metadata: {
                 authorization_endpoint: "http://sts/oidc/authorize",
-                end_session_endpoint:  "http://sts/oidc/logout",
                 token_endpoint: "http://sts/oidc/token",
                 revocation_endpoint: "http://sts/oidc/revoke",
             },
@@ -842,53 +835,6 @@ describe("UserManager", () => {
 
             // assert
             expect(callbackMock).toBeCalledWith(url);
-        });
-    });
-
-    describe("signoutRedirect", () => {
-        it("should not unload user to avoid race condition between actual signout and signout event handlers", async () => {
-            // arrange
-            const navigateMock = jest.fn().mockReturnValue(Promise.resolve({
-                url: "http://localhost:8080",
-            } as NavigateResponse));
-            jest.spyOn(subject["_redirectNavigator"], "prepare").mockReturnValue(Promise.resolve({
-                navigate: navigateMock,
-                close: () => {},
-            }));
-            const user = new User({
-                access_token: "access_token",
-                token_type: "token_type",
-                profile: {} as UserProfile,
-            });
-            await subject.storeUser(user);
-
-            // act
-            await subject.signoutRedirect();
-
-            // assert
-            expect(navigateMock).toHaveBeenCalledTimes(1);
-            const storageString = await subject.settings.userStore.get(subject["_userStoreKey"]);
-            expect(storageString).not.toBeNull();
-        });
-    });
-
-    describe("signoutRedirectCallback", () => {
-        it("should unload user", async () => {
-            // arrange
-            const user = new User({
-                access_token: "access_token",
-                token_type: "token_type",
-                profile: {} as UserProfile,
-            });
-            await subject.storeUser(user);
-
-            expect(await subject.settings.userStore.get(subject["_userStoreKey"])).not.toBeNull();
-
-            // act
-            await subject.signoutRedirectCallback();
-
-            // assert
-            expect(await subject.settings.userStore.get(subject["_userStoreKey"])).toBeNull();
         });
     });
 

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -620,6 +620,9 @@ export class UserManager {
                 args.id_token_hint = id_token;
             }
 
+            await this.removeUser();
+            logger.debug("user removed, creating signout request");
+
             const signoutRequest = await this._client.createSignoutRequest(args);
             logger.debug("got signout request");
 
@@ -635,14 +638,10 @@ export class UserManager {
             throw err;
         }
     }
-
     protected async _signoutEnd(url: string): Promise<SignoutResponse> {
         const logger = this._logger.create("_signoutEnd");
         const signoutResponse = await this._client.processSignoutResponse(url);
         logger.debug("got signout response");
-
-        await this.removeUser();
-        logger.debug("user removed");
 
         return signoutResponse;
     }


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #1379

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers

Lessons learnt:
- It is not 100% reliable that the logout is called (session must be seen by the IDP as valid)
- The remove of the user must happen due to stability reasons before the sign-out request
- The <3.0 behavior is very simple and works 100% reliable

Future:
- To be clarified if we can suppress reliable always the unload user event in that situation
  - with callback: it might be not needed at all, as the client reloads multiple times anyway
  - without callback: for some IDP we land on the IDP signout and not our application