### PR TITLE
fix: Resource Owner Password Credentials flow with oidc scope and no id_token returned will fail sub claim check

### DIFF
--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -610,6 +610,22 @@ describe("ResponseValidator", () => {
 
         });
 
+        it("should process an openid signin response without an id_token and userinfo containing sub property, as a non-openid signin response", async () => {
+            Object.assign(stubResponse, {
+                access_token: "access_token",
+                isOpenId: true,
+            });
+
+            jest.spyOn(subject["_userInfoService"], "getClaims").mockResolvedValue({
+                nickname: "Nick",
+                sub: "subsub",
+            });
+
+            // act
+
+            await expect(subject.validateCredentialsResponse(stubResponse, false)).resolves.toBeUndefined();
+        });
+
         it("should process a valid non-openid signin response skipping userInfo", async () => {
             // arrange
             Object.assign(stubResponse, {

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -53,13 +53,14 @@ export class ResponseValidator {
 
     public async validateCredentialsResponse(response: SigninResponse, skipUserInfo: boolean): Promise<void> {
         const logger = this._logger.create("validateCredentialsResponse");
+        const shouldValidateSubClaim = response.isOpenId && !!response.id_token;
 
-        if (response.isOpenId && !!response.id_token) {
+        if (shouldValidateSubClaim) {
             this._validateIdTokenAttributes(response);
         }
         logger.debug("tokens validated");
 
-        await this._processClaims(response, skipUserInfo, response.isOpenId);
+        await this._processClaims(response, skipUserInfo, shouldValidateSubClaim);
         logger.debug("claims processed");
     }
 


### PR DESCRIPTION
If we have a Resource Owner Password Flow and token endpoint does not return `token_id` in the response while returning scope: `openid` it will fail the sub claim check.
```
        if (validateSub && claims.sub !== response.profile.sub) {
            logger.throw(new Error("subject from UserInfo response does not match subject in ID Token"));
        }
```
After some investigation, i noticed that if we don't have token_id ``_validateIdTokenAttributes`` will be skipped which means that ``response.profile`` will always be an empty object and always fail the check ``(validateSub && claims.sub !== response.profile.sub)``
