### PR TITLE
Add `removeState` as an option to `processSigninResponse`

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -346,7 +346,7 @@ export class OidcClient {
     // (undocumented)
     processResourceOwnerPasswordCredentials({ username, password, skipUserInfo, extraTokenParams, }: ProcessResourceOwnerPasswordCredentialsArgs): Promise<SigninResponse>;
     // (undocumented)
-    processSigninResponse(url: string, extraHeaders?: Record<string, ExtraHeader>): Promise<SigninResponse>;
+    processSigninResponse(url: string, extraHeaders?: Record<string, ExtraHeader>, removeState?: boolean): Promise<SigninResponse>;
     // (undocumented)
     processSignoutResponse(url: string): Promise<SignoutResponse>;
     // (undocumented)

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -478,7 +478,8 @@ describe("OidcClient", () => {
             });
             const getStateMock = jest.spyOn(subject.settings.stateStore, "get")
                 .mockImplementation(async () => item.toStorageString());
-            const removeStateMock = jest.spyOn(subject.settings.stateStore, "remove").mockImplementation(async () => item.toStorageString());
+            const removeStateMock = jest.spyOn(subject.settings.stateStore, "remove")
+                .mockImplementation(async () => item.toStorageString());
             jest.spyOn(subject["_validator"], "validateSigninResponse").mockResolvedValue();
 
             // act

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -465,6 +465,29 @@ describe("OidcClient", () => {
             expect(getDpopProofMock).toHaveBeenCalledTimes(2);
             expect(getDpopProofMock).toHaveBeenNthCalledWith(2, { "_dbName": "oidc", "_storeName": "dpop" }, "some-nonce");
         });
+
+        it("should not delete state when removeState = false", async () => {
+            // arrange
+            const item = await SigninState.create({
+                id: "1",
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "http://app/cb",
+                scope: "scope",
+                request_type: "type",
+            });
+            const getStateMock = jest.spyOn(subject.settings.stateStore, "get")
+                .mockImplementation(async () => item.toStorageString());
+            const removeStateMock = jest.spyOn(subject.settings.stateStore, "remove").mockImplementation(async () => item.toStorageString());
+            jest.spyOn(subject["_validator"], "validateSigninResponse").mockResolvedValue();
+
+            // act
+            await subject.processSigninResponse("http://app/cb?state=1", undefined, false);
+
+            // assert
+            expect(getStateMock).toHaveBeenCalled();
+            expect(removeStateMock).not.toHaveBeenCalled();
+        });
     });
 
     describe("processResourceOwnerPasswordCredentials", () => {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -172,10 +172,10 @@ export class OidcClient {
         return { state, response };
     }
 
-    public async processSigninResponse(url: string, extraHeaders?: Record<string, ExtraHeader>): Promise<SigninResponse> {
+    public async processSigninResponse(url: string, extraHeaders?: Record<string, ExtraHeader>, removeState = true): Promise<SigninResponse> {
         const logger = this._logger.create("processSigninResponse");
 
-        const { state, response } = await this.readSigninResponseState(url, true);
+        const { state, response } = await this.readSigninResponseState(url, removeState);
         logger.debug("received state from storage; validating response");
 
         if (this.settings.dpop && this.settings.dpop.store) {


### PR DESCRIPTION
Use case:

We have a custom extension to OAuth/OIDC where the `code` is an OTP that the user is sent when the OAuth handshake starts. This code is used instead of the typical randomly generated code in exchange for an access token.

If this code is incorrect, the user cannot retry as the state (including PKCE challenge) gets removed from the store as soon as the code is used. With this change, we can pass `removeState = true` which means even if the validation fails, it can be reattempted with a different code.

Without this change, we have to mimic the behaviour of `processSigninResponse` by:
- Calling `readSigninResponseState` directly with `removeState = false`
- Editing the prototype of `OidcClient` so that `_validator.validateSigninResponse()` can be called by the application.
```ts
OidcClient.prototype.getValidator = function () {
  return this._validator;
};
```

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
