### PR TITLE
fix small typo in signinCallback doc in UserManager.ts

### DIFF
--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -363,7 +363,7 @@ export class UserManager {
      * - {@link UserManager.signinPopupCallback}
      * - {@link UserManager.signinSilentCallback}
      *
-     * @throws `Error` If request_type is unknown or signout cannot be processed.
+     * @throws `Error` If request_type is unknown or signin cannot be processed.
      */
     public async signinCallback(url = window.location.href): Promise<User | undefined> {
         const { state } = await this._client.readSigninResponseState(url);


### PR DESCRIPTION
signinCallback documentation seemed to have been copy/pasted from signoutCallback leading to a confusing doc.

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
