### PR TITLE
fix: fix the return type of signinCallback

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -975,7 +975,7 @@ export class UserManager {
     readonly settings: UserManagerSettingsStore;
     // (undocumented)
     protected _signin(args: CreateSigninRequestArgs, handle: IWindow, verifySub?: string): Promise<User>;
-    signinCallback(url?: string): Promise<User | void>;
+    signinCallback(url?: string): Promise<User | undefined>;
     // (undocumented)
     protected _signinEnd(url: string, verifySub?: string): Promise<User>;
     signinPopup(args?: SigninPopupArgs): Promise<User>;

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -365,18 +365,21 @@ export class UserManager {
      *
      * @throws `Error` If request_type is unknown or signout cannot be processed.
      */
-    public async signinCallback(url = window.location.href): Promise<User | void> {
+    public async signinCallback(url = window.location.href): Promise<User | undefined> {
         const { state } = await this._client.readSigninResponseState(url);
         switch (state.request_type) {
             case "si:r":
                 return await this.signinRedirectCallback(url);
             case "si:p":
-                return await this.signinPopupCallback(url);
+                await this.signinPopupCallback(url);
+                break;
             case "si:s":
-                return await this.signinSilentCallback(url);
+                await this.signinSilentCallback(url);
+                break;
             default:
                 throw new Error("invalid response_type in state");
         }
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->

The `Promise<User | void>` return type of `signinCallback` was not convenient to use, so I changed it to the `Promise<User | undefined>` type. There is no runtime change at all since it is just a cast.

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
