### PR TITLE
fix(UserManager): forward popupAbortOnClose to PopupNavigator.prepare

### DIFF
--- a/src/UserManager.test.ts
+++ b/src/UserManager.test.ts
@@ -493,13 +493,14 @@ describe("UserManager", () => {
                     height: 100,
                 },
                 popupWindowTarget: "popupWindowTarget",
+                popupAbortOnClose: true,
             };
 
             // act
             await subject.signinPopup(navParams);
 
             // assert
-            expect(prepareMock).toHaveBeenCalledWith(navParams);
+            expect(prepareMock).toHaveBeenCalledWith(expect.objectContaining(navParams));
         });
 
         it("should pass extra args to _signinStart", async () => {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -263,6 +263,7 @@ export class UserManager {
             popupWindowFeatures,
             popupWindowTarget,
             popupSignal,
+            popupAbortOnClose,
             ...requestArgs
         } = args;
         const url = this.settings.popup_redirect_uri;
@@ -270,7 +271,7 @@ export class UserManager {
             logger.throw(new Error("No popup_redirect_uri configured"));
         }
 
-        const handle = await this._popupNavigator.prepare({ popupWindowFeatures, popupWindowTarget, popupSignal });
+        const handle = await this._popupNavigator.prepare({ popupWindowFeatures, popupWindowTarget, popupSignal, popupAbortOnClose });
         const user = await this._signin({
             request_type: "si:p",
             redirect_uri: url,


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->
Follow-up to #2244
Original issue: #2043

Forward `popupAbortOnClose` from `UserManager.signinPopup` to `PopupNavigator.prepare`; when enabled, closing the popup rejects the navigation promise.

### Checklist

- [ ] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
