### PR TITLE
Adds raiseEvent parameter to getUser() method

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -1005,7 +1005,7 @@ export class UserManager {
     protected readonly _events: UserManagerEvents;
     // (undocumented)
     generateDPoPJkt(dpopSettings: DPoPSettings): Promise<string | undefined>;
-    getUser(): Promise<User | null>;
+    getUser(raiseEvent?: boolean): Promise<User | null>;
     // (undocumented)
     protected readonly _iframeNavigator: INavigator;
     // (undocumented)

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -143,6 +143,60 @@ describe("UserManager", () => {
             expect(loadMock).toHaveBeenCalledWith(user, false);
         });
 
+        it("should execute callbacks for userLoaded event if there is a user stored and the raiseEvent parameter is true", async () => {
+            // arrange
+            const user = new User({
+                access_token: "access_token",
+                token_type: "token_type",
+                profile: {} as UserProfile,
+            });
+            subject["_loadUser"] = jest.fn().mockReturnValue(user);
+            const cb = jest.fn();
+            subject.events.addUserLoaded(cb);
+
+            // act
+            await subject.getUser(true);
+
+            // assert
+            expect(cb).toHaveBeenCalled();
+        });
+
+        it("should not execute callbacks for userLoaded event if there is a user stored and the raiseEvent parameter is false", async () => {
+            // arrange
+            const user = new User({
+                access_token: "access_token",
+                token_type: "token_type",
+                profile: {} as UserProfile,
+            });
+            subject["_loadUser"] = jest.fn().mockReturnValue(user);
+            const cb = jest.fn();
+            subject.events.addUserLoaded(cb);
+
+            // act
+            await subject.getUser(false);
+
+            // assert
+            expect(cb).not.toHaveBeenCalled();
+        });
+
+        it("should not execute callbacks for userLoaded event if there is a user stored and the raiseEvent parameter is not defined", async () => {
+            // arrange
+            const user = new User({
+                access_token: "access_token",
+                token_type: "token_type",
+                profile: {} as UserProfile,
+            });
+            subject["_loadUser"] = jest.fn().mockReturnValue(user);
+            const cb = jest.fn();
+            subject.events.addUserLoaded(cb);
+
+            // act
+            await subject.getUser();
+
+            // assert
+            expect(cb).not.toHaveBeenCalled();
+        });
+
         it("should return null if there is no user stored", async () => {
             // arrange
             subject["_loadUser"] = jest.fn().mockReturnValue(null);

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -131,14 +131,15 @@ export class UserManager {
     /**
      * Load the `User` object for the currently authenticated user.
      *
+     * @param raiseEvent If `true`, the `UserLoaded` event will be raised. Defaults to false.
      * @returns A promise
      */
-    public async getUser(): Promise<User | null> {
+    public async getUser(raiseEvent = false): Promise<User | null> {
         const logger = this._logger.create("getUser");
         const user = await this._loadUser();
         if (user) {
             logger.info("user loaded");
-            await this._events.load(user, false);
+            await this._events.load(user, raiseEvent);
             return user;
         }
 


### PR DESCRIPTION
## Description

Relates to #712 and provides a solution that is backwards-compatible and will fix an issue for some users.

Adding a new parameter `raiseEvent = false` to the `UserManager.getUser()` method to allow execute the `addUserLoaded()` event handlers after raising the `userLoaded` event.

**Background**: The `userLoaded` event does currently not get raised whenever the `user` value is being read from the local storage, which happens whenever no user data has to be fetched from the authority but from the store. In #712 developers complained about this behavior since some business-logic depends on the `getUser()`/`userLoaded` method/event for .e.g. loading additional user-related data from third-party sources like APIs. In the case that a user is already authenticated and e.g. reloads the page, the storage provides the `getUser()` data but does not raise the `userLoaded` event anymore. That will break the described business-logic and must be avoided with a workaround, e.g. using `Proxy()` which is not preferred as the optimal solution (see https://github.com/authts/oidc-client-ts/issues/712#issuecomment-2601945064 for an implementation example with `Proxy()`).

This solution allows raising the event on purpose whenever the parameter is set to handle further business logic after checking for a users authentication.

## Tests

Added unit-tests for the new parameter which is by default set to `false`.