### PR TITLE
allow empty string for client_secret in TokenClient

### DIFF
--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -112,7 +112,7 @@ export class TokenClient {
         let basicAuth: string | undefined;
         switch (this._settings.client_authentication) {
             case "client_secret_basic":
-                if (!client_secret) {
+                if (client_secret === undefined || client_secret === null) {
                     logger.throw(new Error("A client_secret is required"));
                     throw null; // https://github.com/microsoft/TypeScript/issues/46972
                 }
@@ -173,7 +173,7 @@ export class TokenClient {
         let basicAuth: string | undefined;
         switch (this._settings.client_authentication) {
             case "client_secret_basic":
-                if (!client_secret) {
+                if (client_secret === undefined || client_secret === null) {
                     logger.throw(new Error("A client_secret is required"));
                     throw null; // https://github.com/microsoft/TypeScript/issues/46972
                 }
@@ -229,7 +229,7 @@ export class TokenClient {
         let basicAuth: string | undefined;
         switch (this._settings.client_authentication) {
             case "client_secret_basic":
-                if (!client_secret) {
+                if (client_secret === undefined || client_secret === null) {
                     logger.throw(new Error("A client_secret is required"));
                     throw null; // https://github.com/microsoft/TypeScript/issues/46972
                 }


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #1068 and #1438

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers

This pull request includes changes to the TokenClient class in the src/TokenClient.ts file to improve the handling of the client_secret parameter. The changes ensure that the client_secret is explicitly checked for undefined or null values, rather than using a falsy check. This modification allows empty strings as valid client_secret values when using client_secret_basic authentication method, which was previously rejected by the falsy check.
