### PR TITLE
Add url_state to SignoutRequest

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -855,7 +855,7 @@ export type SignoutRedirectArgs = RedirectParams & ExtraSignoutRequestArgs;
 
 // @public (undocumented)
 export class SignoutRequest {
-    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, client_id, }: SignoutRequestArgs);
+    constructor({ url, state_data, id_token_hint, post_logout_redirect_uri, extraQueryParams, request_type, client_id, url_state, }: SignoutRequestArgs);
     // (undocumented)
     readonly state?: State;
     // (undocumented)
@@ -877,6 +877,8 @@ export interface SignoutRequestArgs {
     state_data?: unknown;
     // (undocumented)
     url: string;
+    // (undocumented)
+    url_state?: string;
 }
 
 // @public (undocumented)
@@ -890,6 +892,8 @@ export class SignoutResponse {
     error_uri: string | null;
     // (undocumented)
     readonly state: string | null;
+    // (undocumented)
+    url_state?: string;
     userState: unknown;
 }
 

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -108,7 +108,7 @@ export type ExtraHeader = string | (() => string);
 export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state" | "redirect_uri" | "prompt" | "acr_values" | "login_hint" | "scope" | "max_age" | "ui_locales" | "resource" | "url_state">;
 
 // @public (undocumented)
-export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;
+export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri" | "url_state">;
 
 // Warning: (ae-forgotten-export) The symbol "Mandatory" needs to be exported by the entry point index.d.ts
 //
