### PR TITLE
Make signinPopup work when calling window is iframe

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -351,7 +351,7 @@ export class OidcClient {
     processSignoutResponse(url: string): Promise<SignoutResponse>;
     // (undocumented)
     readSigninResponseState(url: string, removeState?: boolean): Promise<{
-        state: SigninState;
+        state: SigninState | undefined;
         response: SigninResponse;
     }>;
     // (undocumented)

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -394,6 +394,13 @@ export class UserManager {
      */
     public async signinCallback(url = window.location.href): Promise<User | undefined> {
         const { state } = await this._client.readSigninResponseState(url);
+
+        // if no state from storage, assume signin popup
+        if (state === undefined) {
+            await this.signinPopupCallback(url);
+            return undefined;
+        }
+
         switch (state.request_type) {
             case "si:r":
                 return await this.signinRedirectCallback(url);


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #issue

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers

When using signinPopup and your app is within an iframe, the popup cannot access the local storage of the calling window due to  fairly recent changes with partitioning local storage. As such the popup window cant access the stored state in storage from the main calling window.

What my changes do, is if the popup window cant find the SigninState in storage , then it returns undefined for State.
so readSigninResponseState in OidcClient.ts now returns Promise<{ state: SigninState|undefined; response: SigninResponse }
This prevents the Popup window from throwing an error that it couldnt find the state. And it returns the URL which includes the state and the calling window can verify the state instead of doing it in the popup window.


Then in UserManager.ts signinCallback function:
if state returned from await this._client.readSigninResponseState(url); is undefined, we assume we should call signinPopupCallback which sends the url back to the calling window, which itself then verifies state from the url.


I have confirmed that this now works when the calling window is in an iframe, when it previously failed at stage readSigninResponseState.  I have also confirmed that auth fails if the response provides a bad state.

To summarize, the popup window was trying to verify the state in the response from the state in storage, and then when the calling window receives the URL it also verifies the state from storage. Now, if the popup cant get the state from storage it passes the url back and the main window only verifies the url and state from storage.

This allows the library to work when the popup window doesnt have access to the same partitioned local storage as the main calling window when the main calling window is in an iframe.