### PR TITLE
fix(RedirectNavigator): wait until the page is shown again to resolve

### DIFF
--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { once } from "events";
 import {
     RedirectNavigator,
     type PopupWindow,
@@ -325,13 +324,7 @@ describe("UserManager", () => {
     describe("signinRedirect", () => {
         it("should redirect the browser to the authorize url", async () => {
             // act
-            const spy = jest.fn();
-            void subject.signinRedirect().finally(spy);
-
-            // signinRedirect is a promise that will never resolve (since we
-            // want it to hold until the page has redirected), so we wait for
-            // the browser unload event before checking the test assertions.
-            await once(window, "unload");
+            await subject.signinRedirect();
 
             // assert
             expect(window.location.assign).toHaveBeenCalledWith(
@@ -341,9 +334,6 @@ describe("UserManager", () => {
             const state = new URL(location).searchParams.get("state");
             const item = await userStoreMock.get(state!);
             expect(JSON.parse(item!)).toHaveProperty("request_type", "si:r");
-
-            // We check to make sure the promise has not resolved
-            expect(spy).not.toHaveBeenCalled();
         });
 
         it("should pass navigator params to navigator", async () => {

--- a/src/navigators/RedirectNavigator.test.ts
+++ b/src/navigators/RedirectNavigator.test.ts
@@ -1,5 +1,4 @@
 import { mocked } from "jest-mock";
-import { once } from "events";
 import type { UserManagerSettingsStore } from "../UserManagerSettings";
 import { RedirectNavigator } from "./RedirectNavigator";
 
@@ -20,15 +19,9 @@ describe("RedirectNavigator", () => {
 
     it("should redirect to the authority server using a specific redirect method", async () => {
         const handle = await navigator.prepare({ redirectMethod: "replace" });
-        const spy = jest.fn();
-        void handle.navigate({ url: "http://sts/authorize" }).finally(spy);
+        await handle.navigate({ url: "http://sts/authorize" });
 
         expect(window.location.replace).toHaveBeenCalledWith("http://sts/authorize");
-
-        // We check that the promise does not resolve even after the window
-        // unload event
-        await once(window, "unload");
-        expect(spy).not.toHaveBeenCalled();
     });
 
     it("should redirect to the authority server from window top", async () => {
@@ -48,11 +41,6 @@ describe("RedirectNavigator", () => {
         expect(window.location.assign).toHaveBeenCalledTimes(0);
         expect(window.parent.location.assign).toHaveBeenCalledTimes(0);
         expect(window.top!.location.assign).toHaveBeenCalledWith("http://sts/authorize");
-
-        // We check that the promise does not resolve even after the window
-        // unload event
-        await once(window, "unload");
-        expect(spy).not.toHaveBeenCalled();
     });
 
     it("should reject when the navigation is stopped programmatically", async () => {

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -38,9 +38,9 @@ export class RedirectNavigator implements INavigator {
         return {
             navigate: async (params): Promise<never> => {
                 this._logger.create("navigate");
-                // We use a promise that never resolves to block the caller
                 const promise = new Promise((resolve, reject) => {
                     abort = reject;
+                    window.addEventListener("unload", () => resolve(null));
                 });
                 redirect(params.url);
                 return await (promise as Promise<never>);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,17 +10,17 @@ beforeAll(() => {
     });
     globalThis.fetch = jest.fn();
 
-    const unload = () => window.dispatchEvent(new Event("unload"));
+    const pageshow = () => window.dispatchEvent(new Event("pageshow"));
 
     const location = Object.defineProperties({}, {
         ...Object.getOwnPropertyDescriptors(window.location),
         assign: {
             enumerable: true,
-            value: jest.fn(unload),
+            value: jest.fn(pageshow),
         },
         replace: {
             enumerable: true,
-            value: jest.fn(unload),
+            value: jest.fn(pageshow),
         },
     });
     Object.defineProperty(window, "location", {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,23 +10,19 @@ beforeAll(() => {
     });
     globalThis.fetch = jest.fn();
 
-    const unload = () =>
-        setTimeout(() => window.dispatchEvent(new Event("unload")), 200);
+    const unload = () => window.dispatchEvent(new Event("unload"));
 
-    const location = Object.defineProperties(
-        {},
-        {
-            ...Object.getOwnPropertyDescriptors(window.location),
-            assign: {
-                enumerable: true,
-                value: jest.fn(unload),
-            },
-            replace: {
-                enumerable: true,
-                value: jest.fn(unload),
-            },
+    const location = Object.defineProperties({}, {
+        ...Object.getOwnPropertyDescriptors(window.location),
+        assign: {
+            enumerable: true,
+            value: jest.fn(unload),
         },
-    );
+        replace: {
+            enumerable: true,
+            value: jest.fn(unload),
+        },
+    });
     Object.defineProperty(window, "location", {
         enumerable: true,
         get: () => location,


### PR DESCRIPTION
Currently, the redirect navigator blocks indefinitely after making a redirection. In certain cases, this is fine and doesn't create any issues as the main page will either be reloaded fully during a back navigation, or a new redirection will be made after signing in. However, if the main page supports bfcache and the user navigates back without signing in, the execution gets blocked and can't continue. This is an issue as seen in authts/react-oidc-context#1243, where when disabling cache, the issue is gone. To solve this, I brought an event wait back but this time used the pageshow event. This works with bfcache and ensures execution won't continue until the actual page is shown again. This _should_ ensure that the issues seen in #499, #330, and #329 don't come up again. The earlier of these PR's were based off unload which still allowed some execution to happen right away. Using pageshow here doesn't allow any execution until the page is shown again.

Also, this navigator returns the URL after navigating back, which isn't necessary, however, I did this to avoid changes to the public API and was unsure of what would be best. If it'd be better to change NavigateResponse's url to an optional parameter or whatnot, that can be changed.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [X] I have included links for closing relevant issue numbers