### PR TITLE
Support custom iframe attributes for silent signin

### DIFF
--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -132,6 +132,8 @@ export interface IdTokenClaims extends Mandatory<OidcStandardClaims, "sub">, Man
 // @public (undocumented)
 export interface IFrameWindowParams {
     // (undocumented)
+    iframeAttributes?: Record<string, string>;
+    // (undocumented)
     silentRequestTimeoutInSeconds?: number;
 }
 
@@ -1120,6 +1122,7 @@ export interface UserManagerSettings extends OidcClientSettings {
     accessTokenExpiringNotificationTimeInSeconds?: number;
     automaticSilentRenew?: boolean;
     checkSessionIntervalInSeconds?: number;
+    iframeAttributes?: Record<string, string> | undefined;
     iframeNotifyParentOrigin?: string;
     iframeScriptOrigin?: string;
     includeIdTokenInSilentRenew?: boolean;
@@ -1156,6 +1159,8 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     readonly automaticSilentRenew: boolean;
     // (undocumented)
     readonly checkSessionIntervalInSeconds: number;
+    // (undocumented)
+    readonly iframeAttributes?: Record<string, string>;
     // (undocumented)
     readonly iframeNotifyParentOrigin: string | undefined;
     // (undocumented)

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -45,7 +45,7 @@ export type SigninPopupArgs = PopupWindowParams & ExtraSigninRequestArgs;
 /**
  * @public
  */
-export type ExtraSignInSilentArgs = { 
+export type ExtraSignInSilentArgs = {
     // forceIframeAuth bypasses refresh token usage and forces iframe-based silent authentication
     forceIframeAuth?: boolean;
 };
@@ -313,6 +313,7 @@ export class UserManager {
         const logger = this._logger.create("signinSilent");
         const {
             silentRequestTimeoutInSeconds,
+            iframeAttributes,
             ...requestArgs
         } = args;
         // first determine if we have a refresh token, or need to use iframe
@@ -346,7 +347,7 @@ export class UserManager {
             verifySub = user.profile.sub;
         }
 
-        const handle = await this._iframeNavigator.prepare({ silentRequestTimeoutInSeconds });
+        const handle = await this._iframeNavigator.prepare({ silentRequestTimeoutInSeconds, iframeAttributes });
         user = await this._signin({
             request_type: "si:s",
             redirect_uri: url,

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -17,6 +17,7 @@ export const DefaultPopupTarget = "_blank";
 const DefaultAccessTokenExpiringNotificationTimeInSeconds = 60;
 const DefaultCheckSessionIntervalInSeconds = 2;
 export const DefaultSilentRequestTimeoutInSeconds = 10;
+export const DefaultIFrameAttributes = undefined;
 
 /**
  * The settings used to configure the {@link UserManager}.
@@ -45,6 +46,11 @@ export interface UserManagerSettings extends OidcClientSettings {
 
     /** The script origin to check during 'message' callback execution while performing silent auth via iframe (default: window.location.origin) */
     iframeScriptOrigin?: string;
+
+    /**
+     * Defines additional attributes to add to iframe used by silent login.
+     */
+    iframeAttributes?: Record<string, string> | undefined;
 
     /** The URL for the page containing the code handling the silent renew */
     silent_redirect_uri?: string;
@@ -112,6 +118,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
 
     public readonly silent_redirect_uri: string;
     public readonly silentRequestTimeoutInSeconds: number;
+    public readonly iframeAttributes?: Record<string, string>;
     public readonly automaticSilentRenew: boolean;
     public readonly validateSubOnSilentRenew: boolean;
     public readonly includeIdTokenInSilentRenew: boolean;
@@ -142,6 +149,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
 
             iframeNotifyParentOrigin = args.iframeNotifyParentOrigin,
             iframeScriptOrigin = args.iframeScriptOrigin,
+            iframeAttributes = args.iframeAttributes,
 
             requestTimeoutInSeconds,
             silent_redirect_uri = args.redirect_uri,
@@ -178,6 +186,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
 
         this.iframeNotifyParentOrigin = iframeNotifyParentOrigin;
         this.iframeScriptOrigin = iframeScriptOrigin;
+        this.iframeAttributes = iframeAttributes;
 
         this.silent_redirect_uri = silent_redirect_uri;
         this.silentRequestTimeoutInSeconds = silentRequestTimeoutInSeconds || requestTimeoutInSeconds || DefaultSilentRequestTimeoutInSeconds;

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -16,8 +16,9 @@ export class IFrameNavigator implements INavigator {
 
     public async prepare({
         silentRequestTimeoutInSeconds = this._settings.silentRequestTimeoutInSeconds,
+        iframeAttributes = this._settings.iframeAttributes,
     }: IFrameWindowParams): Promise<IFrameWindow> {
-        return new IFrameWindow({ silentRequestTimeoutInSeconds });
+        return new IFrameWindow({ silentRequestTimeoutInSeconds, iframeAttributes });
     }
 
     public async callback(url: string): Promise<void> {

--- a/src/navigators/IFrameWindow.test.ts
+++ b/src/navigators/IFrameWindow.test.ts
@@ -42,6 +42,21 @@ describe("IFrameWindow", () => {
         });
     });
 
+    describe("attributes", () => {
+        let frameWindow: IFrameWindow;
+
+        beforeAll(() => {
+            frameWindow = new IFrameWindow({ iframeAttributes: { "allow": "local-network-access *", "another_attr": "another_value" } });
+        });
+
+        it("should have custom attributes", () => {
+            const allow = frameWindow["_frame"]!.getAttribute("allow");
+            const anotherAttr = frameWindow["_frame"]!.getAttribute("another_attr");
+            expect(allow).toBe("local-network-access *");
+            expect(anotherAttr).toBe("another_value");
+        });
+    });
+
     describe("close", () => {
         let subject: IFrameWindow;
         const parentRemoveChild = vi.fn();

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -5,13 +5,14 @@ import { Logger } from "../utils";
 import { ErrorTimeout } from "../errors";
 import type { NavigateParams, NavigateResponse } from "./IWindow";
 import { AbstractChildWindow } from "./AbstractChildWindow";
-import { DefaultSilentRequestTimeoutInSeconds } from "../UserManagerSettings";
+import { DefaultIFrameAttributes, DefaultSilentRequestTimeoutInSeconds } from "../UserManagerSettings";
 
 /**
  * @public
  */
 export interface IFrameWindowParams {
     silentRequestTimeoutInSeconds?: number;
+    iframeAttributes?: Record<string, string>;
 }
 
 /**
@@ -24,15 +25,16 @@ export class IFrameWindow extends AbstractChildWindow {
 
     public constructor({
         silentRequestTimeoutInSeconds = DefaultSilentRequestTimeoutInSeconds,
+        iframeAttributes = DefaultIFrameAttributes,
     }: IFrameWindowParams) {
         super();
         this._timeoutInSeconds = silentRequestTimeoutInSeconds;
 
-        this._frame = IFrameWindow.createHiddenIframe();
+        this._frame = IFrameWindow.createHiddenIframe(iframeAttributes);
         this._window = this._frame.contentWindow;
     }
 
-    private static createHiddenIframe(): HTMLIFrameElement {
+    private static createHiddenIframe(iframeAttributes: Record<string, string> | undefined): HTMLIFrameElement {
         const iframe = window.document.createElement("iframe");
 
         // shotgun approach
@@ -42,6 +44,12 @@ export class IFrameWindow extends AbstractChildWindow {
         iframe.style.top = "0";
         iframe.width = "0";
         iframe.height = "0";
+
+        if (iframeAttributes) {
+            for (const attr in iframeAttributes) {
+                iframe.setAttribute(attr, iframeAttributes[attr]);
+            }
+        }
 
         window.document.body.appendChild(iframe);
         return iframe;


### PR DESCRIPTION
This PR adds support for passing custom HTML attributes to the iframe used during silent signin (signinSilent).

**Motivation**
Recent Chrome changes around Local Network Access (PNA / Private Network Access) require explicit permission delegation for iframe-based requests to local or private network resources.

A common real-world scenario is:

> A web application hosted on a private/internal address (e.g. https://app.local or an internal DNS/IP) using a public identity provider such as Microsoft Entra ID (Azure AD).

In this setup:

- The main application runs on a private/local network
- Authentication happens via a public endpoint (e.g. login.microsoftonline.com)
- Silent signin is performed using a hidden iframe

With the latest browser restrictions, this iframe may be blocked unless it explicitly declares permission via:
```html
<iframe allow="local-network-access *">
```

Without this attribute:
- Silent authentication can fail
- Users may be unexpectedly logged out or forced into full redirects


**Changes**
Adds optional iframeAttributes configuration:
- Available globally via UserManager settings
- Available per call via signinSilent arguments

**Example usage**
Global configuration
```ts
const userManager = new UserManager({  iframeAttributes: {    allow: "local-network-access *"  }});
```

Per-call override
```ts
await userManager.signinSilent({  iframeAttributes: {    allow: "local-network-access *"  }});
```

**Notes**

- Using the feature is optional and should not change any behavior if not used.
- Supports arbitrary attributes, allowing future browser requirements to be handled without further changes

