### PR TITLE
Ensure `metadataSeed` has priority over remote metadata

### DIFF
--- a/src/MetadataService.test.ts
+++ b/src/MetadataService.test.ts
@@ -148,7 +148,7 @@ describe("MetadataService", () => {
             };
             subject = new MetadataService(new OidcClientSettingsStore(settings));
             const jsonService = subject["_jsonService"]; // access private member
-            jest.spyOn(jsonService, "getJson").mockImplementation(() => Promise.resolve({ jwks_uri: "two" }));
+            jest.spyOn(jsonService, "getJson").mockImplementation(() => Promise.resolve({ issuer: "two", jwks_uri: "two" }));
 
             // act
             const result = await subject.getMetadata();

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -63,7 +63,7 @@ export class MetadataService {
         const metadata = await this._jsonService.getJson(this._metadataUrl, { credentials: this._fetchRequestCredentials, timeoutInSeconds: this._settings.requestTimeoutInSeconds });
 
         logger.debug("merging remote JSON with seed metadata");
-        this._metadata = Object.assign({}, this._settings.metadataSeed, metadata);
+        this._metadata = Object.assign({}, metadata, this._settings.metadataSeed);
         return this._metadata;
     }
 


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes https://github.com/authts/oidc-client-ts/issues/1803

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers

-----

See linked issue for details.

It appears as if the `metadataSeed` merging was reversed, meaning it had no effect once merged with the remote metadata.

This PR ensures that `metadataSeed` overrides the remote metadata, in case the same key is defined in both.