### PR TITLE
feat(SilentRenewService): add maxSilentRenewTimeoutRetries configuration

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -1120,6 +1120,7 @@ export interface UserManagerSettings extends OidcClientSettings {
     iframeScriptOrigin?: string;
     includeIdTokenInSilentRenew?: boolean;
     includeIdTokenInSilentSignout?: boolean;
+    maxSilentRenewTimeoutRetries?: number;
     // (undocumented)
     monitorAnonymousSession?: boolean;
     monitorSession?: boolean;
@@ -1159,6 +1160,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     readonly includeIdTokenInSilentRenew: boolean;
     // (undocumented)
     readonly includeIdTokenInSilentSignout: boolean;
+    // (undocumented)
+    readonly maxSilentRenewTimeoutRetries?: number;
     // (undocumented)
     readonly monitorAnonymousSession: boolean;
     // (undocumented)

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -80,6 +80,13 @@ export interface UserManagerSettings extends OidcClientSettings {
     accessTokenExpiringNotificationTimeInSeconds?: number;
 
     /**
+     * Maximum number of timeout retries before raising silentRenewError event.
+     * Set to 0 to fail immediately on timeout.
+     * Undefined means infinite retries (maintains backward compatibility, default behavior).
+     */
+    maxSilentRenewTimeoutRetries?: number;
+
+    /**
      * Storage object used to persist User for currently authenticated user (default: window.sessionStorage, InMemoryWebStorage iff no window).
      *  E.g. `userStore: new WebStorageStateStore({ store: window.localStorage })`
      */
@@ -120,6 +127,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     public readonly includeIdTokenInSilentSignout: boolean;
 
     public readonly accessTokenExpiringNotificationTimeInSeconds: number;
+    public readonly maxSilentRenewTimeoutRetries?: number;
 
     public readonly userStore: StateStore;
 
@@ -154,6 +162,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
 
             accessTokenExpiringNotificationTimeInSeconds = DefaultAccessTokenExpiringNotificationTimeInSeconds,
 
+            maxSilentRenewTimeoutRetries,
+
             userStore,
         } = args;
 
@@ -186,6 +196,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
         this.includeIdTokenInSilentSignout = includeIdTokenInSilentSignout;
 
         this.accessTokenExpiringNotificationTimeInSeconds = accessTokenExpiringNotificationTimeInSeconds;
+        this.maxSilentRenewTimeoutRetries = maxSilentRenewTimeoutRetries;
 
         if (userStore) {
             this.userStore = userStore;


### PR DESCRIPTION
- Add maxSilentRenewTimeoutRetries property to UserManagerSettings
- Implement timeout retry counter in SilentRenewService
- Track failed timeout attempts and enforce configurable limit
- Reset counter on successful renewal or non-timeout errors
- Fire silentRenewError event when limit is reached
- Update API documentation

<!-- Please link relevant issue numbers or provide context for this change -->
Closes/fixes #2289

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [x] I have included links for closing relevant issue numbers