@@ -336,7 +336,7 @@ export class OidcClient {
     // (undocumented)
     createSigninRequest({ state, request, request_uri, request_type, id_token_hint, login_hint, skipUserInfo, nonce, url_state, response_type, scope, redirect_uri, prompt, display, max_age, ui_locales, acr_values, resource, response_mode, extraQueryParams, extraTokenParams, dpopJkt, omitScopeWhenRequesting, }: CreateSigninRequestArgs): Promise<SigninRequest>;
     // (undocumented)
-    createSignoutRequest({ state, id_token_hint, client_id, request_type, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
+    createSignoutRequest({ state, id_token_hint, client_id, request_type, url_state, post_logout_redirect_uri, extraQueryParams, }?: CreateSignoutRequestArgs): Promise<SignoutRequest>;
     // (undocumented)
     getDpopProof(dpopStore: DPoPStore, nonce?: string): Promise<string>;
     // (undocumented)

--- a/src/OidcClient.test.ts
+++ b/src/OidcClient.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { CryptoUtils, JwtUtils } from "./utils";
+import { CryptoUtils, JwtUtils, URL_STATE_DELIMITER } from "./utils";
 import type { ErrorResponse } from "./errors";
 import type { JwtClaims } from "./Claims";
 import { OidcClient } from "./OidcClient";
@@ -838,6 +838,7 @@ describe("OidcClient", () => {
                 state: "foo",
                 post_logout_redirect_uri: "bar",
                 id_token_hint: "baz",
+                url_state: "qux",
             });
 
             // assert
@@ -847,6 +848,7 @@ describe("OidcClient", () => {
             expect(url).toContain("http://sts/signout");
             expect(url).toContain("post_logout_redirect_uri=bar");
             expect(url).toContain("id_token_hint=baz");
+            expect(url).toContain(encodeURIComponent(URL_STATE_DELIMITER + "qux"));
         });
 
         it("should pass params to SignoutRequest w/o id_token_hint and client_id", async () => {

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -331,6 +331,7 @@ export class OidcClient {
         id_token_hint,
         client_id,
         request_type,
+        url_state,
         post_logout_redirect_uri = this.settings.post_logout_redirect_uri,
         extraQueryParams = this.settings.extraQueryParams,
     }: CreateSignoutRequestArgs = {}): Promise<SignoutRequest> {
@@ -358,6 +359,7 @@ export class OidcClient {
             state_data: state,
             extraQueryParams,
             request_type,
+            url_state,
         });
 
         // house cleaning

--- a/src/SignoutRequest.test.ts
+++ b/src/SignoutRequest.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { SignoutRequest, type SignoutRequestArgs } from "./SignoutRequest";
+import { URL_STATE_DELIMITER } from "./utils";
 
 describe("SignoutRequest", () => {
 
@@ -70,9 +71,45 @@ describe("SignoutRequest", () => {
             expect(subject.url).toContain("state=" + subject.state!.id);
         });
 
+        it("should include state if post_logout_redirect_uri and url_state provided even if state_data is empty", () => {
+            // arrange
+            delete settings.state_data;
+            settings.url_state = "foo";
+
+            // act
+            subject = new SignoutRequest(settings);
+
+            // assert
+            expect(subject.state).toBeDefined();
+            expect(subject.url).toContain("state=" + subject.state!.id + encodeURIComponent(URL_STATE_DELIMITER + "foo"));
+        });
+
         it("should not include state if no post_logout_redirect_uri provided", () => {
             // arrange
             delete settings.post_logout_redirect_uri;
+
+            // act
+            subject = new SignoutRequest(settings);
+
+            // assert
+            expect(subject.url).not.toContain("state=");
+        });
+        
+        it("should include url_state", async () => {
+            // arrange
+            settings.url_state = "foo";
+
+            // act
+            subject = new SignoutRequest(settings);
+
+            // assert
+            expect(subject.url).toContain("state=" + subject.state!.id + encodeURIComponent(URL_STATE_DELIMITER + "foo"));
+        });
+
+        it("should not include state or url_state if no post_logout_redirect_uri provided", () => {
+            // arrange
+            delete settings.post_logout_redirect_uri;
+            settings.url_state = "foo";
 
             // act
             subject = new SignoutRequest(settings);

--- a/src/SignoutResponse.test.ts
+++ b/src/SignoutResponse.test.ts
@@ -38,5 +38,14 @@ describe("SignoutResponse", () => {
             // assert
             expect(subject.state).toEqual("foo");
         });
+        
+        it("should read url_state", () => {
+            // act
+            const subject = new SignoutResponse(new URLSearchParams("state=foo;bar"));
+
+            // assert
+            expect(subject.state).toEqual("foo");
+            expect(subject.url_state).toEqual("bar");
+        });
     });
 });

--- a/src/SignoutResponse.ts
+++ b/src/SignoutResponse.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+import { URL_STATE_DELIMITER } from "./utils";
+
 /**
  * @public
  * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthError
@@ -18,9 +20,17 @@ export class SignoutResponse {
 
     /** custom state data set during the initial signin request */
     public userState: unknown;
+    public url_state?: string;
 
     public constructor(params: URLSearchParams) {
         this.state = params.get("state");
+        if (this.state) {
+            const splitState = decodeURIComponent(this.state).split(URL_STATE_DELIMITER);
+            this.state = splitState[0];
+            if (splitState.length > 1) {
+                this.url_state = splitState.slice(1).join(URL_STATE_DELIMITER);
+            }
+        }
 
         this.error = params.get("error");
         this.error_description = params.get("error_description");

--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -1001,6 +1001,7 @@ describe("UserManager", () => {
                 extraQueryParams: { q : "q" },
                 state: "state",
                 post_logout_redirect_uri: "http://app/extra_callback",
+                url_state: "foo",
             };
 
             // act

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -25,7 +25,7 @@ export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "ex
 /**
  * @public
  */
-export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri">;
+export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri" | "url_state">;
 
 /**
  * @public


### PR DESCRIPTION
Extends the fix added for #293 in PR https://github.com/authts/oidc-client-ts/pull/1212 to also cover sign out.

For background I believe the same principles regarding `state` for sign in within the linked issue also apply in the sign out case as well. I am working with a multi-tenant system that has a proxy to resolve the actual hostname for the redirect_uri, which also needs to send a signed-out user back to the application start page on the right hostname.

Without this fix, I would need to configure every potential hostname as a valid redirect URI in the IDP client config (whilst I think Keycloak can allow wildcards, it's not recommended and others such as Entra ID do not).

This change replicates the concatenated internal opaque state value with a custom `url_state` value and delimiter as used in sign in. Tests have been added to ensure the `url_state` can still be added even if the sign out request does not need to persist any client state.

Apologies for not raising an issue first, in tweaking the code to see if it was viable I basically had the PR already written.

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
