### PR TITLE
feat(signinSilent): enable enforcement of iframe auth flow

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -108,6 +108,11 @@ export type ExtraHeader = string | (() => string);
 export type ExtraSigninRequestArgs = Pick<CreateSigninRequestArgs, "nonce" | "extraQueryParams" | "extraTokenParams" | "state" | "redirect_uri" | "prompt" | "acr_values" | "login_hint" | "scope" | "max_age" | "ui_locales" | "resource" | "url_state">;
 
 // @public (undocumented)
+export type ExtraSignInSilentArgs = {
+    forceIframeAuth?: boolean;
+};
+
+// @public (undocumented)
 export type ExtraSignoutRequestArgs = Pick<CreateSignoutRequestArgs, "extraQueryParams" | "state" | "id_token_hint" | "post_logout_redirect_uri" | "url_state">;
 
 // Warning: (ae-forgotten-export) The symbol "Mandatory" needs to be exported by the entry point index.d.ts
@@ -778,7 +783,7 @@ export class SigninResponse {
 }
 
 // @public (undocumented)
-export type SigninSilentArgs = IFrameWindowParams & ExtraSigninRequestArgs;
+export type SigninSilentArgs = IFrameWindowParams & ExtraSigninRequestArgs & ExtraSignInSilentArgs;
 
 // @public (undocumented)
 export class SigninState extends State {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -45,7 +45,15 @@ export type SigninPopupArgs = PopupWindowParams & ExtraSigninRequestArgs;
 /**
  * @public
  */
-export type SigninSilentArgs = IFrameWindowParams & ExtraSigninRequestArgs;
+export type ExtraSignInSilentArgs = { 
+    // forceIframeAuth bypasses refresh token usage and forces iframe-based silent authentication
+    forceIframeAuth?: boolean;
+};
+
+/**
+ * @public
+ */
+export type SigninSilentArgs = IFrameWindowParams & ExtraSigninRequestArgs & ExtraSignInSilentArgs;
 
 /**
  * @public
@@ -308,7 +316,8 @@ export class UserManager {
         } = args;
         // first determine if we have a refresh token, or need to use iframe
         let user = await this._loadUser();
-        if (user?.refresh_token) {
+        // use refresh token unless forceIframeAuth is explicitly true
+        if (!args.forceIframeAuth && user?.refresh_token) {
             logger.debug("using refresh token");
             const state = new RefreshState(user as Required<User>);
             return await this._useRefreshToken({


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Closes #1890

Adds the option to enforce the iframe auth flow during the silent sign-in.

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers

@pamapa I tried to follow the conventions I could gather from the rest of the code. Please let me know if you want anything changed. This addition should be purely opt-in.
