### PR TITLE
Add nonce validation for ID tokens.

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -806,6 +806,8 @@ export class SigninState extends State {
     // (undocumented)
     static fromStorageString(storageString: string): Promise<SigninState>;
     // (undocumented)
+    readonly nonce: string | undefined;
+    // (undocumented)
     readonly redirect_uri: string;
     // (undocumented)
     readonly response_mode: "query" | "fragment" | undefined;
@@ -837,6 +839,8 @@ export interface SigninStateArgs {
     extraTokenParams?: Record<string, unknown>;
     // (undocumented)
     id?: string;
+    // (undocumented)
+    nonce?: string;
     // (undocumented)
     redirect_uri: string;
     // (undocumented)

--- a/src/ResponseValidator.test.ts
+++ b/src/ResponseValidator.test.ts
@@ -549,6 +549,44 @@ describe("ResponseValidator", () => {
             expect(JwtUtils.decode).toHaveBeenCalledWith("id_token");
             expect(stubResponse).not.toHaveProperty("profile");
         });
+
+        it("should fail if nonce is in state and does not match", async () => {
+            // arrange
+            Object.assign(stubResponse, {
+                id_token: "id_token",
+                isOpenId: true,
+            });
+            jest.spyOn(JwtUtils, "decode").mockReturnValue({ sub: "sub", nonce: "invalid" });
+            Object.assign(stubState, { nonce: "rnd" });
+
+            // act
+            await expect(
+                subject.validateSigninResponse(stubResponse, stubState),
+            )
+                // assert
+                .rejects.toThrow("nonce in id_token does not match nonce in client storage");
+            expect(JwtUtils.decode).toHaveBeenCalledWith("id_token");
+            expect(stubResponse).not.toHaveProperty("profile");
+        });
+
+        it("should fail if nonce is in state and not in token", async () => {
+            // arrange
+            Object.assign(stubResponse, {
+                id_token: "id_token",
+                isOpenId: true,
+            });
+            jest.spyOn(JwtUtils, "decode").mockReturnValue({ sub: "sub" });
+            Object.assign(stubState, { nonce: "rnd" });
+
+            // act
+            await expect(
+                subject.validateSigninResponse(stubResponse, stubState),
+            )
+                // assert
+                .rejects.toThrow("nonce in id_token does not match nonce in client storage");
+            expect(JwtUtils.decode).toHaveBeenCalledWith("id_token");
+            expect(stubResponse).not.toHaveProperty("profile");
+        });
     });
 
     describe("validateCredentialsResponse", () => {

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -43,7 +43,7 @@ export class ResponseValidator {
         logger.debug("code processed");
 
         if (response.isOpenId) {
-            this._validateIdTokenAttributes(response);
+            this._validateIdTokenAttributes(response, "", state.nonce);
         }
         logger.debug("tokens validated");
 
@@ -192,7 +192,7 @@ export class ResponseValidator {
         }
     }
 
-    protected _validateIdTokenAttributes(response: SigninResponse, existingToken?: string): void {
+    protected _validateIdTokenAttributes(response: SigninResponse, existingToken?: string, nonce?: string): void {
         const logger = this._logger.create("_validateIdTokenAttributes");
 
         logger.debug("decoding ID Token JWT");
@@ -200,6 +200,10 @@ export class ResponseValidator {
 
         if (!incoming.sub) {
             logger.throw(new Error("ID Token is missing a subject claim"));
+        }
+
+        if (nonce && incoming.nonce !== nonce) {
+            logger.throw(new Error("nonce in id_token does not match nonce in client storage"));
         }
 
         if (existingToken) {

--- a/src/SigninRequest.test.ts
+++ b/src/SigninRequest.test.ts
@@ -282,6 +282,17 @@ describe("SigninRequest", () => {
             expect(url).toContain("nonce=");
         });
 
+        it("should store nonce in state", async () => {
+            // arrange
+            settings.nonce = "random_nonce";
+
+            // act
+            subject = await SigninRequest.create(settings);
+
+            // assert
+            expect(subject.state.nonce).toEqual("random_nonce");
+        });
+
         it("should include url_state", async () => {
             // arrange
             settings.url_state = "foo";

--- a/src/SigninRequest.ts
+++ b/src/SigninRequest.ts
@@ -112,6 +112,7 @@ export class SigninRequest {
             response_mode,
             client_secret, scope, extraTokenParams,
             skipUserInfo,
+            nonce,
         });
 
         const parsedUrl = new URL(url);

--- a/src/SigninState.test.ts
+++ b/src/SigninState.test.ts
@@ -147,6 +147,21 @@ describe("SigninState", () => {
             // assert
             expect(subject.extraTokenParams).toEqual({ "resourceServer" : "abc" });
         });
+
+        it("should accept nonce", async () => {
+            // act
+            const subject = await SigninState.create({
+                authority: "authority",
+                client_id: "client",
+                redirect_uri: "http://cb",
+                scope: "scope",
+                request_type: "type",
+                nonce: "rnd",
+            });
+
+            // assert
+            expect(subject.nonce).toEqual("rnd");
+        });
     });
 
     it("can serialize and then deserialize", async () => {
@@ -160,6 +175,7 @@ describe("SigninState", () => {
             redirect_uri: "http://cb",
             scope: "scope",
             request_type: "type",
+            nonce: "rnd",
         });
 
         // act

--- a/src/SigninState.ts
+++ b/src/SigninState.ts
@@ -22,6 +22,7 @@ export interface SigninStateArgs {
     response_mode?: "query" | "fragment";
     skipUserInfo?: boolean;
     url_state?: string;
+    nonce?: string;
 }
 
 /** @public */
@@ -56,6 +57,8 @@ export class SigninState extends State {
     public readonly response_mode: "query" | "fragment" | undefined;
 
     public readonly skipUserInfo: boolean | undefined;
+    /** @see {@link SigninRequestCreateArgs.nonce} */
+    public readonly nonce: string | undefined;
 
     private constructor(args: SigninStateArgs) {
         super(args);
@@ -71,6 +74,7 @@ export class SigninState extends State {
 
         this.response_mode = args.response_mode;
         this.skipUserInfo = args.skipUserInfo;
+        this.nonce = args.nonce;
     }
 
     public static async create(args: SigninStateCreateArgs): Promise<SigninState> {
@@ -102,6 +106,7 @@ export class SigninState extends State {
             extraTokenParams : this.extraTokenParams,
             response_mode: this.response_mode,
             skipUserInfo: this.skipUserInfo,
+            nonce: this.nonce,
         });
     }
 


### PR DESCRIPTION
https://github.com/authts/oidc-client-ts/pull/439 added support for forwarding a nonce through the authentication request. This builds on that to store the given nonce in the SigninState and use it to validate the `nonce` claim on the received ID token to ensure that it matches and prevent replay attacks.

I'm still not super familiar with the library internals here so lemme know if ya'll want any changes and I'd be happy to make em. Thank you!

### Checklist

- [x] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [ ] I have included links for closing relevant issue numbers
