### PR TITLE
Allow extraTokenParams in UserManager.signinSilent()  [V2]

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -333,7 +333,7 @@ export class OidcClient {
     // (undocumented)
     protected readonly _tokenClient: TokenClient;
     // (undocumented)
-    useRefreshToken({ state, timeoutInSeconds, }: UseRefreshTokenArgs): Promise<SigninResponse>;
+    useRefreshToken({ state, timeoutInSeconds, extraTokenParams, }: UseRefreshTokenArgs): Promise<SigninResponse>;
     // Warning: (ae-forgotten-export) The symbol "ResponseValidator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -909,6 +909,8 @@ export class User {
 // @public (undocumented)
 export interface UseRefreshTokenArgs {
     // (undocumented)
+    extraTokenParams?: Record<string, unknown>;
+    // (undocumented)
     state: RefreshState;
     // (undocumented)
     timeoutInSeconds?: number;
@@ -987,7 +989,7 @@ export class UserManager {
     // (undocumented)
     storeUser(user: User | null): Promise<void>;
     // (undocumented)
-    protected _useRefreshToken(state: RefreshState): Promise<User>;
+    protected _useRefreshToken(args: UseRefreshTokenArgs): Promise<User>;
     // (undocumented)
     protected get _userStoreKey(): string;
 }

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -35,6 +35,7 @@ export interface CreateSigninRequestArgs
 export interface UseRefreshTokenArgs {
     state: RefreshState;
     timeoutInSeconds?: number;
+    extraTokenParams?: Record<string, unknown>;
 }
 
 /**
@@ -185,6 +186,7 @@ export class OidcClient {
     public async useRefreshToken({
         state,
         timeoutInSeconds,
+        extraTokenParams,
     }: UseRefreshTokenArgs): Promise<SigninResponse> {
         const logger = this._logger.create("useRefreshToken");
 
@@ -207,6 +209,7 @@ export class OidcClient {
             // provide the (possible filtered) scope list
             scope,
             timeoutInSeconds,
+            ...extraTokenParams,
         });
         const response = new SigninResponse(new URLSearchParams());
         Object.assign(response, result);

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -4,7 +4,7 @@
 import { Logger } from "./utils";
 import { ErrorResponse } from "./errors";
 import { type NavigateResponse, type PopupWindowParams, type IWindow, type IFrameWindowParams, type RedirectParams, RedirectNavigator, PopupNavigator, IFrameNavigator, type INavigator } from "./navigators";
-import { OidcClient, type CreateSigninRequestArgs, type CreateSignoutRequestArgs, type ProcessResourceOwnerPasswordCredentialsArgs } from "./OidcClient";
+import { OidcClient, type CreateSigninRequestArgs, type CreateSignoutRequestArgs, type ProcessResourceOwnerPasswordCredentialsArgs, type UseRefreshTokenArgs } from "./OidcClient";
 import { type UserManagerSettings, UserManagerSettingsStore } from "./UserManagerSettings";
 import { User } from "./User";
 import { UserManagerEvents } from "./UserManagerEvents";
@@ -263,8 +263,7 @@ export class UserManager {
         if (user?.refresh_token) {
             logger.debug("using refresh token");
             const state = new RefreshState(user as Required<User>, resource);
-            return await this._useRefreshToken(state);
-        }
+            return await this._useRefreshToken({ state, extraTokenParams: requestArgs.extraTokenParams }); }
 
         const url = this.settings.silent_redirect_uri;
         if (!url) {
@@ -297,12 +296,12 @@ export class UserManager {
         return user;
     }
 
-    protected async _useRefreshToken(state: RefreshState): Promise<User> {
+    protected async _useRefreshToken(args: UseRefreshTokenArgs): Promise<User> {
         const response = await this._client.useRefreshToken({
-            state,
+            ...args,
             timeoutInSeconds: this.settings.silentRequestTimeoutInSeconds,
         });
-        const user = new User({ ...state, ...response });
+        const user = new User({ ...args.state, ...response });
 
         await this.storeUser(user);
         this._events.load(user);


### PR DESCRIPTION
<!-- Please link relevant issue numbers or provide context for this change -->

Backports allowing extraTokenParams in UserManager.signinSilent() to v2, as discussed recently here: https://github.com/authts/oidc-client-ts/issues/1257

### Checklist

- [X] This PR makes changes to the public API <!-- was the API report (docs/oidc-client-ts.api.md) updated by this PR? -->
- [X] I have included links for closing relevant issue numbers
- ^ relevant link included, no unique corresponding issue
