### PR TITLE
Add dpop nonce support

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -63,6 +63,15 @@ export type CreateSignoutRequestArgs = Omit<SignoutRequestArgs, "url" | "state_d
     state?: unknown;
 };
 
+// @public (undocumented)
+export class DPoPState {
+    constructor(keys: CryptoKeyPair, nonce?: string | undefined);
+    // (undocumented)
+    readonly keys: CryptoKeyPair;
+    // (undocumented)
+    nonce?: string | undefined;
+}
+
 // @public
 export class ErrorResponse extends Error {
     constructor(args: {
@@ -157,8 +166,6 @@ export class IndexedDbDPoPStore implements DPoPStore {
     promisifyRequest<T = undefined>(request: IDBRequest<T> | IDBTransaction): Promise<T>;
     // (undocumented)
     remove(key: string): Promise<DPoPState>;
-    // Warning: (ae-forgotten-export) The symbol "DPoPState" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     set(key: string, value: DPoPState): Promise<void>;
     // (undocumented)

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -150,15 +150,17 @@ export class IndexedDbDPoPStore implements DPoPStore {
     // (undocumented)
     readonly _dbName: string;
     // (undocumented)
-    get(key: string): Promise<CryptoKeyPair>;
+    get(key: string): Promise<DPoPState>;
     // (undocumented)
     getAllKeys(): Promise<string[]>;
     // (undocumented)
     promisifyRequest<T = undefined>(request: IDBRequest<T> | IDBTransaction): Promise<T>;
     // (undocumented)
-    remove(key: string): Promise<CryptoKeyPair>;
+    remove(key: string): Promise<DPoPState>;
+    // Warning: (ae-forgotten-export) The symbol "DPoPState" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    set(key: string, value: CryptoKeyPair): Promise<void>;
+    set(key: string, value: DPoPState): Promise<void>;
     // (undocumented)
     readonly _storeName: string;
 }
@@ -329,7 +331,7 @@ export class OidcClient {
     // (undocumented)
     createSignoutRequest({ state, id_token_hint, client_id, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
     // (undocumented)
-    getDpopProof(dpopStore: DPoPStore): Promise<string>;
+    getDpopProof(dpopStore: DPoPStore, nonce?: string): Promise<string>;
     // (undocumented)
     protected readonly _logger: Logger;
     // (undocumented)
@@ -989,7 +991,7 @@ export class UserManager {
     clearStaleState(): Promise<void>;
     // (undocumented)
     protected readonly _client: OidcClient;
-    dpopProof(url: string, user: User, httpMethod?: string): Promise<string | undefined>;
+    dpopProof(url: string, user: User, httpMethod?: string, nonce?: string): Promise<string | undefined>;
     get events(): UserManagerEvents;
     // (undocumented)
     protected readonly _events: UserManagerEvents;

--- a/src/DPoPStore.ts
+++ b/src/DPoPStore.ts
@@ -8,6 +8,9 @@ export interface DPoPStore {
     getAllKeys(): Promise<string[]>;
 }
 
+/**
+ * @public
+ */
 export class DPoPState {
     public constructor(
         public readonly keys: CryptoKeyPair,

--- a/src/DPoPStore.ts
+++ b/src/DPoPStore.ts
@@ -11,6 +11,6 @@ export interface DPoPStore {
 export class DPoPState {
     public constructor(
         public readonly keys: CryptoKeyPair,
-        public readonly nonce?: string,
+        public nonce?: string,
     ) { }
 }

--- a/src/DPoPStore.ts
+++ b/src/DPoPStore.ts
@@ -2,8 +2,15 @@
  * @public
  */
 export interface DPoPStore {
-    set(key: string, value: CryptoKeyPair): Promise<void>;
-    get(key: string): Promise<CryptoKeyPair>;
-    remove(key: string): Promise<CryptoKeyPair>;
+    set(key: string, value: DPoPState): Promise<void>;
+    get(key: string): Promise<DPoPState>;
+    remove(key: string): Promise<DPoPState>;
     getAllKeys(): Promise<string[]>;
+}
+
+export class DPoPState {
+    public constructor(
+        public readonly keys: CryptoKeyPair,
+        public readonly nonce?: string,
+    ) { }
 }

--- a/src/IndexedDbDPoPStore.ts
+++ b/src/IndexedDbDPoPStore.ts
@@ -1,4 +1,4 @@
-import type { DPoPStore } from "./DPoPStore";
+import { DPoPState, type DPoPStore } from "./DPoPStore";
 
 /**
  * Provides a default implementation of the DPoP store using IndexedDB.
@@ -9,7 +9,7 @@ export class IndexedDbDPoPStore implements DPoPStore {
     readonly _dbName: string = "oidc";
     readonly _storeName: string = "dpop";
 
-    public async set(key: string, value: CryptoKeyPair): Promise<void> {
+    public async set(key: string, value: DPoPState): Promise<void> {
         const store = await this.createStore(this._dbName, this._storeName);
         await store("readwrite", (str: IDBObjectStore) => {
             str.put(value, key);
@@ -17,14 +17,14 @@ export class IndexedDbDPoPStore implements DPoPStore {
         });
     }
 
-    public async get(key: string): Promise<CryptoKeyPair> {
+    public async get(key: string): Promise<DPoPState> {
         const store = await this.createStore(this._dbName, this._storeName);
         return await store("readonly", (str) => {
             return this.promisifyRequest(str.get(key));
-        }) as CryptoKeyPair;
+        }) as DPoPState;
     }
 
-    public async remove(key: string): Promise<CryptoKeyPair> {
+    public async remove(key: string): Promise<DPoPState> {
         const item = await this.get(key);
         const store = await this.createStore(this._dbName, this._storeName);
         await store("readwrite", (str) => {

--- a/src/JsonService.ts
+++ b/src/JsonService.ts
@@ -4,6 +4,7 @@
 import { ErrorResponse, ErrorTimeout } from "./errors";
 import type { ExtraHeader } from "./OidcClientSettings";
 import { Logger } from "./utils";
+import { ErrorDPoPNonce } from "./errors/ErrorDPoPNonce";
 
 /**
  * @internal
@@ -180,6 +181,10 @@ export class JsonService {
 
         if (!response.ok) {
             logger.error("Error from server:", json);
+            if (response.headers.has("dpop-nonce")) {
+                const nonce = response.headers.get("dpop-nonce") as string;
+                throw new ErrorDPoPNonce(nonce, `${JSON.stringify(json)}`);
+            }
             if (json.error) {
                 throw new ErrorResponse(json, body);
             }

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { JwtUtils } from "./utils";
+import { CryptoUtils, JwtUtils } from "./utils";
 import type { ErrorResponse } from "./errors";
 import type { JwtClaims } from "./Claims";
 import { OidcClient } from "./OidcClient";
@@ -15,6 +15,8 @@ import { RefreshState } from "./RefreshState";
 import { SigninResponse } from "./SigninResponse";
 import type { UserProfile } from "./User";
 import { IndexedDbDPoPStore } from "./IndexedDbDPoPStore";
+import { ErrorDPoPNonce } from "./errors/ErrorDPoPNonce";
+import { DPoPState } from "./DPoPStore";
 
 describe("OidcClient", () => {
     let subject: OidcClient;
@@ -426,6 +428,43 @@ describe("OidcClient", () => {
             expect(metadataServiceMock).toHaveBeenCalled();
             expect(validateSigninResponseMock).toHaveBeenCalledWith(response, item, { "DPoP": expect.any(String) });
         });
+
+        it("should retry code request if original fails with ErrorDPoPNonce exception", async () => {
+            subject = new OidcClient({
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+                post_logout_redirect_uri: "http://app",
+                dpop: {
+                    bind_authorization_code: false,
+                    store: new IndexedDbDPoPStore(),
+                },
+            });
+
+            // arrange
+            const item = await SigninState.create({
+                id: "1",
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "http://app/cb",
+                scope: "scope",
+                request_type: "type",
+            });
+            jest.spyOn(subject.settings.stateStore, "remove")
+                .mockImplementation(async () => item.toStorageString());
+            const validateSigninResponseMock = jest.spyOn(subject["_validator"], "validateSigninResponse")
+                .mockRejectedValueOnce(new ErrorDPoPNonce("some-nonce"));
+            const getDpopProofMock = jest.spyOn(subject, "getDpopProof");
+            const metadataServiceMock = jest.spyOn(subject["metadataService"], "getTokenEndpoint").mockResolvedValue("http://sts/token");
+            // act
+            await subject.processSigninResponse("http://app/cb?state=1");
+
+            // assert
+            expect(metadataServiceMock).toHaveBeenCalled();
+            expect(validateSigninResponseMock).toHaveBeenCalledTimes(2);
+            expect(getDpopProofMock).toHaveBeenCalledTimes(2);
+            expect(getDpopProofMock).toHaveBeenNthCalledWith(2, { "_dbName": "oidc", "_storeName": "dpop" }, "some-nonce");
+        });
     });
 
     describe("processResourceOwnerPasswordCredentials", () => {
@@ -652,6 +691,50 @@ describe("OidcClient", () => {
             expect(response).toMatchObject(tokenResponse);
             expect(response).toHaveProperty("session_state", state.session_state);
             expect(response).toHaveProperty("scope", state.scope);
+        });
+
+        it("should retry token exchange if tokenClient exchange throws ErrorDPoPNonce exception", async () => {
+            // arrange
+            const settings: OidcClientSettings = {
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "redirect",
+                post_logout_redirect_uri: "http://app",
+                dpop: {
+                    bind_authorization_code: false,
+                    store: new IndexedDbDPoPStore(),
+                },
+            };
+
+            subject = new OidcClient(settings);
+
+            const tokenResponse = {
+                access_token: "new_access_token",
+            };
+            const exchangeRefreshTokenMock =
+                jest.spyOn(subject["_tokenClient"], "exchangeRefreshToken")
+                    .mockRejectedValueOnce(new ErrorDPoPNonce("some-nonce"))
+                    .mockResolvedValueOnce(tokenResponse);
+            jest.spyOn(JwtUtils, "decode").mockReturnValue({ sub: "sub" });
+            jest.spyOn(subject["metadataService"], "getTokenEndpoint").mockResolvedValue("http://sts/token");
+            const getDpopProofSpy = jest.spyOn(subject, "getDpopProof");
+
+            const state = new RefreshState({
+                refresh_token: "refresh_token",
+                id_token: "id_token",
+                session_state: "session_state",
+                scope: "openid",
+                profile: {} as UserProfile,
+            });
+
+            // act
+            await subject.useRefreshToken({ state, resource: "resource" });
+
+            // assert
+
+            expect(exchangeRefreshTokenMock).toHaveBeenCalledTimes(2);
+            expect(getDpopProofSpy).toHaveBeenCalledTimes(2);
+            expect(getDpopProofSpy).toHaveBeenNthCalledWith(2, { "_dbName": "oidc", "_storeName": "dpop" }, "some-nonce");
         });
 
         it("should pass extraHeaders to tokenClient.exchangeRefreshToken if supplied", async () => {
@@ -1030,6 +1113,71 @@ describe("OidcClient", () => {
                 token: "token",
                 token_type_hint: "access_token",
             });
+        });
+    });
+
+    describe("getDpopProof", () => {
+        it("stores a nonce if one is provided", async () => {
+            // arrange
+            const store = new IndexedDbDPoPStore();
+            const keyPair = await CryptoUtils.generateDPoPKeys();
+            jest.spyOn(CryptoUtils, "generateDPoPKeys").mockResolvedValue(keyPair);
+
+            const settings: OidcClientSettings = {
+                authority: "authority",
+                client_id: "dpop_client",
+                redirect_uri: "redirect",
+                post_logout_redirect_uri: "http://app",
+                dpop: {
+                    bind_authorization_code: false,
+                    store: store,
+                },
+            };
+
+            subject = new OidcClient(settings);
+
+            jest.spyOn(subject["metadataService"], "getTokenEndpoint").mockResolvedValue("http://sts/token");
+
+            // act
+            await subject.getDpopProof(store, "some-nonce");
+            const storedDPoPState = await subject.settings.dpop?.store.get("dpop_client");
+            // assert
+
+            expect(storedDPoPState?.nonce).toEqual("some-nonce");
+        });
+
+        it("updates the stored nonce if a new one is provided", async () => {
+            // arrange
+            const store = new IndexedDbDPoPStore();
+            const keyPair = await CryptoUtils.generateDPoPKeys();
+            jest.spyOn(CryptoUtils, "generateDPoPKeys").mockResolvedValue(keyPair);
+            const dpopState = new DPoPState(keyPair, "some-nonce");
+
+            const settings: OidcClientSettings = {
+                authority: "authority",
+                client_id: "dpop_client",
+                redirect_uri: "redirect",
+                post_logout_redirect_uri: "http://app",
+                dpop: {
+                    bind_authorization_code: false,
+                    store: store,
+                },
+            };
+
+            subject = new OidcClient(settings);
+
+            jest.spyOn(subject["metadataService"], "getTokenEndpoint").mockResolvedValue("http://sts/token");
+            await subject.getDpopProof(store, "some-nonce");
+            let storedDPoPState = await subject.settings.dpop?.store.get("dpop_client");
+            expect(storedDPoPState?.nonce).toEqual("some-nonce");
+            dpopState.nonce = "some-other-nonce";
+
+            // act
+            await subject.getDpopProof(store, "some-other-nonce");
+            storedDPoPState = await subject.settings.dpop?.store.get("dpop_client");
+
+            // assert
+            expect(storedDPoPState?.nonce).toEqual("some-other-nonce");
         });
     });
 });

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -221,7 +221,7 @@ export class OidcClient {
             url: await this.metadataService.getTokenEndpoint(false),
             httpMethod: "POST",
             keyPair: dpopState.keys,
-            nonce: nonce,
+            nonce: dpopState.nonce,
         });
     }
 

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -22,6 +22,7 @@ import type { State } from "./State";
 import { mocked } from "jest-mock";
 import { CryptoUtils } from "./utils";
 import { IndexedDbDPoPStore } from "./IndexedDbDPoPStore";
+import { DPoPState } from "./DPoPStore";
 
 describe("UserManager", () => {
     let userStoreMock: WebStorageStateStore;
@@ -361,7 +362,8 @@ describe("UserManager", () => {
             const generateDPoPJktSpy = jest.spyOn(subject, "generateDPoPJkt");
 
             const keyPair = await CryptoUtils.generateDPoPKeys();
-            await subject.settings.dpop?.store?.set("client", keyPair);
+
+            await subject.settings.dpop?.store?.set("client", new DPoPState(keyPair));
 
             // act
             await subject.signinRedirect();
@@ -516,7 +518,7 @@ describe("UserManager", () => {
             const generateDPoPJktSpy = jest.spyOn(subject, "generateDPoPJkt");
 
             const keyPair = await CryptoUtils.generateDPoPKeys();
-            await subject.settings.dpop?.store?.set("client", keyPair);
+            await subject.settings.dpop?.store?.set("client", new DPoPState(keyPair));
 
             const user = new User({
                 access_token: "access_token",
@@ -744,7 +746,7 @@ describe("UserManager", () => {
             });
 
             const keyPair = await CryptoUtils.generateDPoPKeys();
-            await subject.settings.dpop?.store?.set("client", keyPair);
+            await subject.settings.dpop?.store?.set("client", new DPoPState(keyPair));
 
             const user = new User({
                 access_token: "access_token",
@@ -1219,7 +1221,7 @@ describe("UserManager", () => {
             });
             await subject.storeUser(user);
             const dpopKeyPair = await CryptoUtils.generateDPoPKeys();
-            await subject.settings.dpop?.store.set("client", dpopKeyPair);
+            await subject.settings.dpop?.store.set("client", new DPoPState(dpopKeyPair));
 
             // act
             await subject.storeUser(null);
@@ -1255,7 +1257,7 @@ describe("UserManager", () => {
 
             const user = await subject.getUser() as User;
             const keyPair = await CryptoUtils.generateDPoPKeys();
-            const mockDpopStore = jest.spyOn(subject.settings.dpop!.store, "get").mockResolvedValue(keyPair);
+            const mockDpopStore = jest.spyOn(subject.settings.dpop!.store, "get").mockResolvedValue(new DPoPState(keyPair));
 
             // act
             const dpopProof = await subject.dpopProof("http://some.url", user, "POST");

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -813,7 +813,7 @@ export class UserManager {
      * @param url - The URL to generate the DPoP proof for
      * @param user - The user to generate the DPoP proof for
      * @param httpMethod - Optional, defaults to "GET"
-     * @param nonce = Optional nonce provided by the resource server
+     * @param nonce - Optional nonce provided by the resource server
      *
      * @returns A promise containing the DPoP proof or undefined if DPoP is not enabled/no user is found.
      */

--- a/src/errors/ErrorDPoPNonce.ts
+++ b/src/errors/ErrorDPoPNonce.ts
@@ -1,0 +1,10 @@
+export class ErrorDPoPNonce extends Error {
+    /** Marker to detect class: "ErrorDPoPNonce" */
+    public readonly name: string = "ErrorDPoPNonce";
+    public readonly nonce: string;
+
+    public constructor(nonce: string, message?: string) {
+        super(message);
+        this.nonce = nonce;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,4 @@ export type { UserManagerSettings } from "./UserManagerSettings";
 export { Version } from "./Version";
 export { WebStorageStateStore } from "./WebStorageStateStore";
 export { IndexedDbDPoPStore } from "./IndexedDbDPoPStore";
+export { DPoPState } from "./DPoPStore";

--- a/src/utils/CryptoUtils.ts
+++ b/src/utils/CryptoUtils.ts
@@ -6,6 +6,7 @@ export interface GenerateDPoPProofOpts {
     accessToken?: string;
     httpMethod?: string;
     keyPair: CryptoKeyPair;
+    nonce?: string;
 }
 
 const UUID_V4_TEMPLATE = "10000000-1000-4000-8000-100000000000";
@@ -136,6 +137,7 @@ export class CryptoUtils {
         accessToken,
         httpMethod,
         keyPair,
+        nonce,
     }: GenerateDPoPProofOpts): Promise<string> {
         let hashedToken: Uint8Array;
         let encodedHash: string;
@@ -151,6 +153,10 @@ export class CryptoUtils {
             hashedToken = await CryptoUtils.hash("SHA-256", accessToken);
             encodedHash = CryptoUtils.encodeBase64Url(hashedToken);
             payload.ath = encodedHash;
+        }
+
+        if (nonce) {
+            payload.nonce = nonce;
         }
 
         try {


### PR DESCRIPTION
This is a first cut aimed at adding `DPoP` nonce support. I initially removed this feature in the original [PR](https://github.com/authts/oidc-client-ts/pull/1461) and this is a follow up.

This is very experimental and open to change. @pamapa I would really appreciate your thoughts as to how this could be done more cleanly 🙏🏼

The main functionality is supporting [Authorization Server Provided Nonces](https://datatracker.ietf.org/doc/html/rfc9449#name-authorization-server-provid).

According to the spec, if/when an AS requires the use of a nonce and a token request is made without a nonce claim within the DPoP proof JWT, the AS responds with a specific 400 bad request that includes a response header `dpop-nonce` which contains the nonce value to be used. The client is then expected to regenerate its DPoP proof again with the included nonce, and then retry the token request.

>Upon receiving the nonce, the client is expected to retry its token request using a DPoP proof including the supplied nonce value in the nonce claim of the DPoP proof. An example unencoded JWT payload of such a DPoP proof including a nonce is shown below.

e.g.

```
HTTP/1.1 400 Bad Request
 DPoP-Nonce: eyJ7S_zG.eyJH0-Z.HX4w-7v

 {
  "error": "use_dpop_nonce",
  "error_description":
    "Authorization server requires nonce in DPoP proof"
 }
[Figure 20](https://datatracker.ietf.org/doc/html/rfc9449#figure-20): [HTTP 400 Response to a Token Request without a Nonce](https://datatracker.ietf.org/doc/html/rfc9449#name-http-400-response-to-a-toke)
Other HTTP headers and JSON fields MAY also be included in the error response, but there MUST NOT be more than one DPoP-Nonce header.

Upon receiving the nonce, the client is expected to retry its token request using a DPoP proof including the supplied nonce value in the nonce claim of the DPoP proof. An example unencoded JWT payload of such a DPoP proof including a nonce is shown below.

 {
  "jti": "-BwC3ESc6acc2lTc",
  "htm": "POST",
  "htu": "https://server.example.com/token",
  "iat": 1562262616,
  "nonce": "eyJ7S_zG.eyJH0-Z.HX4w-7v"
 }

```


In order to accomodate this I have added a new abstraction `DPoPState`, which is an object that contains both the CryptoKeyPair and the optional nonce value. I have altered the `DPoPStore` interface to accomodate this as the nonce can be used repeatedly for token requests until the AS decides to invalidate.

Which brings me to my next point, the spec is quite open as to how an AS may [provide a new nonce](https://datatracker.ietf.org/doc/html/rfc9449#name-providing-a-new-nonce-value).

>The authorization server MAY supply the new nonce in the same way that the initial one was supplied: by using a DPoP-Nonce HTTP header in the response. The DPoP-Nonce HTTP header field uses the nonce syntax defined in [Section 8.1](https://datatracker.ietf.org/doc/html/rfc9449#NonceSyntax). Each time this happens, it requires an extra protocol round trip.

>A more efficient manner of supplying a new nonce value is also defined by including a DPoP-Nonce HTTP header in the HTTP 200 (OK) response from the previous request. The client MUST use the new nonce value supplied for the next token request and for all subsequent token requests until the authorization server supplies a new nonce.

I attempted to try and add a way to handle a new nonce upon a 200 response but it was going to be messy and potentially involved altering the `SigninResponse`  class, which didn't feel right. I looked at how IdentityServer issues new nonces and they just [re-use the 400 bad request method](https://github.com/DuendeSoftware/IdentityServer/blob/c1e1508c0749265dae983601e7ed7b88eac8fe8b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs#L414-L422). I think we should leave this out for the time being.

In regards to supporting [Resource Server provided nonces](https://datatracker.ietf.org/doc/html/rfc9449#name-resource-server-provided-no), that is a lot simpler as the client should manage storing and renewing the resource provided nonce as it will be returned on a client initiated fetch request to the RS - it has nothing to do with `oidc-client-ts`. For now I have opted to provide a way to supply the nonce as an [optional parameter when creating the DPoPProof on the user manager class](https://github.com/authts/oidc-client-ts/compare/main...dbfr3qs:oidc-client-ts:add-dpop-nonce-support?expand=1#diff-be27343df6f02daa157014989cbc33093c0d605f2103d55d569a6dd1ab3fdf84R820). We can revisit if we want to offer a way for clients to store the RS provided nonce values and/or provide helpers to manage them, but this interaction falls outside the relationship between the client and the AS. 


### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
