### PR TITLE
Remove unneccesary extraHeaders parameter from _useRefreshToken

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -1009,7 +1009,7 @@ export class UserManager {
     // (undocumented)
     storeUser(user: User | null): Promise<void>;
     // (undocumented)
-    protected _useRefreshToken(args: UseRefreshTokenArgs, extraHeaders?: Record<string, ExtraHeader>): Promise<User>;
+    protected _useRefreshToken(args: UseRefreshTokenArgs): Promise<User>;
     // (undocumented)
     protected get _userStoreKey(): string;
 }

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -15,7 +15,6 @@ import type { SignoutResponse } from "./SignoutResponse";
 import type { MetadataService } from "./MetadataService";
 import { RefreshState } from "./RefreshState";
 import type { SigninResponse } from "./SigninResponse";
-import type { ExtraHeader } from "./OidcClientSettings";
 
 /**
  * @public
@@ -330,11 +329,10 @@ export class UserManager {
         return user;
     }
 
-    protected async _useRefreshToken(args: UseRefreshTokenArgs, extraHeaders?: Record<string, ExtraHeader>): Promise<User> {
+    protected async _useRefreshToken(args: UseRefreshTokenArgs): Promise<User> {
         const response = await this._client.useRefreshToken({
             ...args,
             timeoutInSeconds: this.settings.silentRequestTimeoutInSeconds,
-            extraHeaders,
         });
         const user = new User({ ...args.state, ...response });
 


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

I accidentally added the extraHeaders parameter separately to what I'd already added to the USeRefreshTokenArgs. This removes the double up.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
